### PR TITLE
Support of array allocation for single dimension arrays

### DIFF
--- a/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
@@ -678,6 +678,20 @@ public class JavaToDafnyCompiler {
             var argBindings = newClass.getArguments().stream().map(a -> new ActualBinding(null, toExpr(a), false)).toList();
             return new AllocateClass(origin, null, toType(newClass.clazz), new ActualBindings(argBindings));
         }
+        if (expr instanceof JCTree.JCNewArray newArray) {
+            var arrayDimensions = newArray.getDimensions().stream().map(d -> toExpr(d)).toList();
+            var arrayInitializers = newArray.getInitializers();
+            var arrayJavaType = newArray.getType();
+            if (arrayJavaType instanceof JCTree.JCArrayTypeTree _) {
+                reportError(expr, "notSupported", "multi-dimensional arrays");
+            }
+            var arrayDafnyType = toType(arrayJavaType, true);
+
+            if (arrayInitializers != null && !arrayInitializers.isEmpty()) {
+                reportError(expr, "notSupported", "new array with initializers");
+            }
+            return new AllocateArray(origin, null, arrayDafnyType, arrayDimensions, null);
+        }
         var dafnyExpr = toExpr(expr);
         return new ExprRhs(origin, null, dafnyExpr);
     }
@@ -1055,7 +1069,7 @@ public class JavaToDafnyCompiler {
             reportError(tree, "notSupported", "Primitive type kind %s".formatted(primitiveTypeKind));
             return null;
         } else if (tree instanceof JCTree.JCArrayTypeTree arrayTypeTree) {
-            var elemType = toType(arrayTypeTree.getType(), false, originOverride);
+            var elemType = toType(arrayTypeTree.getType(), true, originOverride);
             if (elemType == null) {
                 // should be unreachable
                 throw new IllegalArgumentException("Array type without element type");

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/Arrays.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/Arrays.java
@@ -1,0 +1,72 @@
+// TEST: exitCode=4 dafnyVerified=1 dafnyErrors=1
+
+package com.aws.jverify.verifier.tests;
+
+//import com.aws.jverify.testengine.JVerifyTest;
+
+import com.aws.jverify.*;
+import static com.aws.jverify.JVerify.*;
+
+class Point {
+    private int a;
+    private int b;
+
+    public Point(int a_, int b_) {
+        postcondition(this.a == a_);
+        postcondition(this.b == b_);
+        this.a = a_;
+        this.b = b_;
+    }
+
+    @Pure
+    public int getA() {
+        reads(this);
+        return a;
+    }
+}
+
+// Class that test the support of array allocation and accesses
+//@JVerifyTest
+class Arrays {
+
+    static void intArrayOfSize10() {
+        int[] a = new int[10];
+        a[0]=0;
+        for (int i = 0; i < a.length; i++) {
+            modifies(a);
+            invariant(a[0]==0);
+            a[i] = i;
+        }
+        check(a[0]==0);
+    }
+    static void pointArrayOfSize10() {
+        Point[] a = new Point[10];
+        a[0]=new Point(1,2);
+        for (int i = 1; i < a.length; i++) {
+            modifies(a);
+            // We want a better invariant like
+            // invariant(Forall((Integeer j) -> Implies(0<=j && j<i,a[i]!=null && a[i].getA()==i)));
+            // This does not work now as we cannot pass a non final variable in a lambda
+            invariant(a[0] != null);
+            invariant(a[0].getA()==1);
+            a[i] = new Point(i,i+1);
+        }
+        check(a[0] != null);
+        check(a[0].getA()==1);
+    }
+
+    static void intArrayOfSizeN(int n) {
+        precondition(n>0);
+        int[] a = new int[n];
+        a[0]=0;
+        int i = 0;
+        for (i = 0; i < a.length; i++) {
+            invariant(a[0]==0);
+            modifies(a);
+            a[i] = i;
+        }
+        check(a[0]==0);
+        check(i==n);
+//            ^^^^ Error: assertion might not hold
+    }
+}

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/Arrays.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/Arrays.java
@@ -1,8 +1,8 @@
-// TEST: exitCode=4 dafnyVerified=1 dafnyErrors=1
+// TEST: exitCode=4 dafnyVerified=4 dafnyErrors=1
 
 package com.aws.jverify.verifier.tests;
 
-//import com.aws.jverify.testengine.JVerifyTest;
+import com.aws.jverify.testengine.JVerifyTest;
 
 import com.aws.jverify.*;
 import static com.aws.jverify.JVerify.*;
@@ -26,7 +26,7 @@ class Point {
 }
 
 // Class that test the support of array allocation and accesses
-//@JVerifyTest
+@JVerifyTest
 class Arrays {
 
     static void intArrayOfSize10() {

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/Arrays.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/Arrays.java
@@ -67,6 +67,6 @@ class Arrays {
         }
         check(a[0]==0);
         check(i==n);
-//            ^^^^ Error: assertion might not hold
+//      ^^^^^^^^^^^ Error: assertion might not hold
     }
 }


### PR DESCRIPTION
### What was changed?
Translate JCNewArray into AllocateArray for single dimension arrays

### How has this been tested?
Added test (Arrays.java)
On set of JML tests, makes 12 more tests pass 

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/aws/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
