### PR TITLE
Support of simple forms of instanceof

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,7 +57,7 @@ project(":library") {
     java {
         toolchain {
             // Use Java 17 for this subproject, so Java 17 projects can depend on it at compile-/run-time
-            languageVersion = JavaLanguageVersion.of(22)
+            languageVersion = JavaLanguageVersion.of(17)
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,7 +57,7 @@ project(":library") {
     java {
         toolchain {
             // Use Java 17 for this subproject, so Java 17 projects can depend on it at compile-/run-time
-            languageVersion = JavaLanguageVersion.of(17)
+            languageVersion = JavaLanguageVersion.of(22)
         }
     }
 }

--- a/verifier/src/main/java/com/aws/jverify/generated/TypeTestExpr.java
+++ b/verifier/src/main/java/com/aws/jverify/generated/TypeTestExpr.java
@@ -1,0 +1,9 @@
+package com.aws.jverify.generated;
+
+// Generated TypeTestExpr.java:
+// Generated from C# class
+public class TypeTestExpr extends TypeUnaryExpr {
+  public TypeTestExpr(IOrigin origin, Expression e, Type toType) {
+    super(origin, e, toType);
+  }
+}

--- a/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
@@ -739,6 +739,11 @@ public class JavaToDafnyCompiler {
             reportError(expr, "mutatingExpression", assignOp.getOperator().name.toString() + "=");
             return getHole(origin);
         }
+        else if (expr instanceof JCTree.JCInstanceOf instanceOf) {
+            var expression = toExpr(instanceOf.getExpression());
+            var jcType = toType(instanceOf.getType());
+            return new TypeTestExpr(origin, expression, jcType);
+        }
         reportError(expr, "notSupported", expr.getClass().getSimpleName());
         return getHole(origin);  
     }

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/Operators.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/Operators.java
@@ -1,10 +1,20 @@
-// TEST: exitCode=4 dafnyVerified=9 dafnyErrors=9
+// TEST: exitCode=4 dafnyVerified=13 dafnyErrors=10
 
 package com.aws.jverify.verifier.tests;
 
 import com.aws.jverify.testengine.JVerifyTest;
 
 import static com.aws.jverify.JVerify.*;
+
+interface DummyInterface {}
+class DummyClass implements DummyInterface {
+    public static DummyInterface create() {
+        DummyInterface t =  new DummyClass(); return t; }
+}
+class DummyClass2 implements DummyInterface {
+    public static DummyInterface create() {DummyInterface t =  new DummyClass2(); return t;}
+}
+
 
 @JVerifyTest
 class Operators {
@@ -131,5 +141,21 @@ class Operators {
         int y = 3;
         check(x == y);
 //      ^^^^^^^^^^^^^ Error: assertion might not hold
+    }
+
+    void InstanceOfTrivial() {
+        check(this instanceof Operators);
+    }
+
+    void InstanceOfDummyClass() {
+        DummyClass dc = new DummyClass();
+        check(dc instanceof DummyClass);
+    }
+
+    void InstanceOfKO() {
+        DummyInterface di = DummyClass.create();
+        check(di instanceof DummyClass2);
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Error: assertion might not hold
+
     }
 }


### PR DESCRIPTION
### What was changed?
Support of instanceof in Java, converted to TypeTestExpr in Dafny

### How has this been tested?
Added (positive and negative) test cases in Operators.java 

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/aws/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
