### PR TITLE
feat: translate switch statements

### DIFF
--- a/test-engine/src/main/java/com/aws/jverify/testengine/JVerifyTestEngine.java
+++ b/test-engine/src/main/java/com/aws/jverify/testengine/JVerifyTestEngine.java
@@ -167,9 +167,17 @@ public class JVerifyTestEngine extends HierarchicalTestEngine<EngineExecutionCon
         var expectedAnnotations = parsedMarkup.ranges().stream().sorted().toList();
         assertThat("diagnostics", diagnosticsAsAnnotations, equalTo(expectedAnnotations));
 
-        assertThat("exit code", verificationResults.getExitCode(), is(metadata.exitCode));
-        assertThat("Dafny verified count", verificationResults.getDafnyVerifiedCount(), is(metadata.dafnyVerified));
-        assertThat("Dafny error count", verificationResults.getDafnyErrorCount(), is(metadata.dafnyErrors));
+        Assertions.assertAll(
+                () -> assertThat("exit code",
+                        verificationResults.getExitCode(),
+                        is(metadata.exitCode)),
+                () -> assertThat("Dafny verified count",
+                        verificationResults.getDafnyVerifiedCount(),
+                        is(metadata.dafnyVerified)),
+                () -> assertThat("Dafny error count",
+                        verificationResults.getDafnyErrorCount(),
+                        is(metadata.dafnyErrors))
+        );
     }
 
     private static final Pattern TEST_METADATA_PATTERN = Pattern.compile("^// TEST: (.+)$", Pattern.MULTILINE);

--- a/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
@@ -667,7 +667,7 @@ public class JavaToDafnyCompiler {
         return getHole(toOrigin(tree));
     }
 
-    private static LiteralExpr getHole(IOrigin origin) {
+    static LiteralExpr getHole(IOrigin origin) {
         // TODO should be a typeless 'hole' expression, but Dafny does not have that.
         return new LiteralExpr(origin, true);
     }
@@ -704,7 +704,7 @@ public class JavaToDafnyCompiler {
             var elseBranch = toExpr(conditional.getFalseExpression());
             return new ITEExpr(origin, false, condition, thenBranch, elseBranch);
         } else if (expr instanceof JCTree.JCSwitchExpression switchExpr) {
-            return toExpr(switchExpr);
+            return translateSwitchExpression(switchExpr);
         } else if (expr instanceof JCTree.JCUnary unary) {
             var innerExpr = toExpr(unary.getExpression());
             switch(unary.getTag()) {
@@ -931,72 +931,112 @@ public class JavaToDafnyCompiler {
         };
     }
 
-    private Expression toExpr(JCTree.JCSwitchExpression switchExpr) {
+    private Expression translateSwitchExpression(JCTree.JCSwitchExpression switchExpr) {
         var origin = toOrigin(switchExpr);
+        var patternBodies = translateSwitchLabels(switchExpr);
+        if (patternBodies == null) {
+            return getHole(origin);
+        }
+
+        var translatedCases = patternBodies.stream().map(patternBody -> {
+            var caseOrigin = toOrigin(patternBody.cas());
+            var body = patternBody.body();
+            final Expression translatedBody;
+
+            // A switch rule introduces either an expression, a block, or a throw statement.
+            if (body instanceof JCTree.JCExpression) {
+                translatedBody = toExpr(body);
+            } else {
+                var bodyKind = body instanceof JCTree.JCBlock ? "block" : "throw statement";
+                reportError(body, "notSupported", "switch rule %s".formatted(bodyKind));
+                translatedBody = getHole(caseOrigin);
+            }
+            return new NestedMatchCaseExpr(caseOrigin, patternBody.pattern(), translatedBody, null);
+        }).toList();
+
+        var source = toExpr(switchExpr.getExpression());
+        return new NestedMatchExpr(origin, source, translatedCases, true, null);
+    }
+
+    record SwitchLabelPatternAndBody(JCTree.JCCase cas, ExtendedPattern pattern, JCTree body) {}
+
+    /**
+     * Translates the switch labels of the given {@code switch} statement or expression
+     * into the corresponding {@link ExtendedPattern}s,
+     * and returns the patterns along with their corresponding (untranslated) bodies.
+     * Returns {@code null} if an unrecoverable error is reported,
+     * such as if the input tree uses unsupported features.
+     */
+    @Nullable List<SwitchLabelPatternAndBody> translateSwitchLabels(JCTree switchTree) {
+        // JCTree is the first common superclass of JCSwitch and JCSwitchExpression,
+        // so we settle for dynamically checking that the argument is one of them.
+        var cases = switch (switchTree) {
+            case JCTree.JCSwitch switchStmt -> switchStmt.getCases();
+            case JCTree.JCSwitchExpression switchExpr -> switchExpr.getCases();
+            default -> throw new IllegalArgumentException(
+                    "Expected switch statement or expression but got " + switchTree.getClass());
+        };
 
         // A switch block consists of either *switch rules* (label -> body)
         // or *switch labeled statement groups* (label: {label:} stmts).
         // Unlike switch rules, switch labeled statement groups automatically "fall through" without break statements,
         // but Dafny's match statement/expression can't express that easily.
         // So for now we only support switch blocks using switch rules.
-        if (switchExpr.getCases().getFirst().getCaseKind().equals(JCTree.JCCase.STATEMENT)) {
-            reportError(switchExpr, "notSupported", "switch labeled statement group");
-            return getHole(origin);
+        if (cases.getFirst().getCaseKind().equals(JCTree.JCCase.STATEMENT)) {
+            reportError(switchTree, "notSupported", "switch labeled statement group");
+            return null;
         }
 
+        return cases.stream()
+                .map(cas -> new SwitchLabelPatternAndBody(cas, translateSwitchLabel(cas), cas.getBody()))
+                .toList();
+    }
+
+    /**
+     * Translates the given switch label into a pattern.
+     */
+    private ExtendedPattern translateSwitchLabel(JCTree.JCCase cas) {
         // Each case has a *switch label*, which is either a *default label* or a *case label*.
         // A *case label* consists of either:
         //  - a list of *case constants*
         //  - a null literal (which the javac AST treats like another case constant)
         //  - a *case pattern* (not supported)
-        var translatedCases = new ArrayList<NestedMatchCaseExpr>();
-        for (var cas : switchExpr.getCases()) {
-            // note: if the case label is a null literal, this is the singleton list of the null literal
-            var caseConstants = cas.getExpressions();
-            var defaultLabel = cas.getLabels().stream()
-                    .filter(label -> label instanceof JCTree.JCDefaultCaseLabel)
-                    .findFirst();
 
-            final ExtendedPattern translatedPattern;
-            if (caseConstants.nonEmpty()) {
-                var literals = caseConstants.stream().map(labelExpr -> {
-                    var labelOrigin = toOrigin(labelExpr);
-                    final LiteralExpr litExpr;
-                    if (labelExpr instanceof JCTree.JCLiteral) {
-                        litExpr = (LiteralExpr)toExpr(labelExpr);
-                    } else {
-                        reportError(labelExpr, "notSupported", "non-literal case constant");
-                        litExpr = getHole(labelOrigin);
-                    }
-                    return (ExtendedPattern) new LitPattern(labelOrigin, false, litExpr);
-                }).toList();
-                translatedPattern = new DisjunctivePattern(toOrigin(cas), false, literals);
-            } else if (defaultLabel.isPresent()) {
-                var labelOrigin = toOrigin(defaultLabel.get());
-                translatedPattern = new IdPattern(labelOrigin, false, "_", null, null, false);
-            } else {
-                reportError(cas, "notSupported", "case pattern");
-                translatedPattern = null;
-            }
+        // note: if the case label is a null literal, this is the singleton list of the null literal
+        var caseConstants = cas.getExpressions();
+        var defaultLabel = cas.getLabels().stream()
+                .filter(label -> label instanceof JCTree.JCDefaultCaseLabel)
+                .findFirst();
 
-            final Expression translatedBody;
-            if (cas.getBody() instanceof JCTree.JCExpression) {
-                translatedBody = toExpr(cas.getBody());
-            } else {
-                var bodyKind = cas.getBody() instanceof JCTree.JCBlock ? "block" : "throw statement";
-                reportError(cas, "notSupported", "switch rule %s".formatted(bodyKind));
-                translatedBody = null;
-            }
-
-            if (translatedPattern == null || translatedBody == null) {
-                return getHole(origin);
-            } else {
-                translatedCases.add(new NestedMatchCaseExpr(toOrigin(cas), translatedPattern, translatedBody, null));
-            }
+        if (caseConstants.nonEmpty()) {
+            var literals = caseConstants.stream().map(this::translateCaseConstant).toList();
+            return new DisjunctivePattern(toOrigin(cas), false, literals);
+        } else if (defaultLabel.isPresent()) {
+            return makeWildPattern(toOrigin(defaultLabel.get()));
+        } else {
+            reportError(cas, "notSupported", "case pattern");
+            // Return something sensible
+            return makeWildPattern(toOrigin(cas));
         }
+    }
 
-        var source = toExpr(switchExpr.getExpression());
-        return new NestedMatchExpr(origin, source, translatedCases, true, null);
+    /**
+     * Translates the given switch label case constant into a pattern.
+     */
+    private ExtendedPattern translateCaseConstant(JCTree.JCExpression expr) {
+        var origin = toOrigin(expr);
+        final LiteralExpr litExpr;
+        if (expr instanceof JCTree.JCLiteral) {
+            litExpr = (LiteralExpr)toExpr(expr);
+        } else {
+            reportError(expr, "notSupported", "non-literal case constant");
+            litExpr = getHole(origin);
+        }
+        return new LitPattern(origin, false, litExpr);
+    }
+
+    static IdPattern makeWildPattern(IOrigin origin) {
+        return new IdPattern(origin, false, "_", null, null, false);
     }
 
     private @Nullable Type toType(JCTree tree) {

--- a/verifier/src/main/java/com/aws/jverify/verifier/MethodCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/MethodCompiler.java
@@ -7,6 +7,7 @@ import com.sun.tools.javac.code.TypeTag;
 import com.sun.tools.javac.tree.JCTree;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class MethodCompiler {
 
@@ -68,6 +69,9 @@ public class MethodCompiler {
             }
             case JCTree.JCBreak jcBreak -> {
                 return translateBreak(jcBreak);
+            }
+            case JCTree.JCSwitch jcSwitch -> {
+                return translateSwitchStatement(jcSwitch);
             }
             case JCTree.JCSkip _ -> {
                 return List.of();
@@ -349,6 +353,43 @@ public class MethodCompiler {
                 new ActualBindings(argBindings), null);
         return List.of(new AssignStatement(origin, null, List.of(),
                 List.of(new ExprRhs(applySuffix.getOrigin(), null, applySuffix)), false));
+    }
+
+    public List<Statement> translateSwitchStatement(JCTree.JCSwitch switchStmt) {
+        var origin = compiler.toOrigin(switchStmt);
+        var patternBodies = compiler.translateSwitchLabels(switchStmt);
+        if (patternBodies == null) {
+            return List.of();
+        }
+
+        var translatedCases = patternBodies.stream().map(patternBody -> {
+            var caseOrigin = compiler.toOrigin(patternBody.cas());
+            var body = patternBody.body();
+
+            // A switch rule introduces either an expression, a block, or a throw statement.
+            // Within a switch statement, a switch rule expression must be a statement expression.
+            List<Statement> translatedBody = switch (body) {
+                case JCTree.JCExpressionStatement bodyStatement -> translateStatement(bodyStatement);
+                case JCTree.JCBlock bodyBlock -> translateStatement(bodyBlock);
+                case JCTree.JCThrow ignored -> {
+                    compiler.reportError(body, "notSupported", "switch rule throw");
+                    yield List.of();
+                }
+                default -> throw new JavaViolationException();
+            };
+            return new NestedMatchCaseStmt(caseOrigin, patternBody.pattern(), translatedBody, null);
+        }).collect(Collectors.toCollection(ArrayList::new));
+
+        // The switch statement may not be exhaustive, but a Dafny match statement must be,
+        // so we add a catch-all no-op case to ensure the translated match is exhaustive.
+        // (It would be safe to add this case unconditionally, but Dafny would warn that the case is redundant.)
+        if (!switchStmt.isExhaustive) {
+            translatedCases.add(new NestedMatchCaseStmt(
+                    origin, JavaToDafnyCompiler.makeWildPattern(origin), List.of(), null));
+        }
+
+        var source = compiler.toExpr(switchStmt.getExpression());
+        return List.of(new NestedMatchStmt(origin, null, source, translatedCases, true));
     }
 
     public <T extends JCTree.JCStatement> List<Statement> translateStatements(List<T> statements) {

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/Switches.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/Switches.java
@@ -1,4 +1,4 @@
-// TEST: exitCode=4 dafnyVerified=3 dafnyErrors=3
+// TEST: exitCode=4 dafnyVerified=6 dafnyErrors=4
 
 package com.aws.jverify.verifier.tests;
 
@@ -27,6 +27,29 @@ class Switches {
             case 3 -> 30;
             default -> 40;
         };
+        check(num % 20 == 0);
+//      ^^^^^^^^^^^^^^^^^^^^ Error: assertion might not hold
+    }
+
+    static void switchStmtInt(int i) {
+        var num = -1;
+        switch (i) {
+            case 0 -> num = 10;
+            case 1, 2 -> num = 20;
+            case 3 -> num = 30;
+            default -> num = 40;
+        }
+        check(num % 10 == 0);
+    }
+
+    static void switchStmtIntBad(int i) {
+        var num = -1;
+        switch (i) {
+            case 0 -> num = 10;
+            case 1, 2 -> num = 20;
+            case 3 -> num = 30;
+            default -> num = 40;
+        }
         check(num % 20 == 0);
 //      ^^^^^^^^^^^^^^^^^^^^ Error: assertion might not hold
     }
@@ -69,5 +92,34 @@ class Switches {
         };
         check(!isNull);
 //      ^^^^^^^^^^^^^^ Error: assertion might not hold
+    }
+
+    static void switchStmtBlockBody(int i) {
+        var num = -1;
+        switch (i) {
+            case 0 -> num = 10;
+            case 1, 2, 3, 4 -> {
+                num = 5;
+                switch (i) {
+                    case 1, 2 -> num = num + 25;
+                    case 3, 4 -> {
+                        num = num + 31;
+                        num = num + 14;
+                    }
+                }
+            }
+            default -> num = 60;
+        }
+        check(num % 10 == 0);
+    }
+
+    static void switchStmtNonExhaustive(int i) {
+        var num = -1;
+        switch (i) {
+            case 0 -> num = 10;
+            case 1, 2 -> num = 20;
+            case 3 -> num = 30;
+        }
+        check(num == -1 || num % 10 == 0);
     }
 }

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/TranslationErrors.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/TranslationErrors.java
@@ -90,15 +90,16 @@ class TranslationErrors {
             case Integer ii when ii < 0 -> ii * 3;
 //          ^ error: case pattern is not supported
             case Integer ii when 0 < ii -> ii * 2;
+//          ^ error: case pattern is not supported
             default -> 0;
         };
     }
 
-    int switchBlockBody(int i) {
+    int switchExprBlockBody(int i) {
         return switch (i) {
             case 0 -> 0;
             case 1, 2, 3 -> {
-//          ^ error: switch rule block is not supported
+//                          ^ error: switch rule block is not supported
                 var acc = 0;
                 for (int j = 0; j < i; j++) {
                     acc += j * j;
@@ -112,7 +113,7 @@ class TranslationErrors {
     int switchThrowBody(int i) {
         return switch (i) {
             case 0 -> throw new RuntimeException("");
-//          ^ error: switch rule throw statement is not supported
+//                    ^ error: switch rule throw statement is not supported
             case 1, 2 -> -i;
             default -> i * i * i;
         };


### PR DESCRIPTION
Resolves #107.

### What was changed?

- Support translating switch statements
- Adjust test engine to report all metadata mismatches (exit code, error/verified counts) instead of just the first

### How has this been tested?

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/aws/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
