### PR TITLE
Allow multiple calls to postcondition

### DIFF
--- a/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
@@ -728,20 +728,12 @@ public class JavaToDafnyCompiler {
         applyInvariants(sourceBody, modifiers, methodSymbol, header);
         methodCompiler.checkEmptyExpressions(source, header.invariants, "invariants", "method");
 
-        if (header.returnNames.size() > 1) {
-            reportError(source, "multipleReturnNames");
-            return null;
-        }
         var outs = new ArrayList<Formal>();
         if (methodSymbol.type.getReturnType() != null) {
             var returnType = translateType(methodSymbol.type.getReturnType(), bodyOrigin);
             if (returnType != null) {
                 Name returnName;
-                if (header.returnNames.size() == 1) {
-                    returnName = header.returnNames.getFirst();
-                } else {
-                    returnName = new Name(origin, "r");
-                }
+                returnName = Objects.requireNonNullElseGet(header.returnName, () -> new Name(origin, "r"));
                 outs.add(new Formal(origin, returnName, returnType,
                         false, false, null, null, false, false, false, null));
             }

--- a/verifier/src/main/java/com/aws/jverify/verifier/MethodCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/MethodCompiler.java
@@ -474,15 +474,27 @@ public class MethodCompiler {
                 }
                 case "postcondition" -> {
                     if (invocation.args.size() != 1) {
-                        throw new JavaViolationException("An postcondition call may have only one argument");
+                        throw new JavaViolationException("A postcondition call may have only one argument");
                     }
                     var first = invocation.getArguments().getFirst();
                     if (first instanceof JCTree.JCLambda lambda) {
                         if (lambda.getParameters().size() != 1) {
-                            throw new JavaViolationException("An ensures call lambda may take only one argument");
+                            throw new JavaViolationException("A postcondition ccall lambda may take only one argument");
                         }
                         var parameter = lambda.getParameters().getFirst();
-                        header.returnNames.add(new Name(compiler.toOrigin(lambda), parameter.getName().toString()));
+                        var paramName = parameter.getName().toString();
+                        var origin = compiler.toOrigin(lambda);
+                        
+                        // Only add the first return name or verify subsequent ones match
+                        if (header.returnName == null) {
+                            header.returnName = new Name(origin, paramName);
+                        } else {
+                            var firstName = header.returnName.getValue();
+                            if (!firstName.equals(paramName)) {
+                                compiler.reportError((JCTree) parameter, "multipleReturnNames", firstName, paramName);
+                            }
+                        }
+                        
                         var postconditionPredicate = compiler.expressionCompiler.toExpr(lambda.getBody());
                         if (postconditionPredicate != null) {
                             header.postconditions.add(new AttributedExpression(postconditionPredicate, null, null));

--- a/verifier/src/main/java/com/aws/jverify/verifier/MethodCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/MethodCompiler.java
@@ -479,7 +479,7 @@ public class MethodCompiler {
                     var first = invocation.getArguments().getFirst();
                     if (first instanceof JCTree.JCLambda lambda) {
                         if (lambda.getParameters().size() != 1) {
-                            throw new JavaViolationException("A postcondition ccall lambda may take only one argument");
+                            throw new JavaViolationException("A postcondition call lambda may take only one argument");
                         }
                         var parameter = lambda.getParameters().getFirst();
                         var paramName = parameter.getName().toString();

--- a/verifier/src/main/java/com/aws/jverify/verifier/MethodCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/MethodCompiler.java
@@ -483,7 +483,6 @@ public class MethodCompiler {
                         }
                         var parameter = lambda.getParameters().getFirst();
                         var paramName = parameter.getName().toString();
-                        var origin = compiler.toOrigin(lambda);
                         
                         // Only add the first return name or verify subsequent ones match
                         if (header.returnName == null) {

--- a/verifier/src/main/java/com/aws/jverify/verifier/MethodCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/MethodCompiler.java
@@ -482,6 +482,7 @@ public class MethodCompiler {
                             throw new JavaViolationException("A postcondition call lambda may take only one argument");
                         }
                         var parameter = lambda.getParameters().getFirst();
+                        var origin = compiler.toOrigin(lambda);
                         var paramName = parameter.getName().toString();
                         
                         // Only add the first return name or verify subsequent ones match

--- a/verifier/src/main/java/com/aws/jverify/verifier/MethodOrLoopContract.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/MethodOrLoopContract.java
@@ -14,7 +14,7 @@ public class MethodOrLoopContract {
     boolean isPure;
     List<AttributedExpression> preconditions;
     List<AttributedExpression> postconditions;
-    List<Name> returnNames;
+    Name returnName;
     List<AttributedExpression> invariants;
     List<Expression> decreases;
     List<FrameExpression> reads;
@@ -26,7 +26,7 @@ public class MethodOrLoopContract {
         
         preconditions = new ArrayList<>();
         postconditions = new ArrayList<>();
-        returnNames = new ArrayList<>();
+        returnName = null;
         invariants = new ArrayList<>();
         decreases = new ArrayList<>();
         reads = new ArrayList<>();

--- a/verifier/src/main/resources/com/aws/jverify/messages.properties
+++ b/verifier/src/main/resources/com/aws/jverify/messages.properties
@@ -1,7 +1,7 @@
 compiler.err.pureMethodMultipleStatements=pure method should have only one statement
 compiler.err.pureMethodsNeedsReturnType=pure method should have a return type
 compiler.err.pureMethodNeedsReturnStatement=pure method statement should be a return
-compiler.err.multipleReturnNames=ensures clauses may introduce only one return variable name
+compiler.err.multipleReturnNames=all postcondition lambda parameters must use the same name. Got {1} instead of {0}
 compiler.err.argumentMustBeLambda=the argument to a {0} call must be a lambda
 compiler.err.notSupported={0} is not supported
 compiler.err.contractAfterBody=call to JVerify header method {0} is not allowed after non-header statement

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/MultiplePostconditionsSameNames.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/MultiplePostconditionsSameNames.java
@@ -1,0 +1,16 @@
+package com.aws.jverify.verifier.tests;
+
+import com.aws.jverify.testengine.JVerifyTest;
+
+import static com.aws.jverify.JVerify.postcondition;
+
+@JVerifyTest(exitCode = 0, dafnyVerified = 1, dafnyErrors = 0)
+public class MultiplePostconditionsSameNames {
+    
+    // This should work - same parameter name
+    public static int validMultiplePostconditions() {
+        postcondition((Integer r) -> r > 0);
+        postcondition((Integer r) -> r < 100);
+        return 42;
+    }
+}

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/TranslationErrors.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/TranslationErrors.java
@@ -21,9 +21,9 @@ class TranslationErrors {
     }
     
     int multipleReturnNames() {
-//      ^ error: ensures clauses may introduce only one return variable name
        postcondition((Integer i) -> i > 0);
        postcondition((Integer j) -> j < 2);
+//                            ^ error: all postcondition lambda parameters must use the same name. Got j instead of i
        return 1;
     }
     


### PR DESCRIPTION
### What was changed?
Update in JVerify compilation to allow multiple calls to postcondition with lambda, if the lambda parameters have the same name

### How has this been tested?
Added test case
Modified the error test case


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/aws/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
