### PR TITLE
Partial support of new array and multi-dimensional arrays

### DIFF
--- a/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
@@ -657,10 +657,12 @@ public class JavaToDafnyCompiler {
         if (expr instanceof JCTree.JCNewArray newArray) {
             var arrayDimensions = newArray.getDimensions().stream().map(d -> toExpr(d)).toList();
             var arrayInitializers = newArray.getInitializers();
+            var arrType = toType(newArray.getType(),true);
+
             if (arrayInitializers != null && arrayInitializers.size() > 0) {
                 reportError(expr, "notSupported", "new array with initializers");
             }
-            return new AllocateArray(origin, null, null, arrayDimensions, null);
+            return new AllocateArray(origin, null, arrType, arrayDimensions, null);
         }
         var dafnyExpr = toExpr(expr);
         return new ExprRhs(origin, null, dafnyExpr);
@@ -1039,7 +1041,7 @@ public class JavaToDafnyCompiler {
             reportError(tree, "notSupported", "Primitive type kind %s".formatted(primitiveTypeKind));
             return null;
         } else if (tree instanceof JCTree.JCArrayTypeTree arrayTypeTree) {
-            var elemType = toType(arrayTypeTree.getType(), false, originOverride);
+            var elemType = toType(arrayTypeTree.getType(), true, originOverride);
             if (elemType == null) {
                 // should be unreachable
                 throw new IllegalArgumentException("Array type without element type");

--- a/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
@@ -657,10 +657,12 @@ public class JavaToDafnyCompiler {
         if (expr instanceof JCTree.JCNewArray newArray) {
             var arrayDimensions = newArray.getDimensions().stream().map(d -> toExpr(d)).toList();
             var arrayInitializers = newArray.getInitializers();
+            var arrType = toType(newArray.getType(),true);
+
             if (arrayInitializers != null && arrayInitializers.size() > 0) {
                 reportError(expr, "notSupported", "new array with initializers");
             }
-            return new AllocateArray(origin, null, null, arrayDimensions, null);
+            return new AllocateArray(origin, null, arrType, arrayDimensions, null);
         }
         var dafnyExpr = toExpr(expr);
         return new ExprRhs(origin, null, dafnyExpr);
@@ -1034,7 +1036,7 @@ public class JavaToDafnyCompiler {
             reportError(tree, "notSupported", "Primitive type kind %s".formatted(primitiveTypeKind));
             return null;
         } else if (tree instanceof JCTree.JCArrayTypeTree arrayTypeTree) {
-            var elemType = toType(arrayTypeTree.getType(), false, originOverride);
+            var elemType = toType(arrayTypeTree.getType(), true, originOverride);
             if (elemType == null) {
                 // should be unreachable
                 throw new IllegalArgumentException("Array type without element type");

--- a/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
@@ -740,9 +740,30 @@ public class JavaToDafnyCompiler {
                 return new ExprDotName(origin, toExpr(fieldAccess.selected), getName(fieldAccess, fieldAccess.name), null);
             }
         } else if (expr instanceof JCTree.JCArrayAccess arrayAccess) {
-            var arrayExpr = toExpr(arrayAccess.getExpression());
-            var indexExpr = toExpr(arrayAccess.getIndex());
-            return new SeqSelectExpr(origin, true, arrayExpr, indexExpr, null, null);
+            // If subExpr is of type Array, this means we have an access to a full slice
+            // of a multidimensiobnal array, i.e. something like
+            // int[][] tab = new int[4][4];
+            // tab[1] = new int[4];
+            // This is not supported yet
+            if (expr.type instanceof ArrayType _) {
+                reportError(expr, "Access to slices of multi-dimensions arrays not yet supported");
+                return getHole(origin);
+            }
+            var subExpr = arrayAccess.getExpression();
+            List<Expression> indexE = new ArrayList<>();
+            indexE.add(toExpr(arrayAccess.getIndex()));
+            while(subExpr instanceof JCTree.JCArrayAccess arrayAccess_) {
+                subExpr = arrayAccess_.getExpression();
+                indexE.addFirst(toExpr(arrayAccess_.getIndex()));
+            }
+
+            var arrayExpr = toExpr(subExpr);
+            if (indexE.size() > 1) {
+                return new MultiSelectExpr(origin, arrayExpr, indexE);
+            }
+            else {
+                return new SeqSelectExpr(origin, true, arrayExpr, indexE.getFirst(), null, null);
+            }
         } else if (expr instanceof JCTree.JCParens parens) {
             return toExpr(parens.getExpression());
         } else if (expr instanceof JCTree.JCAssignOp assignOp) {
@@ -1041,12 +1062,19 @@ public class JavaToDafnyCompiler {
             reportError(tree, "notSupported", "Primitive type kind %s".formatted(primitiveTypeKind));
             return null;
         } else if (tree instanceof JCTree.JCArrayTypeTree arrayTypeTree) {
-            var elemType = toType(arrayTypeTree.getType(), true, originOverride);
+            var elemTy = arrayTypeTree.getType();
+            int dimensions = 1;
+            while (elemTy instanceof JCTree.JCArrayTypeTree x) {
+                dimensions++;
+                elemTy = x.getType();
+            }
+            var elemType = toType(elemTy, true, originOverride);
             if (elemType == null) {
                 // should be unreachable
                 throw new IllegalArgumentException("Array type without element type");
             }
-            return new UserDefinedType(origin, new NameSegment(origin, "array" + nullableSuffix, List.of(elemType)));
+            var arrayBase = (dimensions == 1) ? "array" : "array" + dimensions;
+            return new UserDefinedType(origin, new NameSegment(origin, arrayBase + nullableSuffix, List.of(elemType)));
         } else if (tree instanceof JCTree.JCExpression expr) {
             var expression = toExpr(expr);
             

--- a/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
@@ -593,10 +593,12 @@ public class JavaToDafnyCompiler {
         if (expr instanceof JCTree.JCNewArray newArray) {
             var arrayDimensions = newArray.getDimensions().stream().map(d -> toExpr(d)).toList();
             var arrayInitializers = newArray.getInitializers();
+            var arrType = toType(newArray.getType(),true);
+
             if (arrayInitializers != null && arrayInitializers.size() > 0) {
                 reportError(expr, "notSupported", "new array with initializers");
             }
-            return new AllocateArray(origin, null, null, arrayDimensions, null);
+            return new AllocateArray(origin, null, arrType, arrayDimensions, null);
         }
         var dafnyExpr = toExpr(expr);
         return new ExprRhs(origin, null, dafnyExpr);
@@ -962,7 +964,7 @@ public class JavaToDafnyCompiler {
             reportError(tree, "notSupported", "Primitive type kind %s".formatted(primitiveTypeKind));
             return null;
         } else if (tree instanceof JCTree.JCArrayTypeTree arrayTypeTree) {
-            var elemType = toType(arrayTypeTree.getType(), false, originOverride);
+            var elemType = toType(arrayTypeTree.getType(), true, originOverride);
             if (elemType == null) {
                 // should be unreachable
                 throw new IllegalArgumentException("Array type without element type");

--- a/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
@@ -740,7 +740,7 @@ public class JavaToDafnyCompiler {
                 return new ExprDotName(origin, toExpr(fieldAccess.selected), getName(fieldAccess, fieldAccess.name), null);
             }
         } else if (expr instanceof JCTree.JCArrayAccess arrayAccess) {
-            // If subExpr is of type Array, this means we have an access to a full slice
+            // If expr is of type Array, this means we have an access to a full slice
             // of a multidimensional array, i.e. something like
             // int[][] tab = new int[4][4];
             // tab[1] = new int[4];

--- a/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
@@ -654,6 +654,14 @@ public class JavaToDafnyCompiler {
             var argBindings = newClass.getArguments().stream().map(a -> new ActualBinding(null, toExpr(a), false)).toList();
             return new AllocateClass(origin, null, toType(newClass.clazz), new ActualBindings(argBindings));
         }
+        if (expr instanceof JCTree.JCNewArray newArray) {
+            var arrayDimensions = newArray.getDimensions().stream().map(d -> toExpr(d)).toList();
+            var arrayInitializers = newArray.getInitializers();
+            if (arrayInitializers != null && arrayInitializers.size() > 0) {
+                reportError(expr, "notSupported", "new array with initializers");
+            }
+            return new AllocateArray(origin, null, null, arrayDimensions, null);
+        }
         var dafnyExpr = toExpr(expr);
         return new ExprRhs(origin, null, dafnyExpr);
     }

--- a/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
@@ -741,7 +741,7 @@ public class JavaToDafnyCompiler {
             }
         } else if (expr instanceof JCTree.JCArrayAccess arrayAccess) {
             // If subExpr is of type Array, this means we have an access to a full slice
-            // of a multidimensiobnal array, i.e. something like
+            // of a multidimensional array, i.e. something like
             // int[][] tab = new int[4][4];
             // tab[1] = new int[4];
             // This is not supported yet

--- a/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
@@ -676,9 +676,30 @@ public class JavaToDafnyCompiler {
                 return new ExprDotName(origin, toExpr(fieldAccess.selected), getName(fieldAccess, fieldAccess.name), null);
             }
         } else if (expr instanceof JCTree.JCArrayAccess arrayAccess) {
-            var arrayExpr = toExpr(arrayAccess.getExpression());
-            var indexExpr = toExpr(arrayAccess.getIndex());
-            return new SeqSelectExpr(origin, true, arrayExpr, indexExpr, null, null);
+            // If subExpr is of type Array, this means we have an access to a full slice
+            // of a multidimensiobnal array, i.e. something like
+            // int[][] tab = new int[4][4];
+            // tab[1] = new int[4];
+            // This is not supported yet
+            if (expr.type instanceof ArrayType _) {
+                reportError(expr, "Access to slices of multi-dimensions arrays not yet supported");
+                return getHole(origin);
+            }
+            var subExpr = arrayAccess.getExpression();
+            List<Expression> indexE = new ArrayList<>();
+            indexE.add(toExpr(arrayAccess.getIndex()));
+            while(subExpr instanceof JCTree.JCArrayAccess arrayAccess_) {
+                subExpr = arrayAccess_.getExpression();
+                indexE.addFirst(toExpr(arrayAccess_.getIndex()));
+            }
+
+            var arrayExpr = toExpr(subExpr);
+            if (indexE.size() > 1) {
+                return new MultiSelectExpr(origin, arrayExpr, indexE);
+            }
+            else {
+                return new SeqSelectExpr(origin, true, arrayExpr, indexE.getFirst(), null, null);
+            }
         } else if (expr instanceof JCTree.JCParens parens) {
             return toExpr(parens.getExpression());
         } else if (expr instanceof JCTree.JCAssignOp assignOp) {
@@ -964,12 +985,19 @@ public class JavaToDafnyCompiler {
             reportError(tree, "notSupported", "Primitive type kind %s".formatted(primitiveTypeKind));
             return null;
         } else if (tree instanceof JCTree.JCArrayTypeTree arrayTypeTree) {
-            var elemType = toType(arrayTypeTree.getType(), true, originOverride);
+            var elemTy = arrayTypeTree.getType();
+            int dimensions = 1;
+            while (elemTy instanceof JCTree.JCArrayTypeTree x) {
+                dimensions++;
+                elemTy = x.getType();
+            }
+            var elemType = toType(elemTy, true, originOverride);
             if (elemType == null) {
                 // should be unreachable
                 throw new IllegalArgumentException("Array type without element type");
             }
-            return new UserDefinedType(origin, new NameSegment(origin, "array" + nullableSuffix, List.of(elemType)));
+            var arrayBase = (dimensions == 1) ? "array" : "array" + dimensions;
+            return new UserDefinedType(origin, new NameSegment(origin, arrayBase + nullableSuffix, List.of(elemType)));
         } else if (tree instanceof JCTree.JCExpression expr) {
             var expression = toExpr(expr);
             

--- a/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
@@ -590,6 +590,14 @@ public class JavaToDafnyCompiler {
             var argBindings = newClass.getArguments().stream().map(a -> new ActualBinding(null, toExpr(a), false)).toList();
             return new AllocateClass(origin, null, toType(newClass.clazz), new ActualBindings(argBindings));
         }
+        if (expr instanceof JCTree.JCNewArray newArray) {
+            var arrayDimensions = newArray.getDimensions().stream().map(d -> toExpr(d)).toList();
+            var arrayInitializers = newArray.getInitializers();
+            if (arrayInitializers != null && arrayInitializers.size() > 0) {
+                reportError(expr, "notSupported", "new array with initializers");
+            }
+            return new AllocateArray(origin, null, null, arrayDimensions, null);
+        }
         var dafnyExpr = toExpr(expr);
         return new ExprRhs(origin, null, dafnyExpr);
     }

--- a/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
@@ -740,9 +740,30 @@ public class JavaToDafnyCompiler {
                 return new ExprDotName(origin, toExpr(fieldAccess.selected), getName(fieldAccess, fieldAccess.name), null);
             }
         } else if (expr instanceof JCTree.JCArrayAccess arrayAccess) {
-            var arrayExpr = toExpr(arrayAccess.getExpression());
-            var indexExpr = toExpr(arrayAccess.getIndex());
-            return new SeqSelectExpr(origin, true, arrayExpr, indexExpr, null, null);
+            // If subExpr is of type Array, this means we have an access to a full slice
+            // of a multidimensiobnal array, i.e. something like
+            // int[][] tab = new int[4][4];
+            // tab[1] = new int[4];
+            // This is not supported yet
+            if (expr.type instanceof ArrayType _) {
+                reportError(expr, "Access to slices of multi-dimensions arrays not yet supported");
+                return getHole(origin);
+            }
+            var subExpr = arrayAccess.getExpression();
+            List<Expression> indexE = new ArrayList<>();
+            indexE.add(toExpr(arrayAccess.getIndex()));
+            while(subExpr instanceof JCTree.JCArrayAccess arrayAccess_) {
+                subExpr = arrayAccess_.getExpression();
+                indexE.addFirst(toExpr(arrayAccess_.getIndex()));
+            }
+
+            var arrayExpr = toExpr(subExpr);
+            if (indexE.size() > 1) {
+                return new MultiSelectExpr(origin, arrayExpr, indexE);
+            }
+            else {
+                return new SeqSelectExpr(origin, true, arrayExpr, indexE.getFirst(), null, null);
+            }
         } else if (expr instanceof JCTree.JCParens parens) {
             return toExpr(parens.getExpression());
         } else if (expr instanceof JCTree.JCAssignOp assignOp) {
@@ -1036,12 +1057,19 @@ public class JavaToDafnyCompiler {
             reportError(tree, "notSupported", "Primitive type kind %s".formatted(primitiveTypeKind));
             return null;
         } else if (tree instanceof JCTree.JCArrayTypeTree arrayTypeTree) {
-            var elemType = toType(arrayTypeTree.getType(), true, originOverride);
+            var elemTy = arrayTypeTree.getType();
+            int dimensions = 1;
+            while (elemTy instanceof JCTree.JCArrayTypeTree x) {
+                dimensions++;
+                elemTy = x.getType();
+            }
+            var elemType = toType(elemTy, true, originOverride);
             if (elemType == null) {
                 // should be unreachable
                 throw new IllegalArgumentException("Array type without element type");
             }
-            return new UserDefinedType(origin, new NameSegment(origin, "array" + nullableSuffix, List.of(elemType)));
+            var arrayBase = (dimensions == 1) ? "array" : "array" + dimensions;
+            return new UserDefinedType(origin, new NameSegment(origin, arrayBase + nullableSuffix, List.of(elemType)));
         } else if (tree instanceof JCTree.JCExpression expr) {
             var expression = toExpr(expr);
             

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyNewArray.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyNewArray.java
@@ -1,9 +1,16 @@
+<<<<<<< HEAD
 // TEST: exitCode=0 dafnyVerified=4 dafnyErrors=0
+=======
+// TEST: exitCode=0 dafnyVerified=14 dafnyErrors=0
+>>>>>>> 2cd86d8 (support of multidim arrays)
 
 package com.aws.jverify.verifier.tests;
 
 import com.aws.jverify.Pure;
+<<<<<<< HEAD
 import com.aws.jverify.testengine.JVerifyTest;
+=======
+>>>>>>> 2cd86d8 (support of multidim arrays)
 
 import static com.aws.jverify.JVerify.*;
 
@@ -25,7 +32,10 @@ class Aux {
 
 
 @SuppressWarnings({"ConditionalBreakInInfiniteLoop", "StatementWithEmptyBody", "ConstantValue"})
+<<<<<<< HEAD
 @JVerifyTest
+=======
+>>>>>>> 2cd86d8 (support of multidim arrays)
 class VerifyNewArray {
 
     void newIntArray() {
@@ -43,11 +53,22 @@ class VerifyNewArray {
         check(arr[0] == 0);
     }
 
+<<<<<<< HEAD
     void newIntArray2() {
         int[][] arr2 = new int[5][3];
         // no support of length for multi-dimensional arrays yet
         // check(arr2.length == 5);
         // check(arr2[0].length == 3);
+=======
+
+
+
+
+    void newIntArray2() {
+        int[][] arr2 = new int[5][3];
+//        check(arr2.length == 5);
+//        check(arr2[0].length == 3);
+>>>>>>> 2cd86d8 (support of multidim arrays)
         arr2[0][0] = 0;
         for (var i = 1; i < 5; i++) {
             modifies(arr2);

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyNewArray.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyNewArray.java
@@ -45,8 +45,9 @@ class VerifyNewArray {
 
     void newIntArray2() {
         int[][] arr2 = new int[5][3];
-//        check(arr2.length == 5);
-//        check(arr2[0].length == 3);
+        // no support of length for multi-dimensional arrays yet
+        // check(arr2.length == 5);
+        // check(arr2[0].length == 3);
         arr2[0][0] = 0;
         for (var i = 1; i < 5; i++) {
             modifies(arr2);

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyNewArray.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyNewArray.java
@@ -1,0 +1,87 @@
+// TEST: exitCode=0 dafnyVerified=14 dafnyErrors=0
+
+package com.aws.jverify.verifier.tests;
+
+import com.aws.jverify.Pure;
+
+import static com.aws.jverify.JVerify.*;
+
+class Aux {
+    int a;
+    int b;
+    Aux(int a, int b) {
+        // Need a postcondition on the ctor to be able to prove better assertions in
+        // newAuxArray
+        this.a = a;
+        this.b = b;
+    }
+
+    public int getB() {
+        postcondition((Integer x) -> x == this.b);
+        return b;
+    }
+}
+
+
+@SuppressWarnings({"ConditionalBreakInInfiniteLoop", "StatementWithEmptyBody", "ConstantValue"})
+class VerifyNewArray {
+
+    void newIntArray() {
+        int[] arr = new int[5];
+        check(arr.length == 5);
+        arr[0] = 0;
+        for (var i = 1; i < 5; i++) {
+            modifies(arr);
+            invariant(arr[0] == 0);
+            int finalI = i;
+            // Crash with the invariant below
+            // invariant(forall((Integer j) -> implies(0 <= j && j < finalI, arr[j] == 0)));
+            arr[i] = i;
+        }
+        check(arr[0] == 0);
+    }
+
+
+
+
+
+    void newIntArray2() {
+        int[][] arr2 = new int[5][3];
+//        check(arr2.length == 5);
+//        check(arr2[0].length == 3);
+        arr2[0][0] = 0;
+        for (var i = 1; i < 5; i++) {
+            modifies(arr2);
+            invariant(arr2[0][0] == 0);
+            for (var j = 0; j < 3; j++) {
+                modifies(arr2);
+                invariant(arr2[0][0] == 0);
+
+                arr2[i][j] = i + j;
+            }
+        }
+        check(arr2[0][0] == 0);
+    }
+
+
+    void newAuxArray() {
+        var arr = new Aux[15];
+        check(arr.length == 15);
+        arr[0] = new Aux(0, 0);
+        int i;
+        for (i = 1; i < 15; i++) {
+            invariant(arr[0] != null);
+            modifies(arr);
+            int finalI = i;
+            // Crash with the invariant below
+            // invariant(forall((Integer j) -> implies(0<=j && j<finalI,arr[j] != null)));
+            arr[i] = new Aux(i, i + 1);
+        }
+        check(i == 15);
+    }
+
+    @Pure
+    boolean P(int x) {
+        return x > 10;
+    }
+}

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyNewArray.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyNewArray.java
@@ -1,8 +1,9 @@
-// TEST: exitCode=0 dafnyVerified=14 dafnyErrors=0
+// TEST: exitCode=0 dafnyVerified=4 dafnyErrors=0
 
 package com.aws.jverify.verifier.tests;
 
 import com.aws.jverify.Pure;
+import com.aws.jverify.testengine.JVerifyTest;
 
 import static com.aws.jverify.JVerify.*;
 
@@ -24,6 +25,7 @@ class Aux {
 
 
 @SuppressWarnings({"ConditionalBreakInInfiniteLoop", "StatementWithEmptyBody", "ConstantValue"})
+@JVerifyTest
 class VerifyNewArray {
 
     void newIntArray() {
@@ -40,10 +42,6 @@ class VerifyNewArray {
         }
         check(arr[0] == 0);
     }
-
-
-
-
 
     void newIntArray2() {
         int[][] arr2 = new int[5][3];

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyNewArray.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyNewArray.java
@@ -7,10 +7,10 @@ import com.aws.jverify.testengine.JVerifyTest;
 
 import static com.aws.jverify.JVerify.*;
 
-class Aux {
+class Point {
     int a;
     int b;
-    Aux(int a, int b) {
+    Point(int a, int b) {
         // Need a postcondition on the ctor to be able to prove better assertions in
         // newAuxArray
         this.a = a;
@@ -63,10 +63,10 @@ class VerifyNewArray {
     }
 
 
-    void newAuxArray() {
-        var arr = new Aux[15];
+    void newPointArray() {
+        var arr = new Point[15];
         check(arr.length == 15);
-        arr[0] = new Aux(0, 0);
+        arr[0] = new Point(0, 0);
         int i;
         for (i = 1; i < 15; i++) {
             invariant(arr[0] != null);
@@ -74,7 +74,7 @@ class VerifyNewArray {
             int finalI = i;
             // Crash with the invariant below
             // invariant(forall((Integer j) -> implies(0<=j && j<finalI,arr[j] != null)));
-            arr[i] = new Aux(i, i + 1);
+            arr[i] = new Point(i, i + 1);
         }
         check(i == 15);
     }

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyNewArray.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyNewArray.java
@@ -80,8 +80,4 @@ class VerifyNewArray {
         check(i == 15);
     }
 
-    @Pure
-    boolean P(int x) {
-        return x > 10;
-    }
 }

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyStatements.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyStatements.java
@@ -153,16 +153,18 @@ class VerifyStatements {
     void newIntArray() {
         int[] arr = new int[5];
         check(arr.length == 5);
-        arr[0] = 0;
-        arr[1] = arr[0]+1;
+        for (var i = 0; i < 5; i++) {
+            arr[i] = i;
+        }
         check(arr[1] == 1);
     }
 
     void newAuxArray() {
         var arr = new Aux[15];
         check(arr.length == 15);
-        arr[0] = new Aux(1,2);
-        arr[13] = new Aux(4,5);
+        for (var i = 0; i < 15; i++) {
+            arr[i] = new Aux(i, i + 1);
+        }
         var tmp = arr[13].getB();
         check(tmp > 0);
     }

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyStatements.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyStatements.java
@@ -1,4 +1,4 @@
-// TEST: exitCode=0 dafnyVerified=11 dafnyErrors=0
+// TEST: exitCode=0 dafnyVerified=12 dafnyErrors=0
 
 package com.aws.jverify.verifier.tests;
 
@@ -6,6 +6,20 @@ import com.aws.jverify.Pure;
 import com.aws.jverify.testengine.JVerifyTest;
 
 import static com.aws.jverify.JVerify.*;
+
+class Aux {
+    int a;
+    int b;
+    Aux(int a, int b) {
+        this.a = a;
+        this.b = b;
+    }
+    public int getB() {
+        postcondition((Integer x) -> x > 0);
+        return 1;
+    }
+}
+
 
 @SuppressWarnings({"ConditionalBreakInInfiniteLoop", "StatementWithEmptyBody", "ConstantValue"})
 @JVerifyTest
@@ -135,7 +149,24 @@ class VerifyStatements {
     void nativeAssert() {
         assert true;
     }
-    
+
+    void newIntArray() {
+        int[] arr = new int[5];
+        check(arr.length == 5);
+        arr[0] = 0;
+        arr[1] = arr[0]+1;
+        check(arr[1] == 1);
+    }
+
+    void newAuxArray() {
+        var arr = new Aux[15];
+        check(arr.length == 15);
+        arr[0] = new Aux(1,2);
+        arr[13] = new Aux(4,5);
+        var tmp = arr[13].getB();
+        check(tmp > 0);
+    }
+
     @Pure
     boolean P(int x) {
         return x > 10;

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyStatements.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyStatements.java
@@ -1,4 +1,4 @@
-// TEST: exitCode=0 dafnyVerified=12 dafnyErrors=0
+// TEST: exitCode=0 dafnyVerified=14 dafnyErrors=0
 
 package com.aws.jverify.verifier.tests;
 
@@ -10,12 +10,15 @@ class Aux {
     int a;
     int b;
     Aux(int a, int b) {
+        // Need a postcondition on the ctor to be able to prove better assertions in
+        // newAuxArray
         this.a = a;
         this.b = b;
     }
+
     public int getB() {
-        postcondition((Integer x) -> x > 0);
-        return 1;
+        postcondition((Integer x) -> x == this.b);
+        return b;
     }
 }
 
@@ -151,20 +154,48 @@ class VerifyStatements {
     void newIntArray() {
         int[] arr = new int[5];
         check(arr.length == 5);
-        for (var i = 0; i < 5; i++) {
+        arr[0] = 0;
+        for (var i = 1; i < 5; i++) {
+            modifies(arr);
+            invariant(arr[0] == 0);
+            int finalI = i;
+            // Crash with the invariant below
+            // invariant(forall((Integer j) -> implies(0 <= j && j < finalI, arr[j] == 0)));
             arr[i] = i;
         }
-        check(arr[1] == 1);
+        check(arr[0] == 0);
+    }
+
+    void newIntArray2() {
+        int[][] arr = new int[5][3];
+        check(arr.length == 5);
+        check(arr[0].length == 3);
+        arr[0][0] = 0;
+        for (var i = 1; i < 5; i++) {
+            modifies(arr);
+            invariant(arr[0][0] == 0);
+            for (var j = 0; j < 3; j++) {
+                modifies(arr);
+                arr[i][j] = i + j;
+            }
+        }
+        check(arr[0][0] == 0);
     }
 
     void newAuxArray() {
         var arr = new Aux[15];
         check(arr.length == 15);
-        for (var i = 0; i < 15; i++) {
+        arr[0] = new Aux(0, 0);
+        int i;
+        for (i = 1; i < 15; i++) {
+            invariant(arr[0] != null);
+            modifies(arr);
+            int finalI = i;
+            // Crash with the invariant below
+            // invariant(forall((Integer j) -> implies(0<=j && j<finalI,arr[j] != null)));
             arr[i] = new Aux(i, i + 1);
         }
-        var tmp = arr[13].getB();
-        check(tmp > 0);
+        check(i == 15);
     }
 
     @Pure

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyStatements.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyStatements.java
@@ -137,6 +137,7 @@ class VerifyStatements {
         assert true;
     }
 
+
     @Pure
     boolean P(int x) {
         return x > 10;

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyStatements.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyStatements.java
@@ -6,22 +6,6 @@ import com.aws.jverify.Pure;
 
 import static com.aws.jverify.JVerify.*;
 
-class Aux {
-    int a;
-    int b;
-    Aux(int a, int b) {
-        // Need a postcondition on the ctor to be able to prove better assertions in
-        // newAuxArray
-        this.a = a;
-        this.b = b;
-    }
-
-    public int getB() {
-        postcondition((Integer x) -> x == this.b);
-        return b;
-    }
-}
-
 
 @SuppressWarnings({"ConditionalBreakInInfiniteLoop", "StatementWithEmptyBody", "ConstantValue"})
 class VerifyStatements {
@@ -149,53 +133,6 @@ class VerifyStatements {
 
     void nativeAssert() {
         assert true;
-    }
-
-    void newIntArray() {
-        int[] arr = new int[5];
-        check(arr.length == 5);
-        arr[0] = 0;
-        for (var i = 1; i < 5; i++) {
-            modifies(arr);
-            invariant(arr[0] == 0);
-            int finalI = i;
-            // Crash with the invariant below
-            // invariant(forall((Integer j) -> implies(0 <= j && j < finalI, arr[j] == 0)));
-            arr[i] = i;
-        }
-        check(arr[0] == 0);
-    }
-
-    void newIntArray2() {
-        int[][] arr = new int[5][3];
-        check(arr.length == 5);
-        check(arr[0].length == 3);
-        arr[0][0] = 0;
-        for (var i = 1; i < 5; i++) {
-            modifies(arr);
-            invariant(arr[0][0] == 0);
-            for (var j = 0; j < 3; j++) {
-                modifies(arr);
-                arr[i][j] = i + j;
-            }
-        }
-        check(arr[0][0] == 0);
-    }
-
-    void newAuxArray() {
-        var arr = new Aux[15];
-        check(arr.length == 15);
-        arr[0] = new Aux(0, 0);
-        int i;
-        for (i = 1; i < 15; i++) {
-            invariant(arr[0] != null);
-            modifies(arr);
-            int finalI = i;
-            // Crash with the invariant below
-            // invariant(forall((Integer j) -> implies(0<=j && j<finalI,arr[j] != null)));
-            arr[i] = new Aux(i, i + 1);
-        }
-        check(i == 15);
     }
 
     @Pure

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyStatements.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyStatements.java
@@ -151,16 +151,18 @@ class VerifyStatements {
     void newIntArray() {
         int[] arr = new int[5];
         check(arr.length == 5);
-        arr[0] = 0;
-        arr[1] = arr[0]+1;
+        for (var i = 0; i < 5; i++) {
+            arr[i] = i;
+        }
         check(arr[1] == 1);
     }
 
     void newAuxArray() {
         var arr = new Aux[15];
         check(arr.length == 15);
-        arr[0] = new Aux(1,2);
-        arr[13] = new Aux(4,5);
+        for (var i = 0; i < 15; i++) {
+            arr[i] = new Aux(i, i + 1);
+        }
         var tmp = arr[13].getB();
         check(tmp > 0);
     }

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyStatements.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyStatements.java
@@ -1,4 +1,4 @@
-// TEST: exitCode=0 dafnyVerified=12 dafnyErrors=0
+// TEST: exitCode=0 dafnyVerified=14 dafnyErrors=0
 
 package com.aws.jverify.verifier.tests;
 
@@ -11,12 +11,15 @@ class Aux {
     int a;
     int b;
     Aux(int a, int b) {
+        // Need a postcondition on the ctor to be able to prove better assertions in
+        // newAuxArray
         this.a = a;
         this.b = b;
     }
+
     public int getB() {
-        postcondition((Integer x) -> x > 0);
-        return 1;
+        postcondition((Integer x) -> x == this.b);
+        return b;
     }
 }
 
@@ -153,20 +156,48 @@ class VerifyStatements {
     void newIntArray() {
         int[] arr = new int[5];
         check(arr.length == 5);
-        for (var i = 0; i < 5; i++) {
+        arr[0] = 0;
+        for (var i = 1; i < 5; i++) {
+            modifies(arr);
+            invariant(arr[0] == 0);
+            int finalI = i;
+            // Crash with the invariant below
+            // invariant(forall((Integer j) -> implies(0 <= j && j < finalI, arr[j] == 0)));
             arr[i] = i;
         }
-        check(arr[1] == 1);
+        check(arr[0] == 0);
+    }
+
+    void newIntArray2() {
+        int[][] arr = new int[5][3];
+        check(arr.length == 5);
+        check(arr[0].length == 3);
+        arr[0][0] = 0;
+        for (var i = 1; i < 5; i++) {
+            modifies(arr);
+            invariant(arr[0][0] == 0);
+            for (var j = 0; j < 3; j++) {
+                modifies(arr);
+                arr[i][j] = i + j;
+            }
+        }
+        check(arr[0][0] == 0);
     }
 
     void newAuxArray() {
         var arr = new Aux[15];
         check(arr.length == 15);
-        for (var i = 0; i < 15; i++) {
+        arr[0] = new Aux(0, 0);
+        int i;
+        for (i = 1; i < 15; i++) {
+            invariant(arr[0] != null);
+            modifies(arr);
+            int finalI = i;
+            // Crash with the invariant below
+            // invariant(forall((Integer j) -> implies(0<=j && j<finalI,arr[j] != null)));
             arr[i] = new Aux(i, i + 1);
         }
-        var tmp = arr[13].getB();
-        check(tmp > 0);
+        check(i == 15);
     }
 
     @Pure

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyStatements.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyStatements.java
@@ -137,7 +137,6 @@ class VerifyStatements {
         assert true;
     }
 
-
     @Pure
     boolean P(int x) {
         return x > 10;

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyStatements.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyStatements.java
@@ -7,7 +7,6 @@ import com.aws.jverify.testengine.JVerifyTest;
 
 import static com.aws.jverify.JVerify.*;
 
-
 @SuppressWarnings({"ConditionalBreakInInfiniteLoop", "StatementWithEmptyBody", "ConstantValue"})
 @JVerifyTest
 class VerifyStatements {

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyStatements.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyStatements.java
@@ -7,25 +7,6 @@ import com.aws.jverify.testengine.JVerifyTest;
 
 import static com.aws.jverify.JVerify.*;
 
-<<<<<<< HEAD
-=======
-class Aux {
-    int a;
-    int b;
-    Aux(int a, int b) {
-        // Need a postcondition on the ctor to be able to prove better assertions in
-        // newAuxArray
-        this.a = a;
-        this.b = b;
-    }
-
-    public int getB() {
-        postcondition((Integer x) -> x == this.b);
-        return b;
-    }
-}
-
->>>>>>> 206f144 (Improved testing)
 
 @SuppressWarnings({"ConditionalBreakInInfiniteLoop", "StatementWithEmptyBody", "ConstantValue"})
 @JVerifyTest

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyStatements.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyStatements.java
@@ -7,22 +7,6 @@ import com.aws.jverify.testengine.JVerifyTest;
 
 import static com.aws.jverify.JVerify.*;
 
-class Aux {
-    int a;
-    int b;
-    Aux(int a, int b) {
-        // Need a postcondition on the ctor to be able to prove better assertions in
-        // newAuxArray
-        this.a = a;
-        this.b = b;
-    }
-
-    public int getB() {
-        postcondition((Integer x) -> x == this.b);
-        return b;
-    }
-}
-
 
 @SuppressWarnings({"ConditionalBreakInInfiniteLoop", "StatementWithEmptyBody", "ConstantValue"})
 @JVerifyTest
@@ -151,53 +135,6 @@ class VerifyStatements {
 
     void nativeAssert() {
         assert true;
-    }
-
-    void newIntArray() {
-        int[] arr = new int[5];
-        check(arr.length == 5);
-        arr[0] = 0;
-        for (var i = 1; i < 5; i++) {
-            modifies(arr);
-            invariant(arr[0] == 0);
-            int finalI = i;
-            // Crash with the invariant below
-            // invariant(forall((Integer j) -> implies(0 <= j && j < finalI, arr[j] == 0)));
-            arr[i] = i;
-        }
-        check(arr[0] == 0);
-    }
-
-    void newIntArray2() {
-        int[][] arr = new int[5][3];
-        check(arr.length == 5);
-        check(arr[0].length == 3);
-        arr[0][0] = 0;
-        for (var i = 1; i < 5; i++) {
-            modifies(arr);
-            invariant(arr[0][0] == 0);
-            for (var j = 0; j < 3; j++) {
-                modifies(arr);
-                arr[i][j] = i + j;
-            }
-        }
-        check(arr[0][0] == 0);
-    }
-
-    void newAuxArray() {
-        var arr = new Aux[15];
-        check(arr.length == 15);
-        arr[0] = new Aux(0, 0);
-        int i;
-        for (i = 1; i < 15; i++) {
-            invariant(arr[0] != null);
-            modifies(arr);
-            int finalI = i;
-            // Crash with the invariant below
-            // invariant(forall((Integer j) -> implies(0<=j && j<finalI,arr[j] != null)));
-            arr[i] = new Aux(i, i + 1);
-        }
-        check(i == 15);
     }
 
     @Pure

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyStatements.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyStatements.java
@@ -1,10 +1,24 @@
-// TEST: exitCode=0 dafnyVerified=11 dafnyErrors=0
+// TEST: exitCode=0 dafnyVerified=12 dafnyErrors=0
 
 package com.aws.jverify.verifier.tests;
 
 import com.aws.jverify.Pure;
 
 import static com.aws.jverify.JVerify.*;
+
+class Aux {
+    int a;
+    int b;
+    Aux(int a, int b) {
+        this.a = a;
+        this.b = b;
+    }
+    public int getB() {
+        postcondition((Integer x) -> x > 0);
+        return 1;
+    }
+}
+
 
 @SuppressWarnings({"ConditionalBreakInInfiniteLoop", "StatementWithEmptyBody", "ConstantValue"})
 class VerifyStatements {
@@ -133,7 +147,24 @@ class VerifyStatements {
     void nativeAssert() {
         assert true;
     }
-    
+
+    void newIntArray() {
+        int[] arr = new int[5];
+        check(arr.length == 5);
+        arr[0] = 0;
+        arr[1] = arr[0]+1;
+        check(arr[1] == 1);
+    }
+
+    void newAuxArray() {
+        var arr = new Aux[15];
+        check(arr.length == 15);
+        arr[0] = new Aux(1,2);
+        arr[13] = new Aux(4,5);
+        var tmp = arr[13].getB();
+        check(tmp > 0);
+    }
+
     @Pure
     boolean P(int x) {
         return x > 10;

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyStatements.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyStatements.java
@@ -7,6 +7,25 @@ import com.aws.jverify.testengine.JVerifyTest;
 
 import static com.aws.jverify.JVerify.*;
 
+<<<<<<< HEAD
+=======
+class Aux {
+    int a;
+    int b;
+    Aux(int a, int b) {
+        // Need a postcondition on the ctor to be able to prove better assertions in
+        // newAuxArray
+        this.a = a;
+        this.b = b;
+    }
+
+    public int getB() {
+        postcondition((Integer x) -> x == this.b);
+        return b;
+    }
+}
+
+>>>>>>> 206f144 (Improved testing)
 
 @SuppressWarnings({"ConditionalBreakInInfiniteLoop", "StatementWithEmptyBody", "ConstantValue"})
 @JVerifyTest

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyStatements.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyStatements.java
@@ -1,4 +1,4 @@
-// TEST: exitCode=0 dafnyVerified=14 dafnyErrors=0
+// TEST: exitCode=0 dafnyVerified=11 dafnyErrors=0
 
 package com.aws.jverify.verifier.tests;
 


### PR DESCRIPTION
### What was changed?
Adds support for allocating new arrays in Java.
Adds support for multi-dimensional array declaration and access.

Not yet supported:
* Access to sub-arrays in multidimensional arrays
```
int[][] tab = new int[4][4];
tab[1] = new int[4];
```
* Allocation of a new array with an initializer
```
int[] myArray = new int[]{1, 2, 3};
```

### How has this been tested?
Added a test (VerifyNewArray.java)

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/aws/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
