### PR TITLE
Ensure JVerify is robust to class with no constructors

### DIFF
--- a/verifier/src/main/java/com/aws/jverify/verifier/Driver.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/Driver.java
@@ -10,9 +10,9 @@ import java.util.stream.Collectors;
 
 public class Driver {
 
-    public static int verifyJavaExample(VerifierOptions options, String javaCode, Writer output) throws IOException {
+    public static int verifyJavaExample(VerifierOptions options, Path javaFile, Writer output) throws IOException {
         var files = new ArrayList<JavaFileObject>();
-        files.add(new SourceFile("test.java", javaCode));
+        files.add(new SourceFile(javaFile, Files.readString(javaFile)));
         return verifyJavaFiles(files, options, output);
     }
 

--- a/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
@@ -18,9 +18,7 @@ import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.util.Position;
 import com.aws.jverify.generated.*;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.checker.units.qual.A;
 
-import javax.lang.model.element.Modifier;
 import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.TypeKind;
 import javax.tools.*;
@@ -32,6 +30,7 @@ import java.util.stream.Collectors;
 public class JavaToDafnyCompiler {
     public static final String JVERIFY_CLASS = JVerify.class.getName();
     JCTree.JCCompilationUnit compilationUnit;
+    Stack<IOrigin> contextOrigins = new Stack<>();
 
     public FilesContainer analyzeJavaCode(VerifierOptions options, List<JavaFileObject> files) {
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
@@ -86,13 +85,17 @@ public class JavaToDafnyCompiler {
         if (tree instanceof JCTree.JCClassDecl classDecl) {
             var name = getName(classDecl, classDecl.name);
             var origin = declToOrigin(classDecl, name);
+            contextOrigins.push(origin);
 
+            TopLevelDecl result;
             if (isEnum(classDecl.type)) {
-                return translateEnum(classDecl, origin, name);
+                result = translateEnum(classDecl, origin, name);
             } 
             else {
-                return translateClass(nestedTypes, classDecl, origin, name);
+                result = translateClass(nestedTypes, classDecl, origin, name);
             }
+            contextOrigins.pop();
+            return result;
         }
         throw new NotImplementedException(tree.getClass().getName());
     }
@@ -162,10 +165,8 @@ public class JavaToDafnyCompiler {
             case JCTree.JCVariableDecl variableDecl -> {
                 return translateField(variableDecl);
             }
-            case null, default -> {
-            }
+            default -> throw new NotImplementedException(member.getClass().getName());
         }
-        throw new NotImplementedException(member.getClass().getName());
     }
 
     private Field translateField(JCTree.JCVariableDecl variableDecl) {
@@ -209,27 +210,11 @@ public class JavaToDafnyCompiler {
                 throw new RuntimeException("Pure method should have only one statement");
             }
             var returnType = toType(method.getReturnType());
-
-
-            if (annotationsByName.containsKey(Pure.class.getSimpleName())) {
-                if (postHeader.size() != 1) {
-                    throw new RuntimeException("Pure method should have only one statement");
-                }
-                if (returnType == null) {
-                    throw new RuntimeException("Pure method should have a return type");
-                }
-
-                var statement = postHeader.getFirst();
-                if (statement instanceof JCTree.JCReturn returnStatement) {
-                    var body = toExpr(returnStatement.expr);
-                    return new Function(origin, name, null, false, null, List.of(),
-                            ins, header.preconditions, header.postconditions, header.getReads(),
-                            header.getDecreases(), isStatic, false, null, returnType,
-                            body, null, null
-                    );
-                } else {
-                    throw new RuntimeException("Pure method statement should be a return");
-                }
+            if (postHeader.size() != 1) {
+                throw new RuntimeException("Pure method should have only one statement");
+            }
+            if (returnType == null) {
+                throw new RuntimeException("Pure method should have a return type");
             }
 
             var statement = postHeader.getFirst();
@@ -570,23 +555,33 @@ public class JavaToDafnyCompiler {
         int startPos = getStartPos(tree);
         var startToken = toToken(startPos);
         var endToken = toToken(startPos + name.length());
-        return new Name(new TokenRangeOrigin(startToken, endToken), name.toString());
+        var origin = startToken == null ? contextOrigins.peek() : new TokenRangeOrigin(startToken, endToken);
+        return new Name(origin, name.toString());
     }
 
     private IOrigin declToOrigin(JCTree node, Name name) {
         var entireRange = toOrigin(node);
-        return new SourceOrigin(originToRange(entireRange), originToRange((TokenRangeOrigin) name.getOrigin()));
+        return new SourceOrigin(originToRange(entireRange), originToRange(name.getOrigin()));
     }
     
-    private TokenRangeOrigin toOrigin(JCTree node) {
+    private IOrigin toOrigin(JCTree node) {
         var startToken = toToken(TreeInfo.getStartPos(node));
-        int endPos = TreeInfo.getEndPos(node, compilationUnit.endPositions);
+        if (startToken == null) {
+            return contextOrigins.peek();
+        }
+        int endPos = getEndPos(node);
         var endToken = endPos == Position.NOPOS ? toToken(TreeInfo.getStartPos(node) + 1) : toToken(endPos);
         return new TokenRangeOrigin(startToken, endToken);
     }
     
-    private TokenRange originToRange(TokenRangeOrigin tokenRangeOrigin) {
-        return new TokenRange(tokenRangeOrigin.getStartToken(), tokenRangeOrigin.getEndToken());
+    private TokenRange originToRange(IOrigin tokenRangeOrigin) {
+        if (tokenRangeOrigin instanceof SourceOrigin sourceOrigin) {
+            return new TokenRange(sourceOrigin.getEntireRange().getStartToken(), sourceOrigin.getEntireRange().getEndToken());
+        } else if (tokenRangeOrigin instanceof TokenRangeOrigin trOrigin) {
+            return new TokenRange(trOrigin.getStartToken(), trOrigin.getEndToken());
+        } else {
+            throw new NotImplementedException(tokenRangeOrigin.getClass().getName());
+        }
     }
     
     private int getStartPos(JCTree tree) {
@@ -609,7 +604,7 @@ public class JavaToDafnyCompiler {
         int pos = methodDecl.pos;
 
         if (methodDecl.mods != null && methodDecl.mods.pos != Position.NOPOS) {
-            pos = TreeInfo.getEndPos(methodDecl.mods, compilationUnit.endPositions);
+            pos = getEndPos(methodDecl.mods);
         }
 
         String methodName = methodDecl.name.toString();
@@ -617,16 +612,17 @@ public class JavaToDafnyCompiler {
 
         if (isConstructor) {
             if (methodDecl.typarams != null && !methodDecl.typarams.isEmpty()) {
-                pos = TreeInfo.getEndPos(methodDecl.typarams.last(), compilationUnit.endPositions);
+                JCTree.JCTypeParameter last = methodDecl.typarams.last();
+                pos = getEndPos(last);
             }
             return pos;
         } else {
             if (methodDecl.typarams != null && !methodDecl.typarams.isEmpty()) {
-                pos = TreeInfo.getEndPos(methodDecl.typarams.last(), compilationUnit.endPositions);
+                pos = getEndPos(methodDecl.typarams.last());
             }
 
             if (methodDecl.restype != null) {
-                pos = TreeInfo.getEndPos(methodDecl.restype, compilationUnit.endPositions);
+                pos = getEndPos(methodDecl.restype);
             }
         }
 
@@ -652,7 +648,11 @@ public class JavaToDafnyCompiler {
 
         return Position.NOPOS;
     }
-    
+
+    private int getEndPos(JCTree node) {
+        return TreeInfo.getEndPos(node, compilationUnit.endPositions);
+    }
+
     private int getClassNamePosition(JCTree.JCClassDecl classDecl) {
         CharSequence source;
         try {
@@ -663,7 +663,7 @@ public class JavaToDafnyCompiler {
 
         int pos = classDecl.pos;
         if (classDecl.mods != null && classDecl.mods.pos != Position.NOPOS) {
-            pos = TreeInfo.getEndPos(classDecl.mods, compilationUnit.endPositions);
+            pos = getEndPos(classDecl.mods);
         }
 
         // Find the class/interface/enum/record keyword and skip it
@@ -693,11 +693,11 @@ public class JavaToDafnyCompiler {
     
     private Token toToken(int pos) {
         if (pos == Position.NOPOS) {
-            return new Token(-1, -1);
+            return null;
         }
         return new Token(
-                (int) compilationUnit.getLineMap().getLineNumber(pos),
-                (int) compilationUnit.getLineMap().getColumnNumber(pos) + 1);
+                compilationUnit.getLineMap().getLineNumber(pos),
+                compilationUnit.getLineMap().getColumnNumber(pos) + 1);
     }
 
     private List<Statement> translateStatements(List<JCTree.JCStatement> statements) {
@@ -903,7 +903,6 @@ public class JavaToDafnyCompiler {
                     if (invocation.args.size() != 1) {
                         throw new RuntimeException("decreases should have a single argument");
                     }
-                    var first = invocation.getArguments().getFirst();
                     throw new NotImplementedException("decreases");
                 }
                 case "reads" -> {

--- a/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
@@ -692,6 +692,9 @@ public class JavaToDafnyCompiler {
         
     
     private Token toToken(int pos) {
+        if (pos == Position.NOPOS) {
+            return new Token(-1, -1);
+        }
         return new Token(
                 (int) compilationUnit.getLineMap().getLineNumber(pos),
                 (int) compilationUnit.getLineMap().getColumnNumber(pos) + 1);

--- a/verifier/src/test/java/com/aws/jverify/NoConstructor.java
+++ b/verifier/src/test/java/com/aws/jverify/NoConstructor.java
@@ -1,3 +1,8 @@
-class A {
+package com.aws.jverify;
+
+public class NoConstructor {
+
     public int f;
+    public int h;
+
 }

--- a/verifier/src/test/java/com/aws/jverify/NoConstructor.java
+++ b/verifier/src/test/java/com/aws/jverify/NoConstructor.java
@@ -1,8 +1,5 @@
 package com.aws.jverify;
 
 public class NoConstructor {
-
     public int f;
-    public int h;
-
 }

--- a/verifier/src/test/java/com/aws/jverify/NoConstructor.java
+++ b/verifier/src/test/java/com/aws/jverify/NoConstructor.java
@@ -1,0 +1,3 @@
+class A {
+    public int f;
+}

--- a/verifier/src/test/java/com/aws/jverify/TestVerifier.java
+++ b/verifier/src/test/java/com/aws/jverify/TestVerifier.java
@@ -5,6 +5,7 @@ import com.aws.jverify.verifier.VerifierOptions;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.beans.Transient;
 import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -141,6 +142,13 @@ Dafny program verifier finished with 5 verified, 0 errors
 
     }
 
+    @Test
+    public void testNoConstructor() throws IOException, InterruptedException {
+        StringWriter writer = new StringWriter();
+        var exitCode = run("NoConstructor.java", false, writer);
+        var output = canonicalizeNewlines(writer.toString());
+        Assertions.assertEquals(0, exitCode);
+    }
     /**
      * Returns the text with all CRLF sequences replaced with LF.
      * This prevents erroneous failures of diff-based assertions on Windows platforms.

--- a/verifier/src/test/java/com/aws/jverify/TestVerifier.java
+++ b/verifier/src/test/java/com/aws/jverify/TestVerifier.java
@@ -5,7 +5,6 @@ import com.aws.jverify.verifier.VerifierOptions;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.beans.Transient;
 import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -146,7 +145,6 @@ Dafny program verifier finished with 5 verified, 0 errors
     public void testNoConstructor() throws IOException, InterruptedException {
         StringWriter writer = new StringWriter();
         var exitCode = run("NoConstructor.java", false, writer);
-        var output = canonicalizeNewlines(writer.toString());
         Assertions.assertEquals(0, exitCode);
     }
     /**

--- a/verifier/src/test/java/com/aws/jverify/TestVerifier.java
+++ b/verifier/src/test/java/com/aws/jverify/TestVerifier.java
@@ -20,9 +20,9 @@ public class TestVerifier {
         var exitCode = run("UserProfile.java", true, writer);
         var output = canonicalizeNewlines(writer.toString());
         Assertions.assertEquals("""
-/test.java(32:9-32:16): Error: a postcondition could not be proved on this return path
-/test.java(23:21-23:26): Related location: this is the postcondition that could not be proved
-/test.java(25:16-25:77): Related location: this proposition could not be proved
+UserProfile.java(32:9-32:16): Error: a postcondition could not be proved on this return path
+UserProfile.java(23:21-23:26): Related location: this is the postcondition that could not be proved
+UserProfile.java(25:16-25:77): Related location: this proposition could not be proved
 
 Dafny program verifier finished with 7 verified, 1 error
 """, output);
@@ -41,6 +41,7 @@ Dafny program verifier finished with 7 verified, 1 error
         var options = new VerifierOptions(dafnyPath, libraryJar, prelude,
                 null, null, true,
                 new String[] { 
+                        "--use-basename-for-filename"
                         //"--wait-for-debugger"
                 } 
         );
@@ -52,14 +53,14 @@ Dafny program verifier finished with 7 verified, 1 error
         StringWriter writer = new StringWriter();
         var exitCode = run("AssertFalse.java", false, writer);
         var output = canonicalizeNewlines(writer.toString());
-        Assertions.assertEquals("/test.java(7:9-7:21): Error: assertion might not hold\n" +
+        Assertions.assertEquals("AssertFalse.java(7:9-7:21): Error: assertion might not hold\n" +
                 "\n" +
                 "Dafny program verifier finished with 2 verified, 1 error\n", output);
         Assertions.assertEquals(4, exitCode);
     }
 
     private static void checkErrorAt(String output, int line, int col) {
-        Assertions.assertTrue(output.contains("/test.java(" + line + ":" + col + "-"));
+        Assertions.assertTrue(output.contains("Operators.java(" + line + ":" + col + "-"));
     }
 
     @Test
@@ -97,11 +98,11 @@ Dafny program verifier finished with 7 verified, 1 error
         var exitCode = run("FibonacciInvalid.java", false, writer);
         var output = canonicalizeNewlines(writer.toString());
         Assertions.assertEquals("""
-/test.java(44:22-44:23): Error: value does not satisfy the subset constraints of 'nat32'
-/test.java(49:17-49:22): Error: value does not satisfy the subset constraints of 'nat32'
-/test.java(17:13-17:22): Error: a postcondition could not be proved on this return path
-/test.java(14:38-14:50): Related location: this is the postcondition that could not be proved
-/test.java(31:28-31:51): Error: value does not satisfy the subset constraints of 'int32'
+FibonacciInvalid.java(44:22-44:23): Error: value does not satisfy the subset constraints of 'nat32'
+FibonacciInvalid.java(49:17-49:22): Error: value does not satisfy the subset constraints of 'nat32'
+FibonacciInvalid.java(17:13-17:22): Error: a postcondition could not be proved on this return path
+FibonacciInvalid.java(14:38-14:50): Related location: this is the postcondition that could not be proved
+FibonacciInvalid.java(31:28-31:51): Error: value does not satisfy the subset constraints of 'int32'
 
 Dafny program verifier finished with 4 verified, 4 errors
 """, output);

--- a/verifier/src/test/java/com/aws/jverify/TestVerifier.java
+++ b/verifier/src/test/java/com/aws/jverify/TestVerifier.java
@@ -33,7 +33,7 @@ Dafny program verifier finished with 7 verified, 1 error
         var directory = fromExamples 
                 ? Path.of("../examples/src/main/java/com/aws/verifier/examples") 
                 : Path.of("./src/test/java/com/aws/jverify");
-        var source = Files.readString(directory.resolve(inputFileName));
+        var filePath = directory.resolve(inputFileName);
         var dafnyPath = Path.of("../dafny").toAbsolutePath()
                 .resolve(IS_WINDOWS ? "Binaries/Dafny.exe" : "Scripts/dafny");
         var libraryJar = Path.of("../library/build/libs/library.jar");
@@ -44,7 +44,7 @@ Dafny program verifier finished with 7 verified, 1 error
                         //"--wait-for-debugger"
                 } 
         );
-        return Driver.verifyJavaExample(options, source, writer);
+        return Driver.verifyJavaExample(options, filePath, writer);
     }
     
     @Test


### PR DESCRIPTION
### What was changed?
- If a node does not originate from source, use the nearest surrounding origin instead. For example, a default constructor will get the origin of its containing class.
- Fix bug in testing code to enable test files with public classes
- Remove some code duplication in JavaToDafnyCompiler.java

### How has this been tested?
- Added a test case in TestVerifier.java


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/aws/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
