### PR TITLE
fix: handle source and Dafny paths correctly on Windows

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,4 @@
-import org.gradle.internal.instrumentation.api.annotations.ParameterKind.VarargParameter
+import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
 
 plugins {
     id("java")
@@ -161,8 +161,12 @@ project(":verifier") {
     }
     
     tasks.withType<JavaExec> {
-        environment("JVERIFY_DAFNY", project.file("../dafny/Scripts/dafny").absolutePath)
-        
+        if (DefaultNativePlatform.getCurrentOperatingSystem().isWindows) {
+            environment("JVERIFY_DAFNY", project.file("../dafny/Binaries/Dafny.exe").absolutePath)
+        } else {
+            environment("JVERIFY_DAFNY", project.file("../dafny/Scripts/dafny").absolutePath)
+        }
+
         standardInput = System.`in`
         standardOutput = System.out
         

--- a/verifier/src/main/java/com/aws/jverify/verifier/Driver.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/Driver.java
@@ -19,7 +19,7 @@ public class Driver {
     public static int verifyJavaPaths(List<Path> files, VerifierOptions verifierOptions, Writer output) throws IOException {
         List<JavaFileObject> readFiles = files.stream().map((Path p) -> {
             try {
-                return new SourceFile(p.toString(), Files.readString(p));
+                return new SourceFile(p, Files.readString(p));
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/verifier/src/main/java/com/aws/jverify/verifier/Main.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/Main.java
@@ -24,7 +24,7 @@ public class Main {
 
 @Command(name = "verify", description = "Verify Java code that calls the JVerify library")
 class AppCommand implements Callable<Integer> {
-    @Parameters(description = "Java files to verify")
+    @Parameters(description = "Java files to verify", arity = "1..*")
     private List<Path> inputs;
     
     @Option(names = "--print-binary-dafny", description = "Given a filepath, prints the binary Dafny code that is generated from Java")
@@ -46,7 +46,7 @@ class AppCommand implements Callable<Integer> {
         // In the future we'll have to add an argument to specify jar files for dependencies of the input sources,
         // And those will include the JVerify library jar.
         // But right now we manually find the JVerify library jar and include it in the compilation.
-        var jverifyLibraryLocation = Path.of(URI.create(Common.getJarLocationForClass(JVerify.class)).getPath());
+        var jverifyLibraryLocation = Path.of(URI.create(Common.getJarLocationForClass(JVerify.class)));
 
         File tempFile = File.createTempFile("jverify-prelude-", ".dfy");
         InputStream stream = getClass().getResourceAsStream("/additional.dfy");

--- a/verifier/src/main/java/com/aws/jverify/verifier/SourceFile.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/SourceFile.java
@@ -2,12 +2,29 @@ package com.aws.jverify.verifier;
 
 import javax.tools.SimpleJavaFileObject;
 import java.net.URI;
+import java.nio.file.Path;
 
 class SourceFile extends SimpleJavaFileObject {
     final String content;
 
+    /**
+     * Constructs a {@link SourceFile} with the given path and content.
+     * <p>
+     * <strong>NOTE:</strong>
+     * If the path is derived from a real filesystem (and not a hard-coded test value, for example)
+     * then you should instead use {@link SourceFile#SourceFile(Path, String)}
+     * in order to ensure correct functionality across different operating systems.
+     */
     SourceFile(String path, String content) {
         super(URI.create("string:///" + path), Kind.SOURCE);
+        this.content = content;
+    }
+
+    /**
+     * Constructs a {@link SourceFile} with the given path and content.
+     */
+    SourceFile(Path path, String content) {
+        super(path.toUri(), Kind.SOURCE);
         this.content = content;
     }
 

--- a/verifier/src/test/java/com/aws/jverify/TestVerifier.java
+++ b/verifier/src/test/java/com/aws/jverify/TestVerifier.java
@@ -10,10 +10,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 public class TestVerifier {
+    private static final boolean IS_WINDOWS = System.getProperty("os.name", "").toLowerCase().contains("windows");
     
     private int run(String inputFileName, Writer writer) throws IOException {
         var source = Files.readString(Path.of("./src/test/java/com/aws/jverify/" + inputFileName));
-        var dafnyPath = Path.of("../dafny/Scripts/dafny").toAbsolutePath();
+        var dafnyPath = Path.of("../dafny").toAbsolutePath()
+                .resolve(IS_WINDOWS ? "Binaries/Dafny.exe" : "Scripts/dafny");
         var libraryJar = Path.of("../library/build/libs/library.jar");
         var prelude = Path.of("./src/main/resources/additional.dfy");
         var options = new VerifierOptions(dafnyPath, libraryJar, prelude, null, null, false);
@@ -24,7 +26,7 @@ public class TestVerifier {
     public void assertFalse() throws IOException {
         StringWriter writer = new StringWriter();
         var exitCode = run("AssertFalse.java", writer);
-        var output = writer.toString();
+        var output = canonicalizeNewlines(writer.toString());
         Assertions.assertEquals("/test.java(7,14): Error: assertion might not hold\n" +
                 "\n" +
                 "Dafny program verifier finished with 2 verified, 1 error\n", output);
@@ -35,7 +37,7 @@ public class TestVerifier {
     public void fibonacciValid() throws IOException {
         StringWriter writer = new StringWriter();
         var exitCode = run("FibonacciValid.java", writer);
-        var output = writer.toString();
+        var output = canonicalizeNewlines(writer.toString());
         Assertions.assertEquals("\nDafny program verifier finished with 6 verified, 0 errors\n", output);
         Assertions.assertEquals(0, exitCode);
         
@@ -44,7 +46,7 @@ public class TestVerifier {
     public void fibonacciInvalid() throws IOException {
         StringWriter writer = new StringWriter();
         var exitCode = run("FibonacciInvalid.java", writer);
-        var output = writer.toString();
+        var output = canonicalizeNewlines(writer.toString());
         Assertions.assertEquals("/test.java(44,22): Error: value does not satisfy the subset constraints of 'nat32'\n" +
                 "/test.java(49,19): Error: value does not satisfy the subset constraints of 'nat32'\n" +
                 "/test.java(17,13): Error: a postcondition could not be proved on this return path\n" +
@@ -58,8 +60,9 @@ public class TestVerifier {
     
     @Test
     public void testRunThroughGradle() throws IOException, InterruptedException {
+        var gradlePath = IS_WINDOWS ? "../gradlew.bat" : "../gradlew";
         var process = new ProcessBuilder(
-                "../gradlew",
+                gradlePath,
                 ":verifier:run",
                 "--args=\"./src/test/java/com/aws/jverify/FibonacciValid.java\"").start();
         var writer = new StringWriter();
@@ -67,8 +70,17 @@ public class TestVerifier {
         reader.transferTo(writer);
         var exitCode = process.waitFor();
         reader.close();
-        Assertions.assertTrue(writer.toString().contains("Dafny program verifier finished with 6 verified, 0 errors"));
+        var output = canonicalizeNewlines(writer.toString());
+        Assertions.assertTrue(output.contains("Dafny program verifier finished with 6 verified, 0 errors"));
         Assertions.assertEquals(0, exitCode);
 
+    }
+
+    /**
+     * Returns the text with all CRLF sequences replaced with LF.
+     * This prevents erroneous failures of diff-based assertions on Windows platforms.
+     */
+    private static String canonicalizeNewlines(final String text) {
+        return text.replaceAll("\r\n", "\n");
     }
 }


### PR DESCRIPTION
### What was changed?

* Ensures that paths to the Java files-to-be-verified are transformed without throwing invalid character exceptions on Windows (in particular due to drive letters like `C:`)
* Changes paths to the default `dafny` installation, and to the Gradle wrapper, when running on Windows.

### How has this been tested?

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/aws/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
