### PR TITLE
No testengine on classpath by default

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -68,6 +68,11 @@ jobs:
         working-directory: ./jverify-collection
         run: |
           make test-generation-nodiff
+      - name: Getting started command
+        working-directory: ./jverify-collection
+        run: |
+          ./gradlew installDist
+          ./verifier/build/install/verifier/bin/verifier ./examples/src/test/java/com/aws/jverify/examples/BinarySearch.java --dafny ./dafny/Scripts/dafny
       - name: Gradle test
         working-directory: ./jverify-collection
         run: |

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -68,11 +68,20 @@ jobs:
         working-directory: ./jverify-collection
         run: |
           make test-generation-nodiff
-      - name: Getting started command
+      - name: Install verifier CLI locally
         working-directory: ./jverify-collection
         run: |
           ./gradlew installDist
+      - name: Getting started command (non-Windows)
+        if: runner.os != 'Windows'
+        working-directory: ./jverify-collection
+        run: |
           ./verifier/build/install/verifier/bin/verifier ./examples/src/test/java/com/aws/jverify/examples/BinarySearch.java --dafny ./dafny/Scripts/dafny
+      - name: Getting started command (Windows)
+        if: runner.os == 'Windows'
+        working-directory: ./jverify-collection
+        run: |
+          ./verifier/build/install/verifier/bin/verifier.bat ./examples/src/test/java/com/aws/jverify/examples/BinarySearch.java --dafny ./dafny/Scripts/dafny
       - name: Gradle test
         working-directory: ./jverify-collection
         run: |

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -20,7 +20,7 @@ jobs:
         include:
           - os: ubuntu-22.04
             chmod: true
-          - os: windows-2019
+          - os: windows-2022
             chmod: false
       fail-fast: false
         

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -81,7 +81,7 @@ jobs:
         if: runner.os == 'Windows'
         working-directory: ./jverify-collection
         run: |
-          ./verifier/build/install/verifier/bin/verifier.bat ./examples/src/test/java/com/aws/jverify/examples/BinarySearch.java --dafny ./dafny/Scripts/dafny
+          ./verifier/build/install/verifier/bin/verifier.bat ./examples/src/test/java/com/aws/jverify/examples/BinarySearch.java --dafny ./dafny/Binaries/Dafny.exe
       - name: Gradle test
         working-directory: ./jverify-collection
         run: |

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -16,7 +16,7 @@ jobs:
   checks:
     strategy:
       matrix:
-        os: [ ubuntu-22.04, windows-2019 ]
+        os: [ ubuntu-22.04, windows-2022 ]
         include:
           - os: ubuntu-22.04
             chmod: true

--- a/docs/guide/src/getting_started.md
+++ b/docs/guide/src/getting_started.md
@@ -30,7 +30,7 @@ To run JVerify, run the following from the repository root:
 or the following in Windows:
 
 ```
-./verifier/build/install/verifier/bin/verifier.bat ./examples/src/test/java/com/aws/jverify/examples/BinarySearch.java --dafny ./dafny/Scripts/dafny
+./verifier/build/install/verifier/bin/verifier.bat ./examples/src/test/java/com/aws/jverify/examples/BinarySearch.java --dafny ./dafny/Binaries/Dafny.exe
 ```
 
 You should see the following output:

--- a/verifier/src/main/java/com/aws/jverify/verifier/Main.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/Main.java
@@ -57,8 +57,6 @@ class AppCommand implements Callable<Integer> {
         // And those will include the JVerify library jar.
         // But right now we manually find the JVerify library jar and include it in the compilation.
         var jverifyLibraryLocation = Path.of(URI.create(Common.getJarLocationForClass(JVerify.class)));
-        // Likewise, we manually add the test engine jar so that our examples will work as-is
-        var testEngineClassPath = Path.of("../test-engine/build/classes/java/main").toAbsolutePath();
 
         File tempFile = File.createTempFile("jverify-prelude-", ".dfy");
         InputStream stream = getClass().getResourceAsStream("/additional.dfy");
@@ -67,7 +65,7 @@ class AppCommand implements Callable<Integer> {
         var dafnyPath = getDafnyPath();
         additionalJars = additionalJars == null ? List.of() : additionalJars;
         List<Path> jars = Stream.concat(additionalJars.stream(), 
-                Stream.of(jverifyLibraryLocation, testEngineClassPath)).toList();
+                Stream.of(jverifyLibraryLocation)).toList();
         
         var verifierOptions = new VerifierOptions(dafnyPath, jars, tempFile.toPath(),
                 printDafny, printBinaryDafny, showRanges, paths, new String[0], verifyByDefault);


### PR DESCRIPTION
### What was changed?
This path was incorrect, but it's also not needed any more since we removed references to `@JVerifyTest` from the examples.

Also upgraded the Windows runner since `windows-2019` is now deprecated.

### How has this been tested?
Added a CI check.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/aws/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
