### PR TITLE
Allow new in return statement

### DIFF
--- a/verifier/src/main/java/com/aws/jverify/verifier/MethodCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/MethodCompiler.java
@@ -131,8 +131,22 @@ public class MethodCompiler {
         if (expr == null) {
             return List.of(new ReturnStmt(origin, null, null));
         } else {
-            return List.of(new ReturnStmt(origin, null,
-                    List.of(new ExprRhs(compiler.toOrigin(expr), null, compiler.toExpr(expr)))));
+            // Replace
+            //   return e;
+            // by
+            //   var tmp := e;
+            //   return tmp;
+            // so that we can have allocation in e.
+            var exprOrigin = compiler.toOrigin(expr);
+            var returnExpr = compiler.toAssignmentRhs(expr);
+            var newLocalVarName = getTmpVariableName();
+            var newLocalVar = new LocalVariable(exprOrigin,
+                    newLocalVarName, null, false);
+            var newLocalVarExpr = new NameSegment(exprOrigin, newLocalVarName, null);
+            var varDeclStmt = new VarDeclStmt(exprOrigin, null, List.of(newLocalVar), null);
+            var assignment = new AssignStatement(exprOrigin, null, List.of(newLocalVarExpr), List.of(returnExpr), false);
+            var returnStmt = new ReturnStmt(origin, null, List.of(new ExprRhs(exprOrigin, null,newLocalVarExpr)));
+            return List.of(varDeclStmt, assignment,returnStmt);
         }
     }
 
@@ -227,6 +241,9 @@ public class MethodCompiler {
 
     private String getForLoopContinueLabel(JCTree.JCForLoop forLoop) {
         return forLoopContinueLabels.computeIfAbsent(forLoop, _ -> "$loop" + generatedIndex++);
+    }
+    private String getTmpVariableName() {
+        return "#_tmpVar_"+(generatedIndex++);
     }
 
     private List<Statement> translateExpressionStatement(JCTree.JCExpressionStatement statement) {
@@ -469,7 +486,7 @@ public class MethodCompiler {
                 : new BlockStmt(origin, null, List.of(), statements);
     }
 
-    private String getName(String prefix) {
-        return "$" + prefix + generatedIndex++;
-    }
+  //  private String getName(String prefix) {
+  //      return "$" + prefix + generatedIndex++;
+  //  }
 }

--- a/verifier/src/main/java/com/aws/jverify/verifier/MethodCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/MethodCompiler.java
@@ -486,7 +486,4 @@ public class MethodCompiler {
                 : new BlockStmt(origin, null, List.of(), statements);
     }
 
-  //  private String getName(String prefix) {
-  //      return "$" + prefix + generatedIndex++;
-  //  }
 }

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/Allocate.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/Allocate.java
@@ -1,0 +1,42 @@
+// TEST: exitCode=4 dafnyVerified=4 dafnyErrors=1
+
+package com.aws.jverify.verifier.tests;
+
+import com.aws.jverify.testengine.JVerifyTest;
+
+import com.aws.jverify.*;
+import static com.aws.jverify.JVerify.*;
+
+class Point {
+    private int a;
+    private int b;
+
+    public Point(int a_, int b_) {
+        postcondition(this.a == a_);
+        postcondition(this.b == b_);
+        this.a = a_;
+        this.b = b_;
+    }
+
+    @Pure
+    public int getA() {
+        reads(this);
+        return a;
+    }
+}
+
+// Class that test the support of array allocation and accesses
+@JVerifyTest
+class Allocate {
+
+    public static Point allocateInReturn(int a, int b) {
+        postcondition((Point p) -> fresh(p) &&  p.getA() == a);
+        return new Point(a, b);
+    }
+
+    public static void test(int a) {
+        Point p = allocateInReturn(a,2);
+        check(p.getA() == a);
+    }
+
+}

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/Allocate.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/Allocate.java
@@ -1,4 +1,4 @@
-// TEST: exitCode=4 dafnyVerified=4 dafnyErrors=1
+// TEST: exitCode=4 dafnyVerified=5 dafnyErrors=0
 
 package com.aws.jverify.verifier.tests;
 

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/Allocate.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/Allocate.java
@@ -7,11 +7,11 @@ import com.aws.jverify.testengine.JVerifyTest;
 import com.aws.jverify.*;
 import static com.aws.jverify.JVerify.*;
 
-class Point {
+class IntPair {
     private int a;
     private int b;
 
-    public Point(int a_, int b_) {
+    public IntPair(int a_, int b_) {
         postcondition(this.a == a_);
         postcondition(this.b == b_);
         this.a = a_;
@@ -29,13 +29,13 @@ class Point {
 @JVerifyTest
 class Allocate {
 
-    public static Point allocateInReturn(int a, int b) {
-        postcondition((Point p) -> fresh(p) &&  p.getA() == a);
-        return new Point(a, b);
+    public static IntPair allocateInReturn(int a, int b) {
+        postcondition((IntPair p) -> fresh(p) &&  p.getA() == a);
+        return new IntPair(a, b);
     }
 
     public static void test(int a) {
-        Point p = allocateInReturn(a,2);
+        IntPair p = allocateInReturn(a,2);
         check(p.getA() == a);
     }
 

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/Allocate.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/Allocate.java
@@ -1,4 +1,4 @@
-// TEST: exitCode=4 dafnyVerified=5 dafnyErrors=0
+// TEST: exitCode=0 dafnyVerified=5 dafnyErrors=0
 
 package com.aws.jverify.verifier.tests;
 

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/Arrays.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/Arrays.java
@@ -41,7 +41,7 @@ class Arrays {
     }
     static void pointArrayOfSize10() {
         Point[] a = new Point[10];
-        a[0]=new IntPair(1,2);
+        a[0]=new Point(1,2);
         for (int i = 1; i < a.length; i++) {
             modifies(a);
             // We want a better invariant like

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/Arrays.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/Arrays.java
@@ -40,7 +40,7 @@ class Arrays {
         check(a[0]==0);
     }
     static void pointArrayOfSize10() {
-        IntPair[] a = new IntPair[10];
+        Point[] a = new Point[10];
         a[0]=new IntPair(1,2);
         for (int i = 1; i < a.length; i++) {
             modifies(a);
@@ -49,7 +49,7 @@ class Arrays {
             // This does not work now as we cannot pass a non final variable in a lambda
             invariant(a[0] != null);
             invariant(a[0].getA()==1);
-            a[i] = new IntPair(i,i+1);
+            a[i] = new Point(i,i+1);
         }
         check(a[0] != null);
         check(a[0].getA()==1);

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/Arrays.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/Arrays.java
@@ -40,8 +40,8 @@ class Arrays {
         check(a[0]==0);
     }
     static void pointArrayOfSize10() {
-        Point[] a = new Point[10];
-        a[0]=new Point(1,2);
+        IntPair[] a = new IntPair[10];
+        a[0]=new IntPair(1,2);
         for (int i = 1; i < a.length; i++) {
             modifies(a);
             // We want a better invariant like
@@ -49,7 +49,7 @@ class Arrays {
             // This does not work now as we cannot pass a non final variable in a lambda
             invariant(a[0] != null);
             invariant(a[0].getA()==1);
-            a[i] = new Point(i,i+1);
+            a[i] = new IntPair(i,i+1);
         }
         check(a[0] != null);
         check(a[0].getA()==1);


### PR DESCRIPTION
### What was changed?
Adds support for `return new Foo();` by transforming it into three `var tmp := new Foo(); return tmp` 

### How has this been tested?
Added a test (Allocate.java)

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/aws/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
