### PR TITLE
feat: use structured diagnostics in verifier tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -198,6 +198,8 @@ project(":verifier") {
 
         // Optional: annotation processor for compile-time checking
         annotationProcessor("info.picocli:picocli-codegen:4.7.6")
+
+        implementation("com.fasterxml.jackson.core:jackson-databind:2.18.3")
     }
 
     tasks.test {

--- a/common/src/main/java/com/aws/jverify/common/AnnotatedRange.java
+++ b/common/src/main/java/com/aws/jverify/common/AnnotatedRange.java
@@ -1,11 +1,9 @@
 package com.aws.jverify.common;
 
-public class AnnotatedRange {
-    public final String annotation;
-    public final Range range;
-
-    public AnnotatedRange(String annotation, Range range) {
-        this.annotation = annotation;
-        this.range = range;
+public record AnnotatedRange(String annotation, Range range) implements Comparable<AnnotatedRange> {
+    @Override
+    public int compareTo(AnnotatedRange o) {
+        var rangeSign = range.compareTo(o.range);
+        return rangeSign == 0 ? annotation.compareTo(o.annotation) : rangeSign;
     }
 }

--- a/common/src/main/java/com/aws/jverify/common/Position.java
+++ b/common/src/main/java/com/aws/jverify/common/Position.java
@@ -1,9 +1,24 @@
 package com.aws.jverify.common;
 
-public record Position(int line, int character) {
+/**
+ * A position in a character buffer.
+ *
+ * @param line 1-indexed line number
+ * @param character 1-indexed column number
+ */
+public record Position(int line, int character) implements Comparable<Position> {
+    public Position(long line, long character) {
+        this(Math.toIntExact(line), Math.toIntExact(character));
+    }
 
     @Override
     public String toString() {
-        return (line + 1) + ":" + (character + 1);
+        return line + ":" + character;
+    }
+
+    @Override
+    public int compareTo(Position o) {
+        var lineSign = Long.compare(line, o.line);
+        return lineSign == 0 ? Long.compare(character, o.character) : lineSign;
     }
 }

--- a/common/src/main/java/com/aws/jverify/common/Range.java
+++ b/common/src/main/java/com/aws/jverify/common/Range.java
@@ -1,9 +1,14 @@
 package com.aws.jverify.common;
 
-public record Range(Position start, Position end) {
-
+public record Range(Position start, Position end) implements Comparable<Range> {
     @Override
     public String toString() {
         return start.toString() + "-" + end.toString();
+    }
+
+    @Override
+    public int compareTo(Range o) {
+        var startSign = start.compareTo(o.start);
+        return startSign == 0 ? end.compareTo(o.end) : startSign;
     }
 }

--- a/common/src/main/java/com/aws/jverify/common/TestMarkup.java
+++ b/common/src/main/java/com/aws/jverify/common/TestMarkup.java
@@ -17,25 +17,24 @@ import java.util.regex.Pattern;
  * string with the "><" string in it.  This allows for easy creation of "FIT" tests where all
  * that needs to be provided are strings that encode every bit of state necessary in the string
  * itself.
- *
+ * <p>
  * The current set of encoded features we support are: 
- *
+ * <p>
  * >< - The position in the file.  There can be zero or more of these.
- *
- * [> ... <] - A span of text in the file.  There can be many of these and they can be nested
+ * <p>
+ * [> ... <] - A span of text in the file.  There can be many of these, and they can be nested
  * and/or overlap the >< position(s).
- *
+ * <p>
  * {>Name: ... <} A span of text in the file annotated with an identifier.  There can be many of
  * these, including ones with the same name.
- *
- * (>metadata::: ... <) A span of text in the file annotated with metdata.
- *
+ * <p>
+ * (>metadata::: ... <) A span of text in the file annotated with metadata.
+ * <p>
  * We also support Java line comments to specify annotated ranges:
- * ```
+ * {@snippet :
  *    some actual program text
  * // ^^^^^^ this is the annotation with hats pointing to the range
- * ```
- * 
+ * }
  */
 public class TestMarkup {
     private static final String SPAN_START_STRING = "[>";
@@ -168,8 +167,8 @@ public class TestMarkup {
         
         var output = getPositionsAndAnnotatedRanges(input);
         for (AnnotatedRange annotatedRange : output.ranges) {
-            namedRanges.computeIfAbsent(annotatedRange.annotation, _ -> new ArrayList<>())
-                    .add(annotatedRange.range);
+            namedRanges.computeIfAbsent(annotatedRange.annotation(), _ -> new ArrayList<>())
+                    .add(annotatedRange.range());
         }
         
         return new GetPositionsAndNamedRangesResult(output.output, output.positions, namedRanges);
@@ -286,7 +285,7 @@ class TextBuffer {
         }
 
         int character = index - lineStarts[line];
-        return new Position(line, character);
+        return new Position(line + 1, character + 1);
     }
 }
 

--- a/common/src/test/java/com/aws/jverify/common/TestMarkupTest.java
+++ b/common/src/test/java/com/aws/jverify/common/TestMarkupTest.java
@@ -20,11 +20,11 @@ public class TestMarkupTest {
         assertEquals("int x = 10;", output);
         assertEquals(2, positions.size());
 
-        assertEquals(0, positions.get(0).line());
-        assertEquals(4, positions.get(0).character());
+        assertEquals(1, positions.get(0).line());
+        assertEquals(5, positions.get(0).character());
 
-        assertEquals(0, positions.get(1).line());
-        assertEquals(8, positions.get(1).character());
+        assertEquals(1, positions.get(1).line());
+        assertEquals(9, positions.get(1).character());
     }
 
     @Test
@@ -41,10 +41,10 @@ public class TestMarkupTest {
         assertEquals(1, ranges.size());
 
         var span = ranges.getFirst();
-        assertEquals(0, span.start().line());
-        assertEquals(8, span.start().character());
-        assertEquals(0, span.end().line());
-        assertEquals(10, span.end().character());
+        assertEquals(1, span.start().line());
+        assertEquals(9, span.start().character());
+        assertEquals(1, span.end().line());
+        assertEquals(11, span.end().character());
     }
 
     @Test
@@ -57,11 +57,11 @@ public class TestMarkupTest {
         assertEquals(1, result.ranges().size());
 
         var span = result.ranges().getFirst();
-        assertEquals("Value", span.annotation);
-        assertEquals(0, span.range.start().line());
-        assertEquals(8, span.range.start().character());
-        assertEquals(0, span.range.end().line());
-        assertEquals(10, span.range.end().character());
+        assertEquals("Value", span.annotation());
+        assertEquals(1, span.range().start().line());
+        assertEquals(9, span.range().start().character());
+        assertEquals(1, span.range().end().line());
+        assertEquals(11, span.range().end().character());
     }
 
     @Test
@@ -75,10 +75,10 @@ public class TestMarkupTest {
         assertEquals(1, result.ranges().size());
 
         var span = result.ranges().getFirst();
-        assertEquals("Variable declaration", span.annotation);
-        assertEquals(0, span.range.start().line());
-        assertEquals(3, span.range.start().character());
-        assertEquals(0, span.range.end().line());
-        assertEquals(8, span.range.end().character());
+        assertEquals("Variable declaration", span.annotation());
+        assertEquals(1, span.range().start().line());
+        assertEquals(4, span.range().start().character());
+        assertEquals(1, span.range().end().line());
+        assertEquals(9, span.range().end().character());
     }
 }

--- a/examples/src/main/java/com/aws/verifier/examples/BinarySearch.java
+++ b/examples/src/main/java/com/aws/verifier/examples/BinarySearch.java
@@ -1,3 +1,7 @@
+// exitCode: 0
+// dafnyVerified: 3
+// dafnyErrors: 0
+
 package com.aws.verifier.examples;
 
 import static com.aws.jverify.JVerify.*;

--- a/examples/src/main/java/com/aws/verifier/examples/ExternalContract.java
+++ b/examples/src/main/java/com/aws/verifier/examples/ExternalContract.java
@@ -1,3 +1,7 @@
+// exitCode: 0
+// dafnyVerified: 2
+// dafnyErrors: 0
+
 package com.aws.verifier.examples;
 
 import com.aws.jverify.Contract;

--- a/examples/src/main/java/com/aws/verifier/examples/Fibonacci.java
+++ b/examples/src/main/java/com/aws/verifier/examples/Fibonacci.java
@@ -1,3 +1,7 @@
+// exitCode: 0
+// dafnyVerified: 4
+// dafnyErrors: 0
+
 package com.aws.verifier.examples;
 
 import static com.aws.jverify.JVerify.*;

--- a/examples/src/main/java/com/aws/verifier/examples/UserProfile.java
+++ b/examples/src/main/java/com/aws/verifier/examples/UserProfile.java
@@ -1,3 +1,7 @@
+// exitCode: 4
+// dafnyVerified: 5
+// dafnyErrors: 1
+
 package com.aws.verifier.examples;
 
 import static com.aws.jverify.JVerify.*;
@@ -21,8 +25,10 @@ class UserProfile {
     @Pure
     @Invariant // Makes this a pre- and post-condition of all public methods
     private boolean valid() {
+//                  ^^^^^ Related location: this is the postcondition that could not be proved
         reads(this);
         return accountType != AccountType.Premium || premiumFeatures != null;
+//             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Related location: this proposition could not be proved
     }
 
     public void upgradeAccount() {
@@ -30,6 +36,7 @@ class UserProfile {
         this.accountType = AccountType.Premium;
         // this.premiumFeatures = new PremiumFeatures();
         return;
+//      ^^^^^^^ Error: a postcondition could not be proved on this return path
     }
 
     public boolean applyTheme(Theme theme) {

--- a/verifier/src/main/java/com/aws/jverify/verifier/DafnyDiagnostic.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/DafnyDiagnostic.java
@@ -1,10 +1,12 @@
 package com.aws.jverify.verifier;
 
+import com.aws.jverify.common.Range;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.tools.Diagnostic;
 import java.util.List;
 import java.util.Locale;
+import java.util.stream.Stream;
 
 /**
  * Adapts Dafny's {@code --json-diagnostics} output to the {@link Diagnostic} interface.
@@ -29,11 +31,8 @@ public class DafnyDiagnostic implements Diagnostic<String> {
 
     public List<RelatedInfo> relatedInformation;
 
-    public static DafnyDiagnostic forSummary(String summaryLine) {
-        var diagnostic = new DafnyDiagnostic();
-        diagnostic.severity = SEVERITY_INFO;
-        diagnostic.message = summaryLine;
-        return diagnostic;
+    public Range getRange() {
+        return location.range;
     }
 
     @Override
@@ -58,22 +57,30 @@ public class DafnyDiagnostic implements Diagnostic<String> {
 
     @Override
     public long getStartPosition() {
-        return location.range.start.pos;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public long getEndPosition() {
-        return location.range.end.pos;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public long getLineNumber() {
-        return location.range.start.line;
+        return location.range.start().line();
+    }
+
+    public long getEndLineNumber() {
+        return location.range.end().line();
     }
 
     @Override
     public long getColumnNumber() {
-        return location.range.start.character;
+        return location.range.start().character();
+    }
+
+    public long getEndColumnNumber() {
+        return location.range.end().character();
     }
 
     @Override
@@ -86,9 +93,13 @@ public class DafnyDiagnostic implements Diagnostic<String> {
         return message;
     }
 
-    public record Position(int pos, int line, int character) {}
-
-    public record Range(Position start, Position end) {}
+    /**
+     * Returns a stream containing this diagnostic and its related information as diagnostics.
+     */
+    public Stream<DafnyDiagnostic> flattenRelated() {
+        Stream<RelatedInfo> relatedStream = relatedInformation == null ? Stream.empty() : relatedInformation.stream();
+        return Stream.concat(Stream.of(this), relatedStream.map(RelatedInfo::asDiagnostic));
+    }
 
     public record Location(String filename, String uri, Range range) {}
 

--- a/verifier/src/main/java/com/aws/jverify/verifier/DafnyDiagnostic.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/DafnyDiagnostic.java
@@ -1,0 +1,104 @@
+package com.aws.jverify.verifier;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.tools.Diagnostic;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Adapts Dafny's {@code --json-diagnostics} output to the {@link Diagnostic} interface.
+ */
+public class DafnyDiagnostic implements Diagnostic<String> {
+    private static final int SEVERITY_ERROR = 1;
+    private static final int SEVERITY_WARNING = 2;
+    private static final int SEVERITY_INFO = 4;
+
+    public Location location;
+
+    public int severity;
+
+    public String message;
+
+    /**
+     * Corresponds to Dafny's {@code MessageSource} enum,
+     * whose values include {@code Parser}, {@code Resolver}, {@code Verifier}, etc.
+     */
+    @JsonProperty("source")
+    public String messageSource;
+
+    public List<RelatedInfo> relatedInformation;
+
+    public static DafnyDiagnostic forSummary(String summaryLine) {
+        var diagnostic = new DafnyDiagnostic();
+        diagnostic.severity = SEVERITY_INFO;
+        diagnostic.message = summaryLine;
+        return diagnostic;
+    }
+
+    @Override
+    public Kind getKind() {
+        return switch (severity) {
+            case SEVERITY_ERROR -> Kind.ERROR;
+            case SEVERITY_WARNING -> Kind.WARNING;
+            case SEVERITY_INFO -> Kind.NOTE;
+            default -> throw new IllegalStateException("Unexpected severity: " + severity);
+        };
+    }
+
+    @Override
+    public String getSource() {
+        return location == null ? null : location.filename();
+    }
+
+    @Override
+    public long getPosition() {
+        return getStartPosition();
+    }
+
+    @Override
+    public long getStartPosition() {
+        return location.range.start.pos;
+    }
+
+    @Override
+    public long getEndPosition() {
+        return location.range.end.pos;
+    }
+
+    @Override
+    public long getLineNumber() {
+        return location.range.start.line;
+    }
+
+    @Override
+    public long getColumnNumber() {
+        return location.range.start.character;
+    }
+
+    @Override
+    public String getCode() {
+        return null;
+    }
+
+    @Override
+    public String getMessage(Locale locale) {
+        return message;
+    }
+
+    public record Position(int pos, int line, int character) {}
+
+    public record Range(Position start, Position end) {}
+
+    public record Location(String filename, String uri, Range range) {}
+
+    public record RelatedInfo(Location location, String message) {
+        public DafnyDiagnostic asDiagnostic() {
+            var diagnostic = new DafnyDiagnostic();
+            diagnostic.location = location;
+            diagnostic.severity = SEVERITY_INFO;
+            diagnostic.message = "Related location: " + message;
+            return diagnostic;
+        }
+    }
+}

--- a/verifier/src/main/java/com/aws/jverify/verifier/Driver.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/Driver.java
@@ -1,8 +1,11 @@
 package com.aws.jverify.verifier;
 
+import com.aws.jverify.common.Position;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sun.tools.javac.util.*;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import picocli.CommandLine;
 
 import javax.tools.Diagnostic;
@@ -12,25 +15,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Consumer;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class Driver {
-
-    public static int verifyJavaSource(VerifierOptions options, String source, Writer output) throws IOException {
-        var files = new ArrayList<JavaFileObject>();
-        files.add(new SourceFile("file:/test.java", source));
-        return verifyJavaFiles(files, options, output);
-    }
-    
-    public static int verifyJavaExample(VerifierOptions options, Path javaFile, Writer output) throws IOException {
-        var files = new ArrayList<JavaFileObject>();
-        files.add(new SourceFile(javaFile, Files.readString(javaFile)));
-        return verifyJavaFiles(files, options, output);
-    }
-
     public static int verifyJavaPaths(List<Path> files, VerifierOptions verifierOptions, Writer output) throws IOException {
         List<JavaFileObject> readFiles = files.stream().map((Path p) -> {
             try {
@@ -42,11 +31,17 @@ public class Driver {
         return verifyJavaFiles(readFiles, verifierOptions, output);
     }
 
-    public static int verifyJavaFiles(
+    public static VerificationResults verifyJavaFile(JavaFileObject javaFile, VerifierOptions options)
+            throws IOException {
+        return verifyJavaFiles(List.of(javaFile), options);
+    }
+
+    public static VerificationResults verifyJavaFiles(
             List<JavaFileObject> readFiles,
-            VerifierOptions verifierOptions,
-            Consumer<Diagnostic<?>> diagnosticConsumer
+            VerifierOptions verifierOptions
     ) throws IOException {
+        var verificationResults = new VerificationResults();
+
         var context = new Context();
         var compiler = new JavaToDafnyCompiler(context);
         var messages = JavacMessages.instance(context);
@@ -55,22 +50,23 @@ public class Driver {
         var dafnyEquivalent = compiler.analyzeJavaCode(verifierOptions, readFiles);
         var hasErrors = false;
         for (var diagnostic : compiler.diagnostics.getDiagnostics()) {
-            diagnosticConsumer.accept(diagnostic);
+            verificationResults.diagnostics.add(diagnostic);
             if (diagnostic.getKind() == Diagnostic.Kind.ERROR) {
                 hasErrors = true;
             }
         }
         if (dafnyEquivalent == null || hasErrors) {
-            return CommandLine.ExitCode.USAGE;
+            verificationResults.exitCode = CommandLine.ExitCode.USAGE;
+        } else {
+            var programBuilder = new StringBuilder();
+            new Serializer(new TextEncoder(programBuilder)).serialize(dafnyEquivalent);
+            var program = programBuilder.toString();
+            if (verifierOptions.printBinaryDafny() != null) {
+                Files.writeString(verifierOptions.printBinaryDafny(), program);
+            }
+            runDafnyProcess(program, verifierOptions, verificationResults);
         }
-
-        var programBuilder = new StringBuilder();
-        new Serializer(new TextEncoder(programBuilder)).serialize(dafnyEquivalent);
-        var program = programBuilder.toString();
-        if (verifierOptions.printBinaryDafny() != null) {
-            Files.writeString(verifierOptions.printBinaryDafny(), program);
-        }
-        return runDafnyProcess(program, verifierOptions, diagnosticConsumer::accept);
+        return verificationResults;
     }
 
     public static int verifyJavaFiles(
@@ -78,21 +74,59 @@ public class Driver {
             VerifierOptions verifierOptions,
             Writer output
     ) throws IOException {
-        return verifyJavaFiles(readFiles, verifierOptions, diagnostic -> {
-            try {
-                output.write(formatDiagnostic(diagnostic));
-                output.write('\n');
-                if (diagnostic instanceof DafnyDiagnostic dafnyDiagnostic
-                        && dafnyDiagnostic.relatedInformation != null) {
-                    for (var relatedInfo : dafnyDiagnostic.relatedInformation) {
-                        output.write(formatDiagnostic(relatedInfo.asDiagnostic()));
-                        output.write('\n');
-                    }
+        var verificationResults = verifyJavaFiles(readFiles, verifierOptions);
+        for (var diagnostic : verificationResults.diagnostics) {
+            output.write(formatDiagnostic(diagnostic));
+            output.write('\n');
+            if (diagnostic instanceof DafnyDiagnostic dafnyDiagnostic
+                    && dafnyDiagnostic.relatedInformation != null) {
+                for (var relatedInfo : dafnyDiagnostic.relatedInformation) {
+                    output.write(formatDiagnostic(relatedInfo.asDiagnostic()));
+                    output.write('\n');
                 }
-            } catch (IOException e) {
-                throw new RuntimeException("Exception while writing verification output", e);
             }
-        });
+        }
+        assert verificationResults.dafnyFinishedMessage != null;
+        output.write(verificationResults.dafnyFinishedMessage);
+        return verificationResults.exitCode;
+    }
+
+    public static final class VerificationResults {
+        // dummy value to tell when it hasn't been set
+        private int exitCode = -999;
+
+        private final List<Diagnostic<?>> diagnostics = new ArrayList<>();
+
+        /**
+         * Can be null if verification failed before invoking Dafny.
+         */
+        private @Nullable Integer dafnyVerifiedCount;
+
+        /**
+         * Can be null if verification failed before invoking Dafny.
+         */
+        private @Nullable Integer dafnyErrorCount;
+
+        /**
+         * Can be null if verification failed before invoking Dafny.
+         */
+        private @Nullable String dafnyFinishedMessage;
+
+        public int getExitCode() {
+            return exitCode;
+        }
+
+        public List<Diagnostic<?>> getDiagnostics() {
+            return diagnostics;
+        }
+
+        public @Nullable Integer getDafnyVerifiedCount() {
+            return dafnyVerifiedCount;
+        }
+
+        public @Nullable Integer getDafnyErrorCount() {
+            return dafnyErrorCount;
+        }
     }
 
     private static String formatDiagnostic(Diagnostic<?> diagnostic) {
@@ -108,74 +142,64 @@ public class Driver {
             sb.append("-");
             sb.append(line).append(":").append(column + 1);
             sb.append("): ");
-
-            switch (diagnostic.getKind()) {
-                case ERROR:
-                    sb.append("error: ");
-                    break;
-                case WARNING:
-                    sb.append("warning: ");
-                    break;
-                case MANDATORY_WARNING:
-                    sb.append("required Warning: ");
-                    break;
-                case NOTE:
-                    sb.append("note: ");
-                    break;
-                default:
-                    sb.append(diagnostic.getKind()).append(": ");
-            }
         } else if (diagnostic instanceof DafnyDiagnostic dafnyDiagnostic) {
-            if (dafnyDiagnostic.location != null) {
-                sb.append(dafnyDiagnostic.getSource());
-
-                var start = dafnyDiagnostic.location.range().start();
-                var end = dafnyDiagnostic.location.range().end();
-                sb.append("(");
-                sb.append(start.line()).append(":").append(start.character());
-                sb.append("-");
-                sb.append(end.line()).append(":").append(end.character());
-                sb.append("): ");
-            }
+            sb.append(dafnyDiagnostic.getSource())
+                    .append("(")
+                    .append(dafnyDiagnostic.getRange())
+                    .append("): ");
         } else {
             throw new IllegalArgumentException(
                     "Formatting not implemented for diagnostic type " + diagnostic.getClass().getName());
         }
 
-        sb.append(diagnostic.getMessage(null));
+        sb.append(formatMessage(diagnostic));
         return sb.toString();
     }
 
-    public static int runDafnyProcess(String program, VerifierOptions verifierOptions, Consumer<DafnyDiagnostic> diagnosticConsumer) {
-        var dafnyPath = verifierOptions.dafnyPath();
-        try {
-            ProcessBuilder processBuilder = new ProcessBuilder(
-                    dafnyPath.toString(),  // Program path
-                    "verify",
-                    "--library",
-                    verifierOptions.additionalDafnyFile().toAbsolutePath().toString(),
-                    "--allow-axioms",
-                    "--dont-verify-dependencies",
-                    "--input-format",
-                    "Binary",
-                    "--stdin",
-                    "--json-diagnostics",
-                    "--allow-warnings"
-            );
-            if (verifierOptions.printDafny() != null) {
-                processBuilder.command().add("--print=" + verifierOptions.printDafny());
-            }
-            if (verifierOptions.showRanges()) {
-                // --show-snippets has no affect because Dafny can't extract them from the serialized source anyways
-                processBuilder.command().add("--show-snippets=false");
-                processBuilder.command().add("--print-ranges");
-            }
-            processBuilder.command().add("--ignore-indentation");
-            
-            for(var option : verifierOptions.additionalDafnyArguments()) {
-                processBuilder.command().add(option);
-            }
+    public static String formatMessage(Diagnostic<?> diagnostic) {
+        if (diagnostic instanceof JCDiagnostic) {
+            var prefix = switch (diagnostic.getKind()) {
+                case ERROR -> "error";
+                case WARNING -> "warning";
+                case MANDATORY_WARNING -> "required warning";
+                case NOTE -> "note";
+                default -> diagnostic.getKind();
+            };
+            return prefix + ": " + diagnostic.getMessage(null);
+        }
 
+        return diagnostic.getMessage(null);
+    }
+
+    public static void runDafnyProcess(
+            String program, VerifierOptions verifierOptions, VerificationResults outResults) {
+        var processBuilder = new ProcessBuilder(
+                verifierOptions.dafnyPath().toString(),
+                "verify",
+                "--library",
+                verifierOptions.additionalDafnyFile().toAbsolutePath().toString(),
+                "--allow-axioms",
+                "--dont-verify-dependencies",
+                "--input-format",
+                "Binary",
+                "--stdin",
+                "--json-diagnostics",
+                "--allow-warnings"
+        );
+        if (verifierOptions.printDafny() != null) {
+            processBuilder.command().add("--print=" + verifierOptions.printDafny());
+        }
+        if (verifierOptions.showRanges()) {
+            // --show-snippets has no affect because Dafny can't extract them from the serialized source anyways
+            processBuilder.command().add("--show-snippets=false");
+            processBuilder.command().add("--print-ranges");
+        }
+        processBuilder.command().add("--ignore-indentation");
+        for (var option : verifierOptions.additionalDafnyArguments()) {
+            processBuilder.command().add(option);
+        }
+
+        try {
             // Redirect stderr into stdout, instead of reading one and then the other,
             // in order to preserve the order of output and to avoid potential deadlock.
             var process = processBuilder.redirectErrorStream(true).start();
@@ -183,41 +207,52 @@ public class Driver {
                 stdin.write(program);
             }
             try (var stdout = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
-                parseDafnyJsonOutput(stdout).forEach(diagnosticConsumer);
-                return process.waitFor();
+                parseDafnyJsonOutput(stdout, outResults);
+                outResults.exitCode = process.waitFor();
             }
         } catch (InterruptedException | IOException e) {
             e.printStackTrace();
-            return -1;
+            outResults.exitCode = -1;
         }
     }
 
     private static final Pattern dafnySummaryPattern = Pattern.compile(
-            "Dafny program verifier finished with \\d+ verified, \\d+ errors?");
+            "Dafny program verifier finished with (?<VerifiedCount>\\d+) verified, (?<ErrorCount>\\d+) errors?");
 
     /**
-     * Parses the given {@code dafny verify} output into a stream of diagnostics,
-     * including a diagnostic of the verification summary ("Dafny program verifier finished with ...").
+     * Parses the given {@code dafny verify} output,
+     * adding both diagnostics and the summary verified/error counts to {@code outResults}.
      * Note that Dafny must be invoked with {@code --json-diagnostics} or else parsing will fail.
      */
-    private static Stream<DafnyDiagnostic> parseDafnyJsonOutput(BufferedReader dafnyOutput) {
+    private static void parseDafnyJsonOutput(BufferedReader dafnyOutput, VerificationResults outResults) {
         var objectMapper = new ObjectMapper();
-        return dafnyOutput.lines().flatMap(line -> {
+        objectMapper.addMixIn(Position.class, DafnyJsonPosition.class);
+
+        dafnyOutput.lines().forEach(line -> {
+            Matcher matcher;
             if (line.isBlank()) {
-                return Stream.empty();
+                //noinspection UnnecessaryReturnStatement
+                return;  // nothing to do
             } else if (line.startsWith("{")) {
-                final DafnyDiagnostic diagnostic;
                 try {
-                    diagnostic = objectMapper.readValue(line, DafnyDiagnostic.class);
+                    outResults.diagnostics.add(objectMapper.readValue(line, DafnyDiagnostic.class));
                 } catch (JsonProcessingException e) {
                     throw new RuntimeException("Malformed Dafny JSON diagnostic: " + line, e);
                 }
-                return Stream.of(diagnostic);
-            } else if (dafnySummaryPattern.matcher(line).matches()) {
-                return Stream.of(DafnyDiagnostic.forSummary(line));
+            } else if ((matcher = dafnySummaryPattern.matcher(line)).matches()) {
+                outResults.dafnyVerifiedCount = Integer.parseInt(matcher.group("VerifiedCount"));
+                outResults.dafnyErrorCount = Integer.parseInt(matcher.group("ErrorCount"));
+                outResults.dafnyFinishedMessage = line;
             } else {
                 throw new RuntimeException("Could not parse line of Dafny output: " + line);
             }
         });
     }
+
+    /**
+     * Used as an {@link ObjectMapper} mixin when parsing {@link Position},
+     * since Dafny JSON diagnostics include a {@code pos} field that we don't use or need.
+     */
+    @JsonIgnoreProperties({"pos"})
+    private static abstract class DafnyJsonPosition {}
 }

--- a/verifier/src/main/java/com/aws/jverify/verifier/Driver.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/Driver.java
@@ -1,5 +1,7 @@
 package com.aws.jverify.verifier;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sun.tools.javac.util.*;
 import picocli.CommandLine;
 
@@ -10,7 +12,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class Driver {
 
@@ -37,7 +42,11 @@ public class Driver {
         return verifyJavaFiles(readFiles, verifierOptions, output);
     }
 
-    public static int verifyJavaFiles(List<JavaFileObject> readFiles, VerifierOptions verifierOptions, Writer output) throws IOException {
+    public static int verifyJavaFiles(
+            List<JavaFileObject> readFiles,
+            VerifierOptions verifierOptions,
+            Consumer<Diagnostic<?>> diagnosticConsumer
+    ) throws IOException {
         var context = new Context();
         var compiler = new JavaToDafnyCompiler(context);
         var messages = JavacMessages.instance(context);
@@ -45,77 +54,112 @@ public class Driver {
 
         var dafnyEquivalent = compiler.analyzeJavaCode(verifierOptions, readFiles);
         var hasErrors = false;
-        for(var diagnostic : compiler.diagnostics.getDiagnostics()) {
-            output.write(formatDiagnostic(diagnostic) + "\n");
+        for (var diagnostic : compiler.diagnostics.getDiagnostics()) {
+            diagnosticConsumer.accept(diagnostic);
             if (diagnostic.getKind() == Diagnostic.Kind.ERROR) {
                 hasErrors = true;
             }
         }
-        if (dafnyEquivalent != null && !hasErrors) {
-            var programBuilder = new StringBuilder();
-            new Serializer(new TextEncoder(programBuilder)).serialize(dafnyEquivalent);
-            var program = programBuilder.toString();
-            if (verifierOptions.printBinaryDafny() != null) {
-                Files.writeString(verifierOptions.printBinaryDafny(), program);
-            }
-            return runDafnyProcess(program, verifierOptions, output);
+        if (dafnyEquivalent == null || hasErrors) {
+            return CommandLine.ExitCode.USAGE;
         }
-        return CommandLine.ExitCode.USAGE;
+
+        var programBuilder = new StringBuilder();
+        new Serializer(new TextEncoder(programBuilder)).serialize(dafnyEquivalent);
+        var program = programBuilder.toString();
+        if (verifierOptions.printBinaryDafny() != null) {
+            Files.writeString(verifierOptions.printBinaryDafny(), program);
+        }
+        return runDafnyProcess(program, verifierOptions, diagnosticConsumer::accept);
     }
 
-    private static String formatDiagnostic(Diagnostic<? extends JavaFileObject> diagnostic) {
-        StringBuilder sb = new StringBuilder();
+    public static int verifyJavaFiles(
+            List<JavaFileObject> readFiles,
+            VerifierOptions verifierOptions,
+            Writer output
+    ) throws IOException {
+        return verifyJavaFiles(readFiles, verifierOptions, diagnostic -> {
+            try {
+                output.write(formatDiagnostic(diagnostic));
+                output.write('\n');
+                if (diagnostic instanceof DafnyDiagnostic dafnyDiagnostic
+                        && dafnyDiagnostic.relatedInformation != null) {
+                    for (var relatedInfo : dafnyDiagnostic.relatedInformation) {
+                        output.write(formatDiagnostic(relatedInfo.asDiagnostic()));
+                        output.write('\n');
+                    }
+                }
+            } catch (IOException e) {
+                throw new RuntimeException("Exception while writing verification output", e);
+            }
+        });
+    }
 
-        if (diagnostic.getSource() != null) {
-            sb.append(diagnostic.getSource().getName());
-        }
-
-        sb.append("(");
-        sb.append(diagnostic.getLineNumber()).append(":");
-        sb.append(diagnostic.getColumnNumber());
+    private static String formatDiagnostic(Diagnostic<?> diagnostic) {
+        var sb = new StringBuilder();
 
         if (diagnostic instanceof JCDiagnostic jcDiagnostic) {
-            var endLine = diagnostic.getLineNumber();
-            var endColumn = diagnostic.getColumnNumber() + 1;
-            sb.append("-").append(endLine).append(":").append(endColumn);
-        }
+            sb.append(jcDiagnostic.getSource().getName());
 
-        sb.append("): ");
+            var line = diagnostic.getLineNumber();
+            var column = diagnostic.getColumnNumber();
+            sb.append("(");
+            sb.append(line).append(":").append(column);
+            sb.append("-");
+            sb.append(line).append(":").append(column + 1);
+            sb.append("): ");
 
-        switch (diagnostic.getKind()) {
-            case ERROR:
-                sb.append("error: ");
-                break;
-            case WARNING:
-                sb.append("warning: ");
-                break;
-            case MANDATORY_WARNING:
-                sb.append("required Warning: ");
-                break;
-            case NOTE:
-                sb.append("note: ");
-                break;
-            default:
-                sb.append(diagnostic.getKind()).append(": ");
+            switch (diagnostic.getKind()) {
+                case ERROR:
+                    sb.append("error: ");
+                    break;
+                case WARNING:
+                    sb.append("warning: ");
+                    break;
+                case MANDATORY_WARNING:
+                    sb.append("required Warning: ");
+                    break;
+                case NOTE:
+                    sb.append("note: ");
+                    break;
+                default:
+                    sb.append(diagnostic.getKind()).append(": ");
+            }
+        } else if (diagnostic instanceof DafnyDiagnostic dafnyDiagnostic) {
+            if (dafnyDiagnostic.location != null) {
+                sb.append(dafnyDiagnostic.getSource());
+
+                var start = dafnyDiagnostic.location.range().start();
+                var end = dafnyDiagnostic.location.range().end();
+                sb.append("(");
+                sb.append(start.line()).append(":").append(start.character());
+                sb.append("-");
+                sb.append(end.line()).append(":").append(end.character());
+                sb.append("): ");
+            }
+        } else {
+            throw new IllegalArgumentException(
+                    "Formatting not implemented for diagnostic type " + diagnostic.getClass().getName());
         }
 
         sb.append(diagnostic.getMessage(null));
         return sb.toString();
     }
-    
-    public static int runDafnyProcess(String program, VerifierOptions verifierOptions, Writer output) {
+
+    public static int runDafnyProcess(String program, VerifierOptions verifierOptions, Consumer<DafnyDiagnostic> diagnosticConsumer) {
         var dafnyPath = verifierOptions.dafnyPath();
         try {
             ProcessBuilder processBuilder = new ProcessBuilder(
                     dafnyPath.toString(),  // Program path
-                    "verify",                       // First argument
+                    "verify",
                     "--library",
                     verifierOptions.additionalDafnyFile().toAbsolutePath().toString(),
                     "--allow-axioms",
                     "--dont-verify-dependencies",
                     "--input-format",
                     "Binary",
-                    "--stdin",                        // Second argument
+                    "--stdin",
+                    "--json-diagnostics",
                     "--allow-warnings"
             );
             if (verifierOptions.printDafny() != null) {
@@ -132,30 +176,48 @@ public class Driver {
                 processBuilder.command().add(option);
             }
 
-            Process process = processBuilder.start();
-
-            var writer = new OutputStreamWriter(process.getOutputStream());
-            writer.write(program);
-            writer.close();
-
-            
-            // Read the output
-            try (BufferedReader reader = new BufferedReader(
-                    new InputStreamReader(process.getInputStream()))) {
-                reader.transferTo(output);
+            // Redirect stderr into stdout, instead of reading one and then the other,
+            // in order to preserve the order of output and to avoid potential deadlock.
+            var process = processBuilder.redirectErrorStream(true).start();
+            try (var stdin = new OutputStreamWriter(process.getOutputStream())) {
+                stdin.write(program);
             }
-
-            try (BufferedReader reader = new BufferedReader(
-                    new InputStreamReader(process.getErrorStream()))) {
-                reader.transferTo(output);
+            try (var stdout = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                parseDafnyJsonOutput(stdout).forEach(diagnosticConsumer);
+                return process.waitFor();
             }
-
-            int exitCode = process.waitFor();
-            return exitCode;
-
         } catch (InterruptedException | IOException e) {
             e.printStackTrace();
             return -1;
         }
+    }
+
+    private static final Pattern dafnySummaryPattern = Pattern.compile(
+            "Dafny program verifier finished with \\d+ verified, \\d+ errors?");
+
+    /**
+     * Parses the given {@code dafny verify} output into a stream of diagnostics,
+     * including a diagnostic of the verification summary ("Dafny program verifier finished with ...").
+     * Note that Dafny must be invoked with {@code --json-diagnostics} or else parsing will fail.
+     */
+    private static Stream<DafnyDiagnostic> parseDafnyJsonOutput(BufferedReader dafnyOutput) {
+        var objectMapper = new ObjectMapper();
+        return dafnyOutput.lines().flatMap(line -> {
+            if (line.isBlank()) {
+                return Stream.empty();
+            } else if (line.startsWith("{")) {
+                final DafnyDiagnostic diagnostic;
+                try {
+                    diagnostic = objectMapper.readValue(line, DafnyDiagnostic.class);
+                } catch (JsonProcessingException e) {
+                    throw new RuntimeException("Malformed Dafny JSON diagnostic: " + line, e);
+                }
+                return Stream.of(diagnostic);
+            } else if (dafnySummaryPattern.matcher(line).matches()) {
+                return Stream.of(DafnyDiagnostic.forSummary(line));
+            } else {
+                throw new RuntimeException("Could not parse line of Dafny output: " + line);
+            }
+        });
     }
 }

--- a/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
@@ -51,6 +51,8 @@ public class JavaToDafnyCompiler {
             throw new IllegalArgumentException("Could not find file: " + options.libraryJar());
         }
 
+        // don't assume the argument is modifiable
+        files = new ArrayList<>(files);
         files.add(new SourceFile("builtin-contracts.java", Common.getResourceFile(getClass(), builtinFile)));
                 
         List<String> javacOptions = List.of("-classpath", options.libraryJar().toAbsolutePath().toString());

--- a/verifier/src/main/java/com/aws/jverify/verifier/SourceFile.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/SourceFile.java
@@ -4,7 +4,7 @@ import javax.tools.SimpleJavaFileObject;
 import java.net.URI;
 import java.nio.file.Path;
 
-class SourceFile extends SimpleJavaFileObject {
+public class SourceFile extends SimpleJavaFileObject {
     final String content;
 
     /**
@@ -15,7 +15,7 @@ class SourceFile extends SimpleJavaFileObject {
      * then you should instead use {@link SourceFile#SourceFile(Path, String)}
      * in order to ensure correct functionality across different operating systems.
      */
-    SourceFile(String path, String content) {
+    public SourceFile(String path, String content) {
         super(URI.create("string:///" + path), Kind.SOURCE);
         this.content = content;
     }
@@ -23,13 +23,13 @@ class SourceFile extends SimpleJavaFileObject {
     /**
      * Constructs a {@link SourceFile} with the given path and content.
      */
-    SourceFile(Path path, String content) {
+    public SourceFile(Path path, String content) {
         super(path.toUri(), Kind.SOURCE);
         this.content = content;
     }
 
     @Override
-    public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+    public String getCharContent(boolean ignoreEncodingErrors) {
         return content;
     }
 }

--- a/verifier/src/main/java/module-info.java
+++ b/verifier/src/main/java/module-info.java
@@ -8,6 +8,8 @@ module com.aws.jverify.verifier {
     requires info.picocli;
     requires com.aws.jverify;
     requires java.sql;
+    requires com.fasterxml.jackson.annotation;
+    requires com.fasterxml.jackson.databind;
 
     opens com.aws.jverify.verifier to info.picocli;
 }

--- a/verifier/src/test/java/com/aws/jverify/AssertFalse.java
+++ b/verifier/src/test/java/com/aws/jverify/AssertFalse.java
@@ -1,3 +1,7 @@
+// exitCode: 4
+// dafnyVerified: 0
+// dafnyErrors: 1
+
 package com.aws.jverify;
 
 import static com.aws.jverify.JVerify.*;

--- a/verifier/src/test/java/com/aws/jverify/ContractErrors.java
+++ b/verifier/src/test/java/com/aws/jverify/ContractErrors.java
@@ -1,3 +1,5 @@
+// exitCode: 2
+
 package com.aws.jverify;
 
 import static com.aws.jverify.JVerify.check;

--- a/verifier/src/test/java/com/aws/jverify/FibonacciInvalid.java
+++ b/verifier/src/test/java/com/aws/jverify/FibonacciInvalid.java
@@ -1,3 +1,7 @@
+// exitCode: 4
+// dafnyVerified: 2
+// dafnyErrors: 4
+
 package com.aws.jverify;
 
 import static com.aws.jverify.JVerify.*;

--- a/verifier/src/test/java/com/aws/jverify/NoConstructor.java
+++ b/verifier/src/test/java/com/aws/jverify/NoConstructor.java
@@ -1,5 +1,9 @@
+// exitCode: 0
+// dafnyVerified: 0
+// dafnyErrors: 0
+
 package com.aws.jverify;
 
-public class NoConstructor {
+class NoConstructor {
     public int f;
 }

--- a/verifier/src/test/java/com/aws/jverify/Operators.java
+++ b/verifier/src/test/java/com/aws/jverify/Operators.java
@@ -1,3 +1,7 @@
+// exitCode: 4
+// dafnyVerified: 9
+// dafnyErrors: 9
+
 package com.aws.jverify;
 
 import static com.aws.jverify.JVerify.*;

--- a/verifier/src/test/java/com/aws/jverify/ResolutionErrorsBooleanOperators.java
+++ b/verifier/src/test/java/com/aws/jverify/ResolutionErrorsBooleanOperators.java
@@ -1,6 +1,6 @@
-package com.aws.jverify;
+// exitCode: 2
 
-import static com.aws.jverify.JVerify.check;
+package com.aws.jverify;
 
 @SuppressWarnings("ConstantValue")
 class ResolutionErrorsBooleanOperators {

--- a/verifier/src/test/java/com/aws/jverify/ResolutionErrorsDoubleOperators.java
+++ b/verifier/src/test/java/com/aws/jverify/ResolutionErrorsDoubleOperators.java
@@ -1,3 +1,5 @@
+// exitCode: 2
+
 package com.aws.jverify;
 
 @SuppressWarnings("ConstantValue")

--- a/verifier/src/test/java/com/aws/jverify/ResolutionErrorsFloatOperators.java
+++ b/verifier/src/test/java/com/aws/jverify/ResolutionErrorsFloatOperators.java
@@ -1,6 +1,6 @@
-package com.aws.jverify;
+// exitCode: 2
 
-import static com.aws.jverify.JVerify.check;
+package com.aws.jverify;
 
 @SuppressWarnings("ConstantValue")
 class ResolutionErrorsFloatOperators {

--- a/verifier/src/test/java/com/aws/jverify/ResolutionErrorsIntegerOperators.java
+++ b/verifier/src/test/java/com/aws/jverify/ResolutionErrorsIntegerOperators.java
@@ -1,3 +1,5 @@
+// exitCode: 2
+
 package com.aws.jverify;
 
 /**

--- a/verifier/src/test/java/com/aws/jverify/ResolutionErrorsNumericOperators.java
+++ b/verifier/src/test/java/com/aws/jverify/ResolutionErrorsNumericOperators.java
@@ -1,3 +1,5 @@
+// exitCode: 2
+
 package com.aws.jverify;
 
 import static com.aws.jverify.JVerify.check;

--- a/verifier/src/test/java/com/aws/jverify/ShouldVerify.java
+++ b/verifier/src/test/java/com/aws/jverify/ShouldVerify.java
@@ -1,3 +1,7 @@
+// exitCode: 4
+// dafnyVerified: 0
+// dafnyErrors: 4
+
 package com.aws.jverify;
 
 import static com.aws.jverify.JVerify.check;

--- a/verifier/src/test/java/com/aws/jverify/Switches.java
+++ b/verifier/src/test/java/com/aws/jverify/Switches.java
@@ -1,3 +1,7 @@
+// exitCode: 4
+// dafnyVerified: 3
+// dafnyErrors: 3
+
 package com.aws.jverify;
 
 import static com.aws.jverify.JVerify.check;

--- a/verifier/src/test/java/com/aws/jverify/TestVerifier.java
+++ b/verifier/src/test/java/com/aws/jverify/TestVerifier.java
@@ -19,10 +19,8 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
-import java.io.Writer;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
@@ -149,9 +147,11 @@ public class TestVerifier {
     /**
      * Parses test metadata from the given source content.
      * <p>
-     * Note that if verification is expected to fail before invoking Dafny
-     * (i.e. if there are errors in normal Java type-checking or during compilation to Dafny),
-     * then the {@code dafnyVerified} and {@code dafnyErrors} metadata should not appear in the source code.
+     * The {@code exitCode} value is required.
+     * The {@code dafnyVerified} and {@code dafnyErrors} values must either both be present or both be absent
+     * according to whether or not verification is expected to reach the Dafny verification phase.
+     * (That is, if they are present but Dafny is never invoked because there are javac errors,
+     * or if they are absent but Dafny is invoked and terminates normally, then the test should fail.)
      * <p>
      * Example test metadata:
      * {@snippet :
@@ -180,6 +180,9 @@ public class TestVerifier {
         }
         if (exitCode == null) {
             throw new AssertionError("Expected exit code not found in marked source");
+        }
+        if ((dafnyVerified == null) != (dafnyErrors == null)) {
+            throw new AssertionError("Found only one of dafnyVerified and dafnyErrors");
         }
         return new TestMetadata(exitCode, dafnyVerified, dafnyErrors);
     }

--- a/verifier/src/test/java/com/aws/jverify/TestVerifier.java
+++ b/verifier/src/test/java/com/aws/jverify/TestVerifier.java
@@ -22,7 +22,8 @@ public class TestVerifier {
     public void statements() throws IOException {
         verifyMarkedSourceFile("VerifyStatements.java", new DafnyResults(11, 0));
     }
-    
+
+    @Test
     public void resolutionErrorBooleanTest() throws IOException {
         testMarkedSource(getTestFileContent("ResolutionErrorsBooleanOperators.java"),
                 9, CommandLine.ExitCode.USAGE);
@@ -83,10 +84,7 @@ public class TestVerifier {
         StringWriter writer = new StringWriter();
         var exitCode = run("ExternalContract.java", true, writer);
         var output = canonicalizeNewlines(writer.toString());
-        Assertions.assertEquals("""
-
-Dafny program verifier finished with 2 verified, 0 errors
-""", output);
+        assertThat(output, containsString("Dafny program verifier finished with 2 verified, 0 errors"));
         Assertions.assertEquals(0, exitCode);
     }
     
@@ -99,7 +97,6 @@ Dafny program verifier finished with 2 verified, 0 errors
 UserProfile.java(32:9-32:16): Error: a postcondition could not be proved on this return path
 UserProfile.java(23:21-23:26): Related location: this is the postcondition that could not be proved
 UserProfile.java(25:16-25:77): Related location: this proposition could not be proved
-
 Dafny program verifier finished with 5 verified, 1 error
 """, output);
         Assertions.assertEquals(4, exitCode);
@@ -142,7 +139,7 @@ Dafny program verifier finished with 5 verified, 1 error
         StringWriter writer = new StringWriter();
         var exitCode = run("Fibonacci.java", true, writer);
         var output = canonicalizeNewlines(writer.toString());
-        Assertions.assertEquals("\nDafny program verifier finished with 4 verified, 0 errors\n", output);
+        assertThat(output, containsString("Dafny program verifier finished with 4 verified, 0 errors"));
         Assertions.assertEquals(0, exitCode);
     }
 
@@ -151,12 +148,7 @@ Dafny program verifier finished with 5 verified, 1 error
         StringWriter writer = new StringWriter();
         var exitCode = run("BinarySearch.java", true, writer);
         var output = canonicalizeNewlines(writer.toString());
-        Assertions.assertEquals("""
-
-Dafny program verifier finished with 3 verified, 0 errors
-""",
-                output
-        );
+        assertThat(output, containsString("Dafny program verifier finished with 3 verified, 0 errors"));
         Assertions.assertEquals(0, exitCode);
     }
     
@@ -172,21 +164,21 @@ Dafny program verifier finished with 3 verified, 0 errors
         try (var reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
             reader.transferTo(writer);
             exitCode = process.waitFor();
-            reader.close();
         }
         var output = canonicalizeNewlines(writer.toString());
-        Assertions.assertTrue(output.contains("Dafny program verifier finished with 4 verified, 0 errors"));
+        assertThat(output, containsString("Dafny program verifier finished with 4 verified, 0 errors"));
         Assertions.assertEquals(0, exitCode);
     }
 
     @Test
-    public void testNoConstructor() throws IOException, InterruptedException {
+    public void testNoConstructor() throws IOException {
         StringWriter writer = new StringWriter();
         var exitCode = run("NoConstructor.java", false, writer);
         Assertions.assertEquals(0, exitCode);
     }
 
     record DafnyResults(int successCount, int errorCount) {}
+
     private void verifyMarkedSourceFile(String inputFileName, DafnyResults dafnyResults) throws IOException {
         testMarkedSourceVerification(getTestFileContent(inputFileName), dafnyResults);
     }
@@ -263,7 +255,8 @@ Dafny program verifier finished with 3 verified, 0 errors
         return new VerifierOptions(dafnyPath, libraryJar, prelude, 
                 //Path.of("../temp.dfy"),
                 null,
-                null, true,
+                null,
+                true,
                 new String[] {
                         "--use-basename-for-filename"
                         //,"--wait-for-debugger"

--- a/verifier/src/test/java/com/aws/jverify/TestVerifier.java
+++ b/verifier/src/test/java/com/aws/jverify/TestVerifier.java
@@ -1,157 +1,88 @@
 package com.aws.jverify;
 
+import com.aws.jverify.common.AnnotatedRange;
 import com.aws.jverify.common.Common;
+import com.aws.jverify.common.Position;
+import com.aws.jverify.common.Range;
 import com.aws.jverify.common.TestMarkup;
+import com.aws.jverify.verifier.DafnyDiagnostic;
 import com.aws.jverify.verifier.Driver;
+import com.aws.jverify.verifier.SourceFile;
 import com.aws.jverify.verifier.VerifierOptions;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import picocli.CommandLine;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
-import java.io.*;
+import javax.tools.Diagnostic;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.StringWriter;
+import java.io.Writer;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.endsWith;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TestVerifier {
     private static final boolean IS_WINDOWS = System.getProperty("os.name", "").toLowerCase().contains("windows");
 
-    @Test
-    public void statements() throws IOException {
-        verifyMarkedSourceFile("VerifyStatements.java", new DafnyResults(11, 0));
-    }
+    private static final Path TEST_FILES_DIRECTORY = Path.of("./src/test/java/com/aws/jverify");
 
-    @Test
-    public void resolutionErrorBooleanTest() throws IOException {
-        testMarkedSource(getTestFileContent("ResolutionErrorsBooleanOperators.java"),
-                9, CommandLine.ExitCode.USAGE);
-    }
+    private static final Path EXAMPLES_DIRECTORY = Path.of("../examples/src/main/java/com/aws/verifier/examples");
 
-    @Test
-    public void verifyBooleanTest() throws IOException {
-        verifyMarkedSourceFile("VerifyBooleanOperators.java", new DafnyResults(0, 1));
-    }
-    
-    @Test
-    public void resolutionErrorIntegerTest() throws IOException {
-        testMarkedSource(getTestFileContent("ResolutionErrorsIntegerOperators.java"),
-                19, CommandLine.ExitCode.USAGE);
-    }
-    
-    @Test
-    public void resolutionErrorNumericTest() throws IOException {
-        testMarkedSource(getTestFileContent("ResolutionErrorsNumericOperators.java"),
-                9, CommandLine.ExitCode.USAGE);
-    }
-
-    @Test
-    public void resolutionErrorsDouble() throws IOException {
-        testMarkedSource(getTestFileContent("ResolutionErrorsDoubleOperators.java"),
-                20, CommandLine.ExitCode.USAGE);
-    }
-    
-    @Test
-    public void resolutionErrorsFloat() throws IOException {
-        testMarkedSource(getTestFileContent("ResolutionErrorsFloatOperators.java"),
-                20, CommandLine.ExitCode.USAGE);
-    }
-
-    @Test
-    public void verifyNumericTest() throws IOException {
-        verifyMarkedSourceFile("VerifyNumericOperators.java", new DafnyResults(0, 1));
-    }
-    
-    @Test
-    public void types() throws IOException {
-        verifyMarkedSourceFile("Types.java", new DafnyResults(0, 3));
-    }
-    
-    @Test
-    public void shouldVerify() throws IOException {
-        verifyMarkedSourceFile("ShouldVerify.java", new DafnyResults(0, 4));
-    }
-    
-    @Test
-    public void contractErrors() throws IOException {
-        testMarkedSource(getTestFileContent("ContractErrors.java"), 
-                3, CommandLine.ExitCode.USAGE);
-    }
-    
-    @Test
-    public void externalContract() throws IOException {
-        StringWriter writer = new StringWriter();
-        var exitCode = run("ExternalContract.java", true, writer);
-        var output = canonicalizeNewlines(writer.toString());
-        assertThat(output, containsString("Dafny program verifier finished with 2 verified, 0 errors"));
-        Assertions.assertEquals(0, exitCode);
-    }
-    
-    @Test
-    public void userProfile() throws IOException {
-        StringWriter writer = new StringWriter();
-        var exitCode = run("UserProfile.java", true, writer);
-        var output = canonicalizeNewlines(writer.toString());
-        Assertions.assertEquals("""
-UserProfile.java(32:9-32:16): Error: a postcondition could not be proved on this return path
-UserProfile.java(23:21-23:26): Related location: this is the postcondition that could not be proved
-UserProfile.java(25:16-25:77): Related location: this proposition could not be proved
-Dafny program verifier finished with 5 verified, 1 error
-""", output);
-        Assertions.assertEquals(4, exitCode);
-    }
-
-    @Test
-    public void translationErrors() throws IOException {
-        String markedSource = getTestFileContent("TranslationErrors.java");
-        testMarkedSource(markedSource, 15, CommandLine.ExitCode.USAGE);
-    }
-    
     @Test
     public void javaError() throws IOException {
         var source = Common.getResourceFile(getClass(), "/JavaError.java");
-        testMarkedSource(source, 1, CommandLine.ExitCode.USAGE);
-    }
-    
-    @Test
-    public void assertFalse() throws IOException {
-        verifyMarkedSourceFile("AssertFalse.java", new DafnyResults(0, 1));
+        testMarkedSource(new SourceFile("JavaError.java", source));
     }
 
-    @Test
-    public void fibonacciInvalid() throws IOException {
-        verifyMarkedSourceFile("FibonacciInvalid.java", new DafnyResults(2, 4));
+    // TODO: read from directory instead of hard-coding
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "AssertFalse.java",
+            "ContractErrors.java",
+            "FibonacciInvalid.java",
+            "NoConstructor.java",
+            "Operators.java",
+            "ResolutionErrorsBooleanOperators.java",
+            "ResolutionErrorsDoubleOperators.java",
+            "ResolutionErrorsFloatOperators.java",
+            "ResolutionErrorsIntegerOperators.java",
+            "ResolutionErrorsNumericOperators.java",
+            "ShouldVerify.java",
+            "Switches.java",
+            "TranslationErrors.java",
+            "Types.java",
+            "VerifyBooleanOperators.java",
+            "VerifyNumericOperators.java",
+            "VerifyStatements.java",
+    })
+    public void verifyTestFile(String fileName) throws IOException {
+        testMarkedSource(TEST_FILES_DIRECTORY.resolve(fileName));
     }
 
-    @Test
-    public void operators() throws IOException {
-        verifyMarkedSourceFile("Operators.java", new DafnyResults(9, 9));
+    // Files are hard-coded for now since not all examples can be compiled and run as-is:
+    //  - RuntimePreconditionExample: the try-catch can't be translated yet
+    //  - BinarySearchProperty: the jqwik dependency needs to be added to the classpath
+    //
+    // TODO: read from directory instead of hard-coding
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "BinarySearch.java",
+            "ExternalContract.java",
+            "Fibonacci.java",
+            "UserProfile.java",
+    })
+    public void verifyExampleFile(String fileName) throws IOException {
+        testMarkedSource(EXAMPLES_DIRECTORY.resolve(fileName));
     }
 
-    @Test
-    public void switches() throws IOException {
-        verifyMarkedSourceFile("Switches.java", new DafnyResults(3, 3));
-    }
-
-    @Test
-    public void fibonacciValid() throws IOException {
-        StringWriter writer = new StringWriter();
-        var exitCode = run("Fibonacci.java", true, writer);
-        var output = canonicalizeNewlines(writer.toString());
-        assertThat(output, containsString("Dafny program verifier finished with 4 verified, 0 errors"));
-        Assertions.assertEquals(0, exitCode);
-    }
-
-    @Test
-    public void binarySearchValid() throws IOException {
-        StringWriter writer = new StringWriter();
-        var exitCode = run("BinarySearch.java", true, writer);
-        var output = canonicalizeNewlines(writer.toString());
-        assertThat(output, containsString("Dafny program verifier finished with 3 verified, 0 errors"));
-        Assertions.assertEquals(0, exitCode);
-    }
-    
     @Test
     public void testRunThroughGradle() throws IOException, InterruptedException {
         var gradlePath = IS_WINDOWS ? "../gradlew.bat" : "../gradlew";
@@ -170,64 +101,96 @@ Dafny program verifier finished with 5 verified, 1 error
         Assertions.assertEquals(0, exitCode);
     }
 
-    @Test
-    public void testNoConstructor() throws IOException {
-        StringWriter writer = new StringWriter();
-        var exitCode = run("NoConstructor.java", false, writer);
-        Assertions.assertEquals(0, exitCode);
-    }
-
-    record DafnyResults(int successCount, int errorCount) {}
-
-    private void verifyMarkedSourceFile(String inputFileName, DafnyResults dafnyResults) throws IOException {
-        testMarkedSourceVerification(getTestFileContent(inputFileName), dafnyResults);
-    }
-
-    private static String getTestFileContent(String inputFileName) throws IOException {
-        var directory = Path.of("./src/test/java/com/aws/jverify");
-        var filePath = directory.resolve(inputFileName);
-        return Files.readString(filePath);
-    }
-
-    private void testMarkedSourceVerification(String markedSource, DafnyResults dafnyResults) throws IOException {
-        int expectedExitCode = dafnyResults.errorCount() > 0 ? 4 : 0;
-        var output = testMarkedSource(markedSource, dafnyResults.errorCount(), expectedExitCode);
-        var pluralization = dafnyResults.errorCount() != 1 ? "s" : "";
-        String ending = "Dafny program verifier finished with " +
-                dafnyResults.successCount() + " verified, " +
-                dafnyResults.errorCount() + " error" + pluralization + "\n";
-        assertThat(output, endsWith(ending));
+    /**
+     * @see #testMarkedSource(SourceFile)
+     */
+    private static void testMarkedSource(Path markedSourcePath) throws IOException {
+        var markedSource = Files.readString(markedSourcePath);
+        testMarkedSource(new SourceFile(markedSourcePath, markedSource));
     }
 
     /**
-     * Verifies the given source code, asserting that each markup annotation appears in the output,
-     * and that the exit code and number of matched error annotations are as expected.
-     * <p>
-     * NOTE: Errors that appear in the verification output, but which don't appear in the marked-up source code,
-     * are currently silently ignored.
+     * Verifies the given source code and asserts that the exit code, emitted diagnostics,
+     * and verified/error counts (from Dafny) match the specified values in the source code's test metadata.
+     * See {@link #parseMetadata(String)} for details on the metadata format.
      */
-    private static String testMarkedSource(String markedSource, int expectedErrorCount, int expectedExitCode) throws IOException {
-        StringWriter writer = new StringWriter();
-        var options = getVerifierOptions();
-        var result = TestMarkup.getPositionsAndAnnotatedRanges(markedSource);
-        var source = result.output();
-        var exitCode = Driver.verifyJavaSource(options, source, writer);
-        var output = canonicalizeNewlines(writer.toString());
-        var errorsFound = 0;
-        for(var range : result.ranges()) {
-            var positionString = "(" + range.range.toString() + ")";
-            String expectation = positionString + ": " + range.annotation;
-            if (range.annotation.startsWith("Error:") || range.annotation.startsWith("error: ")) {
-                errorsFound++;
-            }
+    private static void testMarkedSource(SourceFile markedSourceFile) throws IOException {
+        var parsedMarkup = TestMarkup.getPositionsAndAnnotatedRanges(markedSourceFile.getCharContent(false));
+        var source = parsedMarkup.output();
+        var metadata = parseMetadata(source);
 
-            assertThat(output, containsString(expectation));
+        var options = getVerifierOptions();
+        var verificationResults = Driver.verifyJavaFile(markedSourceFile, options);
+
+        var diagnosticsAsAnnotations = verificationResults.getDiagnostics().stream()
+                .flatMap(diagnostic -> diagnostic instanceof DafnyDiagnostic dafnyDiagnostic
+                        ? dafnyDiagnostic.flattenRelated()
+                        : Stream.of(diagnostic))
+                .map(TestVerifier::diagnosticAsAnnotatedRange)
+                .sorted()
+                .toList();
+        var expectedAnnotations = parsedMarkup.ranges().stream().sorted().toList();
+        assertThat("diagnostics", diagnosticsAsAnnotations, equalTo(expectedAnnotations));
+
+        assertThat("exit code", verificationResults.getExitCode(), is(metadata.exitCode));
+        assertThat("Dafny verified count", verificationResults.getDafnyVerifiedCount(), is(metadata.dafnyVerified));
+        assertThat("Dafny error count", verificationResults.getDafnyErrorCount(), is(metadata.dafnyErrors));
+    }
+
+    private static final Pattern TEST_METADATA_PATTERN = Pattern.compile(
+            "^// (?<ExitCodeLine>exitCode: (?<ExitCode>-?\\d+))$"
+                    + "|^// (?<DafnyVerifiedLine>dafnyVerified: (?<DafnyVerified>\\d+))$"
+                    + "|^// (?<DafnyErrorsLine>dafnyErrors: (?<DafnyErrors>\\d+))$",
+            Pattern.MULTILINE
+    );
+
+    private record TestMetadata(int exitCode, Integer dafnyVerified, Integer dafnyErrors) {}
+
+    /**
+     * Parses test metadata from the given source content.
+     * <p>
+     * Note that if verification is expected to fail before invoking Dafny
+     * (i.e. if there are errors in normal Java type-checking or during compilation to Dafny),
+     * then the {@code dafnyVerified} and {@code dafnyErrors} metadata should not appear in the source code.
+     * <p>
+     * Example test metadata:
+     * {@snippet :
+     * // exitCode: 4
+     * // dafnyVerified: 1
+     * // dafnyErrors: 2
+     *
+     * class Foo {
+     *     // ...
+     * }
+     * }
+     */
+    private static TestMetadata parseMetadata(String source) {
+        Integer exitCode = null;
+        Integer dafnyVerified = null;
+        Integer dafnyErrors = null;
+        var metadataMatcher = TEST_METADATA_PATTERN.matcher(source);
+        while (metadataMatcher.find()) {
+            if (metadataMatcher.group("ExitCodeLine") != null) {
+                exitCode = Integer.parseInt(metadataMatcher.group("ExitCode"));
+            } else if (metadataMatcher.group("DafnyVerifiedLine") != null) {
+                dafnyVerified = Integer.parseInt(metadataMatcher.group("DafnyVerified"));
+            } else if (metadataMatcher.group("DafnyErrorsLine") != null) {
+                dafnyErrors = Integer.parseInt(metadataMatcher.group("DafnyErrors"));
+            }
         }
-        Assertions.assertEquals(expectedErrorCount, errorsFound,
-                () -> "Mismatched error count in output:\n%s".formatted(output));
-        Assertions.assertEquals(expectedExitCode, exitCode,
-                () -> "Mismatched exit code; output:\n%s".formatted(output));
-        return output;
+        if (exitCode == null) {
+            throw new AssertionError("Expected exit code not found in marked source");
+        }
+        return new TestMetadata(exitCode, dafnyVerified, dafnyErrors);
+    }
+
+    private static AnnotatedRange diagnosticAsAnnotatedRange(Diagnostic<?> diagnostic) {
+        var startPos = new Position(diagnostic.getLineNumber(), diagnostic.getColumnNumber());
+        var endPos = diagnostic instanceof DafnyDiagnostic dafnyDiagnostic
+                ? new Position(dafnyDiagnostic.getEndLineNumber(), dafnyDiagnostic.getEndColumnNumber())
+                : new Position(startPos.line(), startPos.character() + 1);
+        var range = new Range(startPos, endPos);
+        return new AnnotatedRange(Driver.formatMessage(diagnostic), range);
     }
 
     /**
@@ -238,26 +201,17 @@ Dafny program verifier finished with 5 verified, 1 error
         return text.replaceAll("\r\n", "\n");
     }
 
-    private int run(String inputFileName, boolean fromExamples, Writer writer) throws IOException {
-        var directory = fromExamples
-                ? Path.of("../examples/src/main/java/com/aws/verifier/examples")
-                : Path.of("./src/test/java/com/aws/jverify");
-        var filePath = directory.resolve(inputFileName);
-        var options = getVerifierOptions();
-        return Driver.verifyJavaExample(options, filePath, writer);
-    }
-
     private static VerifierOptions getVerifierOptions() {
         var dafnyPath = Path.of("../dafny").toAbsolutePath()
                 .resolve(IS_WINDOWS ? "Binaries/Dafny.exe" : "Scripts/dafny");
         var libraryJar = Path.of("../library/build/libs/library.jar");
         var prelude = Path.of("./src/main/resources/additional.dfy");
-        return new VerifierOptions(dafnyPath, libraryJar, prelude, 
+        return new VerifierOptions(dafnyPath, libraryJar, prelude,
                 //Path.of("../temp.dfy"),
                 null,
                 null,
                 true,
-                new String[] {
+                new String[]{
                         "--use-basename-for-filename"
                         //,"--wait-for-debugger"
                 }

--- a/verifier/src/test/java/com/aws/jverify/TranslationErrors.java
+++ b/verifier/src/test/java/com/aws/jverify/TranslationErrors.java
@@ -1,3 +1,5 @@
+// exitCode: 2
+
 package com.aws.jverify;
 
 import static com.aws.jverify.JVerify.*;

--- a/verifier/src/test/java/com/aws/jverify/Types.java
+++ b/verifier/src/test/java/com/aws/jverify/Types.java
@@ -1,3 +1,7 @@
+// exitCode: 4
+// dafnyVerified: 0
+// dafnyErrors: 3
+
 package com.aws.jverify;
 
 class Types {

--- a/verifier/src/test/java/com/aws/jverify/VerifyBooleanOperators.java
+++ b/verifier/src/test/java/com/aws/jverify/VerifyBooleanOperators.java
@@ -1,3 +1,7 @@
+// exitCode: 4
+// dafnyVerified: 0
+// dafnyErrors: 1
+
 package com.aws.jverify;
 
 import static com.aws.jverify.JVerify.check;

--- a/verifier/src/test/java/com/aws/jverify/VerifyNumericOperators.java
+++ b/verifier/src/test/java/com/aws/jverify/VerifyNumericOperators.java
@@ -1,3 +1,7 @@
+// exitCode: 4
+// dafnyVerified: 0
+// dafnyErrors: 1
+
 package com.aws.jverify;
 
 import static com.aws.jverify.JVerify.check;

--- a/verifier/src/test/java/com/aws/jverify/VerifyStatements.java
+++ b/verifier/src/test/java/com/aws/jverify/VerifyStatements.java
@@ -1,3 +1,7 @@
+// exitCode: 0
+// dafnyVerified: 11
+// dafnyErrors: 0
+
 package com.aws.jverify;
 
 import static com.aws.jverify.JVerify.*;

--- a/verifier/src/test/resources/JavaError.java
+++ b/verifier/src/test/resources/JavaError.java
@@ -1,3 +1,5 @@
+// exitCode: 2
+
 package com.aws.jverify;
 
 class JavaError {


### PR DESCRIPTION
### What was changed?

- Refactor the driver to receive structured output from Dafny by passing `--json-diagnostics`, and to return a new `VerificationResults` record (instead of separately returning an exit code and writing all javac/Dafny output to a `Writer`)
  - (The `Writer`-based overload of `verifyJavaFiles` was adapted for use on the command-line code path.)
- Refactor the verifier tests to check expected results using the structured `VerificationResults`
  - (This closes a [testing gap](https://github.com/aws/jverify/pull/110#discussion_r2049327260) that would silently ignore errors that appeared in the verification output but not in the marked-up source.)
- Reduce verifier test boilerplate by parameterizing test methods, and by storing expected exit codes and Dafny verified/error counts directly in the test files' contents
  - (Previously, the `resolutionErrorBooleanTest` method was missing the `@Test` annotation and so it wasn't actually being tested - test parameterization will help detect that kind of mistake)
- Add `DafnyDiagnostic` to adapt Dafny's diagnostics to the `javax.tools.Diagnostic` interface (which `JCDiagnostic` also implements)
- Change `Position` to use 1-indexed line and column numbers, to better align with both Dafny's `Token` and `javax.tools.Diagnostic`

### How has this been tested?

No new functionality was added; the existing tests continue to pass as expected.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/aws/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
