### PR TITLE
feat: translate type casts

### DIFF
--- a/docs/guide/src/supported_java_features.md
+++ b/docs/guide/src/supported_java_features.md
@@ -18,6 +18,7 @@ JVerify intends to support the full Java language, but is currently being develo
 - `assert` statement
 - Constructors
 - `instanceof`, but only without a pattern
+- Type casts: `(SomeType)someValue`
 - `class`, but only without type parameters
 - `interface`, but only without type parameters
 - `implements`, but only classes implementing interfaces
@@ -38,7 +39,6 @@ Nothing yet
 - `package` statements
 - Multi-dimensional array instantiation: `new [,]`
 - Array instantiation with initializers: `new int[] { 1, 2, 3 }`
-- Type casts: `(SomeType)someValue`
 - Type parameters for types, including the declaration, declaration of bounds, and application
 - `extends`: but only classes inheriting other classes
 - Enhanced for loop: `for(var x : xs) { ... }`

--- a/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
@@ -775,11 +775,14 @@ public class JavaToDafnyCompiler {
         } else if (expr instanceof JCTree.JCAssignOp assignOp) {
             reportError(expr, "mutatingExpression", assignOp.getOperator().name.toString() + "=");
             return getHole(origin);
-        }
-        else if (expr instanceof JCTree.JCInstanceOf instanceOf) {
+        } else if (expr instanceof JCTree.JCInstanceOf instanceOf) {
             var expression = toExpr(instanceOf.getExpression());
             var jcType = toType(instanceOf.getType());
             return new TypeTestExpr(origin, expression, jcType);
+        } else if (expr instanceof JCTree.JCTypeCast cast) {
+            var castExpr = toExpr(cast.getExpression());
+            var type = toType(cast.getType());
+            return new ConversionExpr(origin, castExpr, type, "");
         }
         reportError(expr, "notSupported", expr.getClass().getSimpleName());
         return getHole(origin);  

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/Operators.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/Operators.java
@@ -1,4 +1,4 @@
-// TEST: exitCode=4 dafnyVerified=13 dafnyErrors=10
+// TEST: exitCode=4 dafnyVerified=16 dafnyErrors=12
 
 package com.aws.jverify.verifier.tests;
 
@@ -157,5 +157,38 @@ class Operators {
         check(di instanceof DummyClass2);
 //      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Error: assertion might not hold
 
+    }
+
+    @SuppressWarnings({"RedundantCast", "ConstantValue"})
+    void castNumTrivial(int i) {
+        check(i == (int) i);
+        check(i == (long) i);
+        check(i == (int) (long) i);
+    }
+
+    void castNumInvalid(int i) {
+        check(i == (short) i);
+//                 ^^^^^^^^^ Error: result of operation might violate subset type constraint for 'int16'
+    }
+
+    void castRefTrivial() {
+        //noinspection ConstantValue,RedundantCast
+        check(this == (Operators) this);
+    }
+
+    void castDummyClass() {
+        DummyClass dc1 = new DummyClass();
+        DummyInterface dc2 = new DummyClass2();
+        //noinspection ConstantValue,NewObjectEquality,RedundantCast
+        check((DummyInterface) dc1 != dc2);
+    }
+
+    void castRefInvalid() {
+        DummyClass dc1 = new DummyClass();
+        DummyInterface dc2 = new DummyClass2();
+
+        //noinspection RedundantCast,NewObjectEquality,DataFlowIssue
+        check(dc1 == (DummyClass) dc2);
+//                   ^^^^^^^^^^^^^^^^ Error: value of expression (of type 'DummyInterface') is not known to be an instance of type 'DummyClass'
     }
 }


### PR DESCRIPTION
### What was changed?

Add support for simple forms of type casts, which are translated directly to `as` expressions in Dafny.

Unfortunately, invalid numeric casts result in error messages that refer to the respective numeric types using the Dafny names (e.g. `int16`). I'm not sure whether there's a nice way to improve that without nontrivial changes to Dafny's error reporting.

### How has this been tested?

Added unit tests.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/aws/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
