### PR TITLE
Fix NullPointer exception when an interface method is not used

### DIFF
--- a/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
@@ -13,6 +13,7 @@ import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.TypeTag;
 import com.sun.tools.javac.tree.EndPosTable;
 import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.tree.JCTree.JCStatement;
 import com.sun.tools.javac.tree.TreeMaker;
 
 import com.sun.tools.javac.tree.TreeInfo;
@@ -515,7 +516,8 @@ public class JavaToDafnyCompiler {
 
         if (annotationsByName.containsKey(Pure.class.getName())) {
             var header = new HeaderContainer();
-            var postHeader = methodCompiler.translateHeader(method.body.stats, header);
+            List<JCStatement> statements = method.getBody() == null ? List.of() : method.getBody().stats;
+            var postHeader = methodCompiler.translateHeader(statements, header);
             applyInvariants(method, header);
             if (postHeader.size() != 1) {
                 reportError(method, "pureMethodMultipleStatements");
@@ -549,7 +551,8 @@ public class JavaToDafnyCompiler {
                     body, null, null);
         } else {
             var header = new HeaderContainer();
-            var postHeader = methodCompiler.translateHeader(method.getBody().stats, header);
+            List<JCStatement> statements = method.getBody() == null ? List.of() : method.getBody().stats;
+            var postHeader = methodCompiler.translateHeader(statements, header);
             applyInvariants(method, header);
             methodCompiler.checkEmptyExpressions(method, header.invariants, "invariants", "method");
 

--- a/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
@@ -616,7 +616,10 @@ public class JavaToDafnyCompiler {
                 BlockStmt body;
                 if (shouldVerify) {
                     var bodyStatements = methodCompiler.translateStatements(postHeader);
-                    body = new BlockStmt(toOrigin(method.body), null, List.of(), bodyStatements);
+                    // Empty body to a method means we are translating a methodDecl from an interface.
+                    // This should be translated as a Method without body (rather than with an empty body) to have it
+                    // havoc-ed during analysis
+                    body = bodyStatements.isEmpty() ? null : new BlockStmt(toOrigin(method.body), null, List.of(), bodyStatements);
                 } else {
                     body = null;
                 }

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/Interfaces.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/Interfaces.java
@@ -13,6 +13,7 @@ interface I {
     int m();
 }
 
+// Empty interface to check robustness (see Issue #161)
 interface Unused {
     void unused(int x);
 }

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/Interfaces.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/Interfaces.java
@@ -5,7 +5,7 @@ import com.aws.jverify.testengine.JVerifyTest;
 
 import static com.aws.jverify.JVerify.*;
 
-@JVerifyTest(exitCode = 4, dafnyVerified = 10, dafnyErrors = 4)
+@JVerifyTest(exitCode = 4, dafnyVerified = 10, dafnyErrors = 5)
 class Interfaces {}
 
 interface I {
@@ -14,8 +14,16 @@ interface I {
 }
 
 // Empty interface to check robustness (see Issue #161)
-interface Unused {
-    void unused(int x);
+interface Undefined {
+    int undefined(int x);
+}
+
+class UndefinedUser {
+    public void using(Undefined u) {
+        int tmp = u.undefined(1);
+        check(tmp == 13);
+//      ^^^^^^^^^^^^^^^^ Error: assertion might not hold
+    }
 }
 
 @Contract(I.class)

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/Interfaces.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/Interfaces.java
@@ -13,6 +13,10 @@ interface I {
     int m();
 }
 
+interface Unused {
+    void unused(int x);
+}
+
 @Contract(I.class)
 class IContract implements I {
 


### PR DESCRIPTION
### What was changed?
Fixes issue #161 

### How has this been tested?
Added test case in file Interfaces.java

Removes this exception when analyzing 14 files from the JML test files

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/aws/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
