### PR TITLE
Fix: resolution error when two for-loops in the same scope use same index name 

### DIFF
--- a/verifier/src/main/java/com/aws/jverify/verifier/MethodCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/MethodCompiler.java
@@ -171,7 +171,9 @@ public class MethodCompiler {
         var result = new ArrayList<Statement>(initializer.size() + 1);
         result.addAll(initializer);
         result.add(loop);
-        return result;
+        // Pack the statements in a block to ensure the loop index variable is
+        // scoped
+        return List.of(new BlockStmt(origin, null, List.of(), result));
     }
 
     private List<Statement> translateDoWhileLoop(JCTree.JCDoWhileLoop doWhileLoop, List<Label> labels) {

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyStatements.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/VerifyStatements.java
@@ -1,4 +1,4 @@
-// TEST: exitCode=0 dafnyVerified=11 dafnyErrors=0
+// TEST: exitCode=0 dafnyVerified=12 dafnyErrors=0
 
 package com.aws.jverify.verifier.tests;
 
@@ -125,6 +125,20 @@ class VerifyStatements {
             x = x + 1;
         } while(x < 5);
         check(x == 5);
+    }
+
+    void twoForLoops() {
+        int cnt = 0;
+        for (var i = 0; i < 10; i++) {
+            invariant(cnt==i);
+            cnt++;
+        }
+        check(cnt==10);
+        for (var i = 0; i < 10; i++) {
+            invariant(cnt-10==i);
+            cnt++;
+        }
+        check(cnt==20);
     }
     
     void skip() {


### PR DESCRIPTION
### What was changed?
This fixes a bug in JVerify to Dafny translation that would cause a resolution error when two for-loops in the same scope use the same name for their index. For example:
```
   for (var i=0; i<10; i++) {...}
   for (var i=0; i<10; i++) {...}
```

This fails with current JVerify version.

### How has this been tested?
Added a test case in VerifyStatements.java

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/aws/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
