### PR TITLE
Enable the Dafny source location consistency check

### DIFF
--- a/verifier/src/main/java/com/aws/jverify/verifier/Driver.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/Driver.java
@@ -232,7 +232,8 @@ public class Driver {
                 "--json-diagnostics",
                 "--type-system-refresh",
                 "--general-newtypes",
-                "--general-traits=datatype"
+                "--general-traits=datatype",
+                "--check-source-location-consistency"
         );
         if (verifierOptions.printDafny() != null) {
             processBuilder.command().add("--print=" + verifierOptions.printDafny());

--- a/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
@@ -182,7 +182,7 @@ public class JavaToDafnyCompiler {
                 args));
     }
 
-    List<AttributedExpression> invariants = new ArrayList<>();
+    List<Symbol.MethodSymbol> invariants = new ArrayList<>();
     List<JCTree.JCVariableDecl> initializers = new ArrayList<>();
     
     enum ShouldVerifyMode { AlwaysYes, DefaultYes, AlwaysNo, DefaultNo, Inherit }
@@ -348,12 +348,7 @@ public class JavaToDafnyCompiler {
                 if (methodDecl.getModifiers().getAnnotations().stream().
                         anyMatch(a -> a.getAnnotationType() instanceof JCTree.JCIdent ident && 
                                 ident.name.contentEquals("Invariant"))) {
-                    var memberName = nameMangler.mangleSymbolName(methodDecl.sym);
-                    var invariantName = getName(methodDecl, memberName);
-                    var invariantOrigin = declToOrigin(methodDecl, invariantName);
-                    ApplySuffix call = new ApplySuffix(invariantOrigin, new NameSegment(invariantOrigin,
-                            memberName, null), null, new ActualBindings(List.of()), null);
-                    invariants.add(new AttributedExpression(call,null, null)); 
+                    invariants.add(methodDecl.sym);
                 }
             }
         }
@@ -664,10 +659,16 @@ public class JavaToDafnyCompiler {
         boolean isPublic = (method.getModifiers().flags & Flags.PUBLIC) != 0;
         if (isPublic) {
             for(var invariant : invariants) {
+                var memberName = nameMangler.mangleSymbolName(invariant);
+                var invariantName = getName(method, memberName);
+                var invariantOrigin = declToOrigin(method, invariantName);
+                ApplySuffix call = new ApplySuffix(invariantOrigin, new NameSegment(invariantOrigin,
+                        memberName, null), null, new ActualBindings(List.of()), null);
+                var invariantCall = new AttributedExpression(call,null, null);
                 if (!TreeInfo.isConstructor(method)) {
-                    header.preconditions.add(invariant);
+                    header.preconditions.add(invariantCall);
                 }
-                header.postconditions.add(invariant);
+                header.postconditions.add(invariantCall);
             }
         }
     }
@@ -889,6 +890,7 @@ public class JavaToDafnyCompiler {
             return null;
         }
 
+        var origin = toOrigin(invocation);
         var receiver = invocation.getMethodSelect() instanceof JCTree.JCFieldAccess fieldAccess
                 ? fieldAccess.selected
                 : null;
@@ -903,7 +905,6 @@ public class JavaToDafnyCompiler {
                     reportError(args.getFirst(), "argumentMustBeLambda", methodName);
                     return null;
                 }
-                var origin = toOrigin(lambda.getBody());
                 var boundVars = lambda.params.stream().map(param -> {
                     var paramOrigin = toOrigin(lambda);
                     var paramName = new Name(paramOrigin, param.getName().toString());
@@ -925,16 +926,16 @@ public class JavaToDafnyCompiler {
                 var array = args.get(0);
                 var fromIndex = args.length() > 1 ? args.get(1) : null;
                 var toIndex = args.length() > 2 ? args.get(2) : null;
-                return toSubsequence(array, fromIndex, toIndex);
+                return toSubsequence(origin, array, fromIndex, toIndex);
             }
             case "drop" -> {
-                return toSubsequence(receiver, args.getFirst(), null);
+                return toSubsequence(origin, receiver, args.getFirst(), null);
             }
             case "take" -> {
-                return toSubsequence(receiver, null, args.getFirst());
+                return toSubsequence(origin, receiver, null, args.getFirst());
             }
             case "subsequence" -> {
-                return toSubsequence(receiver, args.get(0), args.get(1));
+                return toSubsequence(origin, receiver, args.get(0), args.get(1));
             }
             case "contains" -> {
                 var element = toExpr(args.getFirst());
@@ -955,8 +956,7 @@ public class JavaToDafnyCompiler {
         return null;
     }
 
-    private SeqSelectExpr toSubsequence(JCTree.JCExpression seqOrArray, JCTree.@Nullable JCExpression lo, JCTree.@Nullable JCExpression hi) {
-        var origin = toOrigin(seqOrArray);
+    private SeqSelectExpr toSubsequence(IOrigin origin, JCTree.JCExpression seqOrArray, JCTree.@Nullable JCExpression lo, JCTree.@Nullable JCExpression hi) {
         var seqOrArrayExpr = toExpr(seqOrArray);
         var loExpr = lo == null ? null : toExpr(lo);
         var hiExpr = hi == null ? null : toExpr(hi);

--- a/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
@@ -716,9 +716,13 @@ public class JavaToDafnyCompiler {
         var dafnyExpr = toExpr(expr);
         return new ExprRhs(origin, null, dafnyExpr);
     }
-    
+
     private Expression toExpr(JCTree.JCExpression expr) {
-        var origin = toOrigin(expr);
+        return toExpr(expr, null);
+    }
+
+    private Expression toExpr(JCTree.JCExpression expr, IOrigin originOverride) {
+        var origin = Objects.requireNonNullElseGet(originOverride, () -> toOrigin(expr));
         switch (expr) {
             case JCTree.JCConditional conditional -> {
                 var condition = toExpr(conditional.getCondition());
@@ -1161,7 +1165,7 @@ public class JavaToDafnyCompiler {
             }
             return new UserDefinedType(origin, new NameSegment(origin, "array" + nullableSuffix, List.of(elemType)));
         } else if (tree instanceof JCTree.JCExpression expr) {
-            var expression = toExpr(expr);
+            var expression = toExpr(expr, origin);
             
             // Remove the name qualification because we do not support that yet
             Expression nameSegment;

--- a/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
@@ -594,11 +594,12 @@ public class JavaToDafnyCompiler {
                 if (shouldVerify) {
                     ArrayList<Statement> bodyStatements = new ArrayList<>();
                     var treeMaker = TreeMaker.instance(context);
+                    var initializerOrigin = toOrigin(method.body);
 
                     for (JCTree.JCVariableDecl variableDecl : initializers) {
                       var rhs = variableDecl.getInitializer();
                       var assignStmt = treeMaker.Assignment(variableDecl.sym,rhs);
-                      bodyStatements.addAll(methodCompiler.translateStatement(assignStmt));
+                      bodyStatements.addAll(methodCompiler.translateStatement(assignStmt, initializerOrigin));
                     }
                     bodyStatements.addAll(methodCompiler.translateStatements(postHeader));
 
@@ -685,7 +686,11 @@ public class JavaToDafnyCompiler {
     }
 
     public AssignmentRhs toAssignmentRhs(JCTree.JCExpression expr) {
-        var origin = toOrigin(expr);
+        return toAssignmentRhs(expr, null);
+    }
+
+    public AssignmentRhs toAssignmentRhs(JCTree.JCExpression expr, IOrigin originOverride) {
+        var origin = Objects.requireNonNullElseGet(originOverride, () -> toOrigin(expr));
         switch (expr) {
             case JCTree.JCNewClass newClass -> {
                 var argBindings = newClass.getArguments().stream().map(a -> new ActualBinding(null, toExpr(a), false)).toList();
@@ -713,15 +718,15 @@ public class JavaToDafnyCompiler {
             case null, default -> {
             }
         }
-        var dafnyExpr = toExpr(expr);
+        var dafnyExpr = toExpr(expr, originOverride);
         return new ExprRhs(origin, null, dafnyExpr);
     }
 
-    private Expression toExpr(JCTree.JCExpression expr) {
+    public Expression toExpr(JCTree.JCExpression expr) {
         return toExpr(expr, null);
     }
 
-    private Expression toExpr(JCTree.JCExpression expr, IOrigin originOverride) {
+    public Expression toExpr(JCTree.JCExpression expr, IOrigin originOverride) {
         var origin = Objects.requireNonNullElseGet(originOverride, () -> toOrigin(expr));
         switch (expr) {
             case JCTree.JCConditional conditional -> {

--- a/verifier/src/main/java/com/aws/jverify/verifier/MethodCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/MethodCompiler.java
@@ -25,7 +25,6 @@ public class MethodCompiler {
 
     public int generatedIndex = 0;
 
-
     public List<Statement> translateStatement(JCTree.JCStatement statement) {
         return translateStatement(statement, null);
     }

--- a/verifier/src/main/java/com/aws/jverify/verifier/MethodCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/MethodCompiler.java
@@ -208,7 +208,7 @@ public class MethodCompiler {
             var rhs = compiler.toAssignmentRhs(initializer);
             List<Expression> lhss = List.of(new IdentifierExpr(localVariable.getOrigin(), localVariable.getName()));
             List<AssignmentRhs> rhss = List.of(rhs);
-            dafnyInitializer = new AssignStatement(rhs.getOrigin(), null, lhss, rhss, false);
+            dafnyInitializer = new AssignStatement(origin, null, lhss, rhss, false);
         }
 
         return List.of(new VarDeclStmt(origin, null, List.of(localVariable), dafnyInitializer));

--- a/verifier/src/main/java/com/aws/jverify/verifier/MethodCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/MethodCompiler.java
@@ -24,9 +24,14 @@ public class MethodCompiler {
     private JCTree.JCStatement outerLoop;
 
     public int generatedIndex = 0;
-    
+
+
     public List<Statement> translateStatement(JCTree.JCStatement statement) {
-        var origin = compiler.toOrigin(statement);
+        return translateStatement(statement, null);
+    }
+
+    public List<Statement> translateStatement(JCTree.JCStatement statement, IOrigin originOverride) {
+        var origin = Objects.requireNonNullElseGet(originOverride, () -> compiler.toOrigin(statement));
         if (statement instanceof JCTree.JCLabeledStatement labeledStatement) {
             labels.add(new Label(origin, labeledStatement.getLabel().toString()));
             return translateStatement(labeledStatement.getStatement());
@@ -36,7 +41,7 @@ public class MethodCompiler {
 
         switch (statement) {
             case JCTree.JCExpressionStatement expressionStatement -> {
-                return translateExpressionStatement(expressionStatement);
+                return translateExpressionStatement(expressionStatement, originOverride);
             }
             case JCTree.JCAssert assertStmt -> {
                 return List.of(new AssertStmt(origin, null, compiler.toExpr(assertStmt.getCondition()), null));
@@ -251,14 +256,14 @@ public class MethodCompiler {
         return "#_tmpVar_"+(generatedIndex++);
     }
 
-    private List<Statement> translateExpressionStatement(JCTree.JCExpressionStatement statement) {
+    private List<Statement> translateExpressionStatement(JCTree.JCExpressionStatement statement, IOrigin originOverride) {
         var expr = statement.getExpression();
         switch (expr) {
             case JCTree.JCMethodInvocation invocation -> {
                 return translateStatementMethodInvocation(invocation);
             }
             case JCTree.JCAssign assign -> {
-                return translateAssign(assign);
+                return translateAssign(assign, originOverride);
             }
             case JCTree.JCAssignOp assignOp -> {
                 return translateAssignOp(assignOp);
@@ -310,10 +315,11 @@ public class MethodCompiler {
         return List.of(new AssignStatement(origin, null, lhss, rhss, false));
     }
 
-    private List<Statement> translateAssign(JCTree.JCAssign assign) {
-        List<Expression> lhss = List.of(compiler.toExpr(assign.getVariable()));
-        List<AssignmentRhs> rhss = List.of(compiler.toAssignmentRhs(assign.getExpression()));
-        return List.of(new AssignStatement(compiler.toOrigin(assign), null, lhss, rhss, false));
+    private List<Statement> translateAssign(JCTree.JCAssign assign, IOrigin originOverride) {
+        var origin = Objects.requireNonNullElseGet(originOverride, () -> compiler.toOrigin(assign));
+        List<Expression> lhss = List.of(compiler.toExpr(assign.getVariable(), originOverride));
+        List<AssignmentRhs> rhss = List.of(compiler.toAssignmentRhs(assign.getExpression(), originOverride));
+        return List.of(new AssignStatement(origin, null, lhss, rhss, false));
     }
 
     private List<Statement> translateStatementMethodInvocation(JCTree.JCMethodInvocation invocation) {
@@ -394,7 +400,11 @@ public class MethodCompiler {
     }
 
     public <T extends JCTree.JCStatement> List<Statement> translateStatements(List<T> statements) {
-        return statements.stream().flatMap(s -> translateStatement(s).stream()).toList();
+        return translateStatements(statements, null);
+    }
+
+    public <T extends JCTree.JCStatement> List<Statement> translateStatements(List<T> statements, IOrigin originOverride) {
+        return statements.stream().flatMap(s -> translateStatement(s, originOverride).stream()).toList();
     }
 
     public void checkEmptyExpressions(JCTree tree,

--- a/verifier/src/main/resources/com/aws/jverify/dafny.properties
+++ b/verifier/src/main/resources/com/aws/jverify/dafny.properties
@@ -1,2 +1,2 @@
 dafnyVersion=4.10.1
-dafnyRef=aa1bce8c5c1255d9b64286e212b952d66e917f64
+dafnyRef=da00c9fcfa6f768ccbfee5662898c3ee25d91b0e


### PR DESCRIPTION
### What was changed?
Adds `--check-source-location-consistency` when invoking Dafny, and corrects a number of inconsistent origins the translation was generating.

Mostly I added more `originOverride`s parameters to various translation methods. I only threaded these overrides through the call chains enough for the existing tests to pass however. We will likely have to continue to thread them through more as more cases and tests are added.

In some cases this is necessary because javac or our own translation code is creating synthetic JCTree values with no position attached. For example, we duplicate initializers into explicit statements at the beginning of constructors. I experimented at first with providing these missing positions, via `TreeMaker.at` for example, but found that this approach wouldn't work without a way to clone JCTree values, which I wasn't able to find anywhere.

### How has this been tested?
Existing tests.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/aws/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
