### PR TITLE
Only used complex compiled names when necessary

### DIFF
--- a/verifier/src/main/java/com/aws/jverify/verifier/BlockCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/BlockCompiler.java
@@ -9,11 +9,11 @@ import com.sun.tools.javac.tree.JCTree;
 import java.util.*;
 import java.util.stream.Collectors;
 
-public class MethodCompiler {
+public class BlockCompiler {
 
     private final JavaToDafnyCompiler compiler;
 
-    public MethodCompiler(JavaToDafnyCompiler compiler) {
+    public BlockCompiler(JavaToDafnyCompiler compiler) {
         this.compiler = compiler;
     }
 

--- a/verifier/src/main/java/com/aws/jverify/verifier/BlockCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/BlockCompiler.java
@@ -353,7 +353,7 @@ public class BlockCompiler {
                 return List.of();
             }
             
-            var baseConstructorName = compiler.nameCompiler.mangleSymbolName(baseConstructor);
+            var baseConstructorName = compiler.nameCompiler.getCompiledName(baseConstructor);
             var initName = JavaToDafnyCompiler.getInitMethodName(baseConstructorName);
             var arguments = invocation.getArguments().stream().map(
                     e -> new ActualBinding(null, compiler.expressionCompiler.toExpr(e), false)).toList();
@@ -577,7 +577,7 @@ public class BlockCompiler {
             case JCTree.JCNewClass newClass -> {
                 var argBindings = newClass.getArguments().stream().map(
                         a -> new ActualBinding(null, compiler.expressionCompiler.toExpr(a), false)).toList();
-                String ctorNameStr = compiler.nameCompiler.mangleSymbolName(newClass.constructor);
+                String ctorNameStr = compiler.nameCompiler.getCompiledName(newClass.constructor);
                 Name ctorName = new Name(origin, ctorNameStr);
                 var baseType = (NameSegment)compiler.expressionCompiler.toExpr(newClass.clazz);
                 var classBaseType = new NameSegment(baseType.getOrigin(), "_Class_" + baseType.getName(), baseType.getOptTypeArguments());

--- a/verifier/src/main/java/com/aws/jverify/verifier/BlockCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/BlockCompiler.java
@@ -353,7 +353,7 @@ public class BlockCompiler {
                 return List.of();
             }
             
-            var baseConstructorName = compiler.nameMangler.mangleSymbolName(baseConstructor);
+            var baseConstructorName = compiler.nameCompiler.mangleSymbolName(baseConstructor);
             var initName = JavaToDafnyCompiler.getInitMethodName(baseConstructorName);
             var arguments = invocation.getArguments().stream().map(
                     e -> new ActualBinding(null, compiler.expressionCompiler.toExpr(e), false)).toList();
@@ -577,7 +577,7 @@ public class BlockCompiler {
             case JCTree.JCNewClass newClass -> {
                 var argBindings = newClass.getArguments().stream().map(
                         a -> new ActualBinding(null, compiler.expressionCompiler.toExpr(a), false)).toList();
-                String ctorNameStr = compiler.nameMangler.mangleSymbolName(newClass.constructor);
+                String ctorNameStr = compiler.nameCompiler.mangleSymbolName(newClass.constructor);
                 Name ctorName = new Name(origin, ctorNameStr);
                 var baseType = (NameSegment)compiler.expressionCompiler.toExpr(newClass.clazz);
                 var classBaseType = new NameSegment(baseType.getOrigin(), "_Class_" + baseType.getName(), baseType.getOptTypeArguments());

--- a/verifier/src/main/java/com/aws/jverify/verifier/Driver.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/Driver.java
@@ -238,8 +238,8 @@ public class Driver {
         }
     }
 
-    public static void runDafnyProcess(NameMangler mangler, 
-            String program, VerifierOptions verifierOptions, VerificationResults outResults) {
+    public static void runDafnyProcess(NameCompiler mangler,
+                                       String program, VerifierOptions verifierOptions, VerificationResults outResults) {
         // First check the Dafny version is correct
         checkDafnyVersion(verifierOptions);
 
@@ -298,7 +298,7 @@ public class Driver {
      * adding both diagnostics and the summary verified/error counts to {@code outResults}.
      * Note that Dafny must be invoked with {@code --json-diagnostics} or else parsing will fail.
      */
-    private static void parseDafnyJsonOutput(NameMangler mangler,  BufferedReader dafnyOutput, VerificationResults outResults) {
+    private static void parseDafnyJsonOutput(NameCompiler mangler, BufferedReader dafnyOutput, VerificationResults outResults) {
         var objectMapper = new ObjectMapper();
         
         SimpleModule module = new SimpleModule();

--- a/verifier/src/main/java/com/aws/jverify/verifier/Driver.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/Driver.java
@@ -320,7 +320,7 @@ public class Driver {
                     switch (output) {
                         case DafnyDiagnostic dafnyDiagnostic -> {
                             for (var index = 0; index < dafnyDiagnostic.arguments.length; index++) {
-                                dafnyDiagnostic.arguments[index] = mangler.safeUnmangleName(dafnyDiagnostic.arguments[index]);
+                                dafnyDiagnostic.arguments[index] = mangler.safeGetOriginalName(dafnyDiagnostic.arguments[index]);
                             }
                         }
                         case StatusMessage statusMessage -> {

--- a/verifier/src/main/java/com/aws/jverify/verifier/ExpressionCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/ExpressionCompiler.java
@@ -131,7 +131,7 @@ public class ExpressionCompiler {
                 return translateBinary(binary, binary.type, binary.getLeftOperand().type, operator, left, right);
             }
             case JCTree.JCIdent identifier -> {
-                var identName = compiler.nameCompiler.mangleSymbolName(identifier.sym);
+                var identName = compiler.nameCompiler.getCompiledName(identifier.sym);
                 if (identName.contentEquals("this")) {
                     return new ThisExpr(origin);
                 }
@@ -198,7 +198,7 @@ public class ExpressionCompiler {
             }
             case JCTree.JCFieldAccess fieldAccess -> {
                 if (fieldAccess.sym instanceof Symbol.ClassSymbol classSymbol) {
-                    return new NameSegment(origin, compiler.nameCompiler.mangleSymbolName(classSymbol), List.of());
+                    return new NameSegment(origin, compiler.nameCompiler.getCompiledName(classSymbol), List.of());
                 }
                 if (fieldAccess.sym instanceof Symbol.DynamicMethodSymbol dynamicMethodSymbol) {
                     return translateDynamicMethod(origin, fieldAccess, dynamicMethodSymbol);
@@ -209,7 +209,7 @@ public class ExpressionCompiler {
                     return new ExprDotName(origin, selectedExpr, compiler.getName(fieldAccess, "Length"), null);
                 }
 
-                var fieldName = compiler.nameCompiler.mangleSymbolName(fieldAccess.sym);
+                var fieldName = compiler.nameCompiler.getCompiledName(fieldAccess.sym);
                 if (compiler.isEnum(fieldAccess.selected)) {
                     return new ApplySuffix(origin, new NameSegment(origin, fieldName, null),
                             null, new ActualBindings(List.of()), null);

--- a/verifier/src/main/java/com/aws/jverify/verifier/ExpressionCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/ExpressionCompiler.java
@@ -295,7 +295,7 @@ public class ExpressionCompiler {
      *
      * <p>Note: header methodContracts like {@link JVerify#precondition(boolean)}
      * and {@link JVerify#postcondition(boolean)}
-     * must be translated by {@link MethodCompiler#translateStatement(JCTree.JCStatement)},
+     * must be translated by {@link BlockCompiler#translateStatement(JCTree.JCStatement)},
      * not here.
      */
     private @Nullable Expression jverifyLibMethodToExpr(JCTree.JCMethodInvocation invocation) {

--- a/verifier/src/main/java/com/aws/jverify/verifier/ExpressionCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/ExpressionCompiler.java
@@ -469,7 +469,7 @@ public class ExpressionCompiler {
         var methodSymbol = (Symbol.MethodSymbol)((Symbol.MethodHandleSymbol)dynamicMethodSymbol.staticArgs[1]).baseSymbol();
         var arguments = params.<JCTree.JCExpression>map(p -> maker.Ident(p.sym)).appendList(interfaceMethodSymbol.params().map(p -> maker.Ident(p)));
         JCTree.JCExpression methodCall;
-        if (compiler.isConstructor(methodSymbol)) {
+        if (JavaToDafnyCompiler.isConstructor(methodSymbol)) {
             var newClass = maker.NewClass(null, com.sun.tools.javac.util.List.nil(), maker.Type(methodSymbol.owner.type), arguments, null);
             newClass.constructor = methodSymbol;
             methodCall = newClass;

--- a/verifier/src/main/java/com/aws/jverify/verifier/ExpressionCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/ExpressionCompiler.java
@@ -131,7 +131,7 @@ public class ExpressionCompiler {
                 return translateBinary(binary, binary.type, binary.getLeftOperand().type, operator, left, right);
             }
             case JCTree.JCIdent identifier -> {
-                var identName = compiler.nameMangler.mangleSymbolName(identifier.sym);
+                var identName = compiler.nameCompiler.mangleSymbolName(identifier.sym);
                 if (identName.contentEquals("this")) {
                     return new ThisExpr(origin);
                 }
@@ -198,7 +198,7 @@ public class ExpressionCompiler {
             }
             case JCTree.JCFieldAccess fieldAccess -> {
                 if (fieldAccess.sym instanceof Symbol.ClassSymbol classSymbol) {
-                    return new NameSegment(origin, compiler.nameMangler.mangleSymbolName(classSymbol), List.of());
+                    return new NameSegment(origin, compiler.nameCompiler.mangleSymbolName(classSymbol), List.of());
                 }
                 if (fieldAccess.sym instanceof Symbol.DynamicMethodSymbol dynamicMethodSymbol) {
                     return translateDynamicMethod(origin, fieldAccess, dynamicMethodSymbol);
@@ -209,7 +209,7 @@ public class ExpressionCompiler {
                     return new ExprDotName(origin, selectedExpr, compiler.getName(fieldAccess, "Length"), null);
                 }
 
-                var fieldName = compiler.nameMangler.mangleSymbolName(fieldAccess.sym);
+                var fieldName = compiler.nameCompiler.mangleSymbolName(fieldAccess.sym);
                 if (compiler.isEnum(fieldAccess.selected)) {
                     return new ApplySuffix(origin, new NameSegment(origin, fieldName, null),
                             null, new ActualBindings(List.of()), null);

--- a/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
@@ -57,7 +57,7 @@ public class JavaToDafnyCompiler {
     public final Set<Symbol.MethodSymbol> symbolsWithAContract = new HashSet<>();
     private final Stack<IOrigin> contextOrigins = new Stack<>();
     public final DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
-    public final NameCompiler nameMangler = new NameCompiler();
+    public final NameCompiler nameCompiler = new NameCompiler();
     private JCDiagnostic.Factory diagnosticFactory;
 
     /**
@@ -85,7 +85,7 @@ public class JavaToDafnyCompiler {
     }
 
     public NameCompiler getNameMangler() {
-        return nameMangler;
+        return nameCompiler;
     }
     
     public @Nullable FilesContainer analyzeJavaCode(VerifierOptions options, List<JavaFileObject> files) {
@@ -558,7 +558,7 @@ public class JavaToDafnyCompiler {
                     
                     
                     typeForWhichCurrentClassIsDefiningContract = contractee;
-                    name = new Name(name.getOrigin(), nameMangler.mangleSymbolName(typeForWhichCurrentClassIsDefiningContract));
+                    name = new Name(name.getOrigin(), nameCompiler.mangleSymbolName(typeForWhichCurrentClassIsDefiningContract));
                 }
             }
 
@@ -807,7 +807,7 @@ public class JavaToDafnyCompiler {
         List<DatatypeCtor> constructors = new ArrayList<>();
         for(var member : classDecl.getMembers()) {
             if (member instanceof JCTree.JCVariableDecl variableDecl) {
-                var variableName = nameMangler.mangleSymbolName(variableDecl.sym);
+                var variableName = nameCompiler.mangleSymbolName(variableDecl.sym);
                 Name constructorName = getName(variableDecl, variableName);
                 constructors.add(new DatatypeCtor(declToOrigin(variableDecl, constructorName), constructorName, 
                         null, false, List.of()));
@@ -1183,7 +1183,7 @@ public class JavaToDafnyCompiler {
         // Only apply invariants to public instance methods (not static methods)
         if (isPublic && !isStaticMethod) {
             for(var invariant : invariants) {
-                var memberName = nameMangler.mangleSymbolName(invariant);
+                var memberName = nameCompiler.mangleSymbolName(invariant);
                 var invariantName = getName(source, memberName);
                 var invariantOrigin = declToOrigin(source, invariantName);
                 ApplySuffix call = new ApplySuffix(invariantOrigin, new NameSegment(invariantOrigin,
@@ -1306,7 +1306,7 @@ public class JavaToDafnyCompiler {
                 }
 
                 // Remove the name qualification because we do not support that yet
-                var mangledName = nameMangler.mangleSymbolName(classType.tsym);
+                var mangledName = nameCompiler.mangleSymbolName(classType.tsym);
                 var arguments = classType.getTypeArguments().map(a -> translateType(null, a, origin));
                 if (arguments.isEmpty()) {
                     arguments = null;
@@ -1318,7 +1318,7 @@ public class JavaToDafnyCompiler {
                 return new UserDefinedType(origin, nameSegment);
             }
             case com.sun.tools.javac.code.Type.TypeVar typeVar -> {
-                return new UserDefinedType(origin, new NameSegment(origin, nameMangler.mangleSymbolName(typeVar.tsym), null));
+                return new UserDefinedType(origin, new NameSegment(origin, nameCompiler.mangleSymbolName(typeVar.tsym), null));
             }
             case null, default -> {
             }
@@ -1358,7 +1358,7 @@ public class JavaToDafnyCompiler {
     }
     
     Name getName(JCTree tree, Symbol symbol) {
-        return getName(tree, nameMangler.mangleSymbolName(symbol), symbol.name.length());
+        return getName(tree, nameCompiler.mangleSymbolName(symbol), symbol.name.length());
     }
 
     Name getName(JCTree tree, String name) {

--- a/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
@@ -1298,10 +1298,10 @@ public class JavaToDafnyCompiler {
                     return new UserDefinedType(origin, new NameSegment(origin, "char16", null));
                 }
                 case FLOAT -> {
-                    return new UserDefinedType(origin, new NameSegment(origin, "Float", null));
+                    return new UserDefinedType(origin, new NameSegment(origin, "float", null));
                 }
                 case DOUBLE -> {
-                    return new UserDefinedType(origin, new NameSegment(origin, "Double", null));
+                    return new UserDefinedType(origin, new NameSegment(origin, "double", null));
                 }
             }
 

--- a/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
@@ -12,6 +12,7 @@ import com.sun.tools.javac.api.MultiTaskListener;
 import com.sun.tools.javac.code.Flags;
 import com.sun.tools.javac.code.Kinds;
 import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.TypeMetadata;
 import com.sun.tools.javac.code.Types;
 import com.sun.tools.javac.comp.AttrContext;
 import com.sun.tools.javac.comp.CompileStates;
@@ -882,8 +883,18 @@ public class JavaToDafnyCompiler {
     }
 
     private boolean isNullable(com.sun.tools.javac.code.Type type) {
+        TypeMetadata.Annotations metadata = type.getMetadata(TypeMetadata.Annotations.class);
+        if (metadata != null) {
+            // In some JDK distributions, this conditional is necessary to detect the nullable annotation.
+            if (metadata.annotationBuffer().stream().
+                    anyMatch(s -> s.type.tsym.getQualifiedName().contentEquals(
+                            com.aws.jverify.Nullable.class.getName()))) {
+                return true; 
+            }
+        }
         return type.getAnnotation(com.aws.jverify.Nullable.class) != null;
     }
+    
 
     private @Nullable MethodOrFunction translateMethodDecl(JCTree.JCMethodDecl method) {
         return translateMethodOrLambda(method, method.getModifiers(), method.sym, method.body, method.typarams, null);

--- a/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
@@ -377,7 +377,7 @@ public class JavaToDafnyCompiler {
                 (JCTree.JCAnnotation a) -> a.getAnnotationType().type.toString(),
                 a -> a));
 
-        var methodCompiler = new MethodCompiler(this);
+        var methodCompiler = new BlockCompiler(this);
         var isPure = methodAnnotationsByName.containsKey(Pure.class.getName());
         var header = new MethodOrLoopContract(methodDecl, isPure);
         if (methodDecl.getBody() != null) {
@@ -944,7 +944,7 @@ public class JavaToDafnyCompiler {
 
         var dafnyTypeParameters = translateTypeParameters(typeParameters);
 
-        var methodCompiler = new MethodCompiler(this);
+        var methodCompiler = new BlockCompiler(this);
         Name name;
         if (typeForWhichCurrentClassIsDefiningContract != null && isConstructor(methodSymbol)) {
             name = getName(source, NameMangler.getConstructorName(typeForWhichCurrentClassIsDefiningContract)); 
@@ -1067,7 +1067,7 @@ public class JavaToDafnyCompiler {
         var bodyOrigin = toOrigin(sourceBody);
 
         @Nullable MethodOrLoopContract externalContract = findExternalContract(methodSymbol);
-        var methodCompiler = new MethodCompiler(this);
+        var methodCompiler = new BlockCompiler(this);
         var name = getName(source, methodSymbol);
         var origin = declToOrigin(source, name);
         var isStatic = isStatic(modifiers);

--- a/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
@@ -558,7 +558,7 @@ public class JavaToDafnyCompiler {
                     
                     
                     typeForWhichCurrentClassIsDefiningContract = contractee;
-                    name = new Name(name.getOrigin(), nameCompiler.mangleSymbolName(typeForWhichCurrentClassIsDefiningContract));
+                    name = new Name(name.getOrigin(), nameCompiler.getCompiledName(typeForWhichCurrentClassIsDefiningContract));
                 }
             }
 
@@ -807,7 +807,7 @@ public class JavaToDafnyCompiler {
         List<DatatypeCtor> constructors = new ArrayList<>();
         for(var member : classDecl.getMembers()) {
             if (member instanceof JCTree.JCVariableDecl variableDecl) {
-                var variableName = nameCompiler.mangleSymbolName(variableDecl.sym);
+                var variableName = nameCompiler.getCompiledName(variableDecl.sym);
                 Name constructorName = getName(variableDecl, variableName);
                 constructors.add(new DatatypeCtor(declToOrigin(variableDecl, constructorName), constructorName, 
                         null, false, List.of()));
@@ -1183,7 +1183,7 @@ public class JavaToDafnyCompiler {
         // Only apply invariants to public instance methods (not static methods)
         if (isPublic && !isStaticMethod) {
             for(var invariant : invariants) {
-                var memberName = nameCompiler.mangleSymbolName(invariant);
+                var memberName = nameCompiler.getCompiledName(invariant);
                 var invariantName = getName(source, memberName);
                 var invariantOrigin = declToOrigin(source, invariantName);
                 ApplySuffix call = new ApplySuffix(invariantOrigin, new NameSegment(invariantOrigin,
@@ -1306,7 +1306,7 @@ public class JavaToDafnyCompiler {
                 }
 
                 // Remove the name qualification because we do not support that yet
-                var mangledName = nameCompiler.mangleSymbolName(classType.tsym);
+                var mangledName = nameCompiler.getCompiledName(classType.tsym);
                 var arguments = classType.getTypeArguments().map(a -> translateType(null, a, origin));
                 if (arguments.isEmpty()) {
                     arguments = null;
@@ -1318,7 +1318,7 @@ public class JavaToDafnyCompiler {
                 return new UserDefinedType(origin, nameSegment);
             }
             case com.sun.tools.javac.code.Type.TypeVar typeVar -> {
-                return new UserDefinedType(origin, new NameSegment(origin, nameCompiler.mangleSymbolName(typeVar.tsym), null));
+                return new UserDefinedType(origin, new NameSegment(origin, nameCompiler.getCompiledName(typeVar.tsym), null));
             }
             case null, default -> {
             }
@@ -1358,7 +1358,7 @@ public class JavaToDafnyCompiler {
     }
     
     Name getName(JCTree tree, Symbol symbol) {
-        return getName(tree, nameCompiler.mangleSymbolName(symbol), symbol.name.length());
+        return getName(tree, nameCompiler.getCompiledName(symbol), symbol.name.length());
     }
 
     Name getName(JCTree tree, String name) {

--- a/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
@@ -98,6 +98,9 @@ public class JavaToDafnyCompiler {
             discoverContractsAndTypeHierarchy((JCTree.JCCompilationUnit) compilationUnit);
             declarationsForFile.put(compilationUnit, new ArrayList<>());
         }
+        for(var compiledClass : declarationsForSymbolContract.keySet()) {
+            nameCompiler.registerClass(compiledClass);
+        }
         compileSymbolsTopologically();
 
         List<FileStart> filesStarts = new ArrayList<>();
@@ -535,10 +538,8 @@ public class JavaToDafnyCompiler {
 
             processVerifyAnnotation(annotationsByName);
 
-            Name name = getName(classDecl, classDecl.sym);
-            var origin = declToOrigin(classDecl, name);
-            contextOrigins.push(origin);
 
+            Name name = null;
             var contractAnnotation = annotationsByName.get(Contract.class.getName());
             if (contractAnnotation != null) {
                 var contractee = getContractTarget(classDecl, contractAnnotation);
@@ -558,9 +559,15 @@ public class JavaToDafnyCompiler {
                     
                     
                     typeForWhichCurrentClassIsDefiningContract = contractee;
-                    name = new Name(name.getOrigin(), nameCompiler.getCompiledName(typeForWhichCurrentClassIsDefiningContract));
+                    name = getName(classDecl, typeForWhichCurrentClassIsDefiningContract);
                 }
             }
+
+            if (name == null) {
+                name = getName(classDecl, classDecl.sym);
+            }
+            var origin = declToOrigin(classDecl, name);
+            contextOrigins.push(origin);
 
             List<? extends TopLevelDecl> result;
             if (isEnum(classDecl.type)) {

--- a/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
@@ -48,7 +48,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import static com.aws.jverify.verifier.NameMangler.CTOR_PREFIX;
+import static com.aws.jverify.verifier.NameCompiler.CTOR_PREFIX;
 
 public class JavaToDafnyCompiler {
     public static final String JVERIFY_CLASS = JVerify.class.getName();
@@ -57,7 +57,7 @@ public class JavaToDafnyCompiler {
     public final Set<Symbol.MethodSymbol> symbolsWithAContract = new HashSet<>();
     private final Stack<IOrigin> contextOrigins = new Stack<>();
     public final DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
-    public final NameMangler nameMangler = new NameMangler();
+    public final NameCompiler nameMangler = new NameCompiler();
     private JCDiagnostic.Factory diagnosticFactory;
 
     /**
@@ -84,7 +84,7 @@ public class JavaToDafnyCompiler {
                 : ShouldVerifyMode.DefaultNo);
     }
 
-    public NameMangler getNameMangler() {
+    public NameCompiler getNameMangler() {
         return nameMangler;
     }
     
@@ -947,7 +947,7 @@ public class JavaToDafnyCompiler {
         var methodCompiler = new BlockCompiler(this);
         Name name;
         if (typeForWhichCurrentClassIsDefiningContract != null && isConstructor(methodSymbol)) {
-            name = getName(source, NameMangler.getConstructorName(typeForWhichCurrentClassIsDefiningContract)); 
+            name = getName(source, NameCompiler.getConstructorName(typeForWhichCurrentClassIsDefiningContract)); 
         } else {
             name = getName(source, methodSymbol);
         }

--- a/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/JavaToDafnyCompiler.java
@@ -311,15 +311,6 @@ public class JavaToDafnyCompiler {
                 }
             }
             if (contractAnnotation == null) {
-                for(var member : classDecl.getMembers()) {
-                    if (!(member instanceof JCTree.JCMethodDecl methodDecl)) {
-                        continue;
-                    }
-                    // Don't report errors when extracting this contract here,
-                    // since the actual translation of the method will report them.
-                    var header = extractContract(methodDecl, false);
-                    methodContracts.put(methodDecl.sym, header);
-                }
                 var declsForSymbol = declarationsForSymbolContract.computeIfAbsent(classDecl.sym, (_) -> new ArrayList<>());
                 declsForSymbol.add(classDecl);
                 addHierarchyForSymbol(classDecl.sym);
@@ -531,6 +522,7 @@ public class JavaToDafnyCompiler {
     
     List<? extends TopLevelDecl> translateTypeDeclaration(Tree tree) {
         if (tree instanceof JCTree.JCClassDecl classDecl) {
+            
             var annotations = classDecl.getModifiers().getAnnotations();
             var annotationsByName = annotations.stream().collect(Collectors.toMap(
                     (JCTree.JCAnnotation a) -> a.getAnnotationType().type.toString(),
@@ -560,6 +552,16 @@ public class JavaToDafnyCompiler {
                     
                     typeForWhichCurrentClassIsDefiningContract = contractee;
                     name = getName(classDecl, typeForWhichCurrentClassIsDefiningContract);
+                }
+            } else {
+                for(var member : classDecl.getMembers()) {
+                    if (!(member instanceof JCTree.JCMethodDecl methodDecl)) {
+                        continue;
+                    }
+                    // Don't report errors when extracting this contract here,
+                    // since the actual translation of the method will report them.
+                    var header = extractContract(methodDecl, false);
+                    methodContracts.put(methodDecl.sym, header);
                 }
             }
 

--- a/verifier/src/main/java/com/aws/jverify/verifier/NameCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/NameCompiler.java
@@ -70,12 +70,13 @@ public class NameCompiler {
         if (symbolStringMap.containsKey(s)) {
             return symbolStringMap.get(s);
         }
-        var mangled = uncachedMangleSymbolName(s);
-        reverseSymbolStringMap.put(mangled, s);
-        return mangled;
+        var compiledName = uncachedGetSymbolName(s);
+        symbolStringMap.put(s, compiledName);
+        reverseSymbolStringMap.put(compiledName, s);
+        return compiledName;
     }
     
-    private String uncachedMangleSymbolName(Symbol s) {
+    private String uncachedGetSymbolName(Symbol s) {
         switch (s) {
             case Symbol.ClassSymbol classSymbol -> {
                 return classSymbol.getQualifiedName().toString().replace(".", "_");
@@ -85,7 +86,7 @@ public class NameCompiler {
             }
             case Symbol.VarSymbol varSymbol -> {
                 if (varSymbol.getKind().isField()) {
-                    return mangleFieldName(varSymbol);
+                    return getFieldName(varSymbol);
                 } else { // Local variable, do not mangle
                     return s.name.toString();
                 }
@@ -96,7 +97,7 @@ public class NameCompiler {
         }
     }
 
-    private String mangleFieldName(Symbol.VarSymbol s) {
+    private String getFieldName(Symbol.VarSymbol s) {
         if (s.name.contentEquals("this")) {
             return s.name.toString();
         }

--- a/verifier/src/main/java/com/aws/jverify/verifier/NameCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/NameCompiler.java
@@ -1,13 +1,10 @@
 package com.aws.jverify.verifier;
 
-import com.aws.jverify.generated.Name;
 import com.sun.tools.javac.code.Symbol;
 
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Type.*;
-import jdk.jshell.execution.Util;
 
-import javax.xml.transform.OutputKeys;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.List;
@@ -20,7 +17,7 @@ import java.util.List;
  *   - a suffix is added to all method names. This suffix encodes the parameter types, as given by the typeMangling
  *     method
  */
-public class NameMangler {
+public class NameCompiler {
     static private final String fieldPrefix = "F_";
     static private final String methodPrefix = "Z_";
     public static final String CTOR_PREFIX = "_ctor_";
@@ -57,7 +54,7 @@ public class NameMangler {
         }
     }
 
-    public NameMangler() {
+    public NameCompiler() {
         this.symbolStringMap = new HashMap<>();
         this.reverseSymbolStringMap = new HashMap<>();
     }

--- a/verifier/src/main/java/com/aws/jverify/verifier/NameCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/NameCompiler.java
@@ -56,7 +56,7 @@ public class NameCompiler {
     private String uncachedGetCompiledName(Symbol s) {
         switch (s) {
             case Symbol.ClassSymbol classSymbol -> {
-                if (classNameOccurrences.get(classSymbol.name) > 1) {
+                if (classNameOccurrences.computeIfAbsent(classSymbol.name, _ -> 2) > 1) {
                     return classSymbol.getQualifiedName().toString().replace(".", "_");
                 }
                 return classSymbol.name.toString();

--- a/verifier/src/main/java/com/aws/jverify/verifier/NameCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/NameCompiler.java
@@ -10,20 +10,23 @@ import java.util.Map;
 import java.util.List;
 
 /**
- * Update the name of all method and field names of symbols within a compilation unit
- * to ensure uniqueness. The mangling algorithm is deterministic and works as follows:
- *   - a prefix ("_F") is added to a field name
- *   - a prefix ("_Z") is added to method names (except constructors)
- *   - a suffix is added to all method names. This suffix encodes the parameter types, as given by the typeMangling
- *     method
+ * Maps names of symbols (classes, methods, fields) to compiled names to ensure uniqueness at the Dafny level.
+ * The name mapping works as follows:
+ *   - For fields that conflict with method names: prefix "F_" is added
+ *   - For methods that conflict with field names: prefix "Z_" is added
+ *   - For constructors: prefix "_ctor_" followed by the class name is used
+ *   - For overloaded methods: a suffix encoding parameter types is added (e.g. "_iCjava_lang_String")
+ *   - For classes with name collisions: fully qualified name with dots replaced by underscores
+ * 
+ * This class maintains bidirectional mappings between original and compiled names,
+ * allowing for name resolution in both directions.
  */
 public class NameCompiler {
     static private final String fieldPrefix = "F_";
     static private final String methodPrefix = "Z_";
     public static final String CTOR_PREFIX = "_ctor_";
 
-    // Map from symbols to mangled names
-    private final Map<com.sun.tools.javac.util.Name, Integer> classNameOccurrences = new HashMap<>();
+    private final Map<com.sun.tools.javac.util.Name, Integer> classNameOccurrenceCounts = new HashMap<>();
     private final Map<Symbol, String> symbolStringMap;
     private final Map<String, Symbol> reverseSymbolStringMap;
 
@@ -33,7 +36,7 @@ public class NameCompiler {
     }
     
     public void registerClass(Symbol.ClassSymbol classSymbol) {
-        classNameOccurrences.merge(classSymbol.name, 1, (a, b) -> a + 1);
+        classNameOccurrenceCounts.merge(classSymbol.name, 1, (a, b) -> a + 1);
     }
 
     public String safeGetOriginalName(String name) {
@@ -56,7 +59,7 @@ public class NameCompiler {
     private String uncachedGetCompiledName(Symbol s) {
         switch (s) {
             case Symbol.ClassSymbol classSymbol -> {
-                if (classNameOccurrences.computeIfAbsent(classSymbol.name, _ -> 2) > 1) {
+                if (classNameOccurrenceCounts.computeIfAbsent(classSymbol.name, _ -> 2) > 1) {
                     return classSymbol.getQualifiedName().toString().replace(".", "_");
                 }
                 return classSymbol.name.toString();
@@ -67,7 +70,7 @@ public class NameCompiler {
             case Symbol.VarSymbol varSymbol -> {
                 if (varSymbol.getKind().isField()) {
                     return getFieldName(varSymbol);
-                } else { // Local variable, do not mangle
+                } else { // Local variable, do not change
                     return s.name.toString();
                 }
             }
@@ -139,7 +142,7 @@ public class NameCompiler {
             case BOOLEAN: {return "z";}
             case CLASS: {
                 var classTypeStr = type.toString();
-                // Changing '.' to '_' so that the mangled name is a valid Dafny name
+                // Changing '.' to '_' so that the new name is a valid Dafny name
                 // TODO: test this for more complicated class names, e.g. when JCTypeApply is supported
                 return "C" + classTypeStr.replace('.','_');
             }

--- a/verifier/src/main/java/com/aws/jverify/verifier/NameCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/NameCompiler.java
@@ -59,24 +59,24 @@ public class NameCompiler {
         this.reverseSymbolStringMap = new HashMap<>();
     }
 
-    public String safeUnmangleName(String name) {
+    public String safeGetOriginalName(String name) {
         if (reverseSymbolStringMap.containsKey(name)) {
             return reverseSymbolStringMap.get(name).name.toString();
         }
         return name;
     }
 
-    public String mangleSymbolName(Symbol s) {
+    public String getCompiledName(Symbol s) {
         if (symbolStringMap.containsKey(s)) {
             return symbolStringMap.get(s);
         }
-        var compiledName = uncachedGetSymbolName(s);
+        var compiledName = uncachedGetCompiledName(s);
         symbolStringMap.put(s, compiledName);
         reverseSymbolStringMap.put(compiledName, s);
         return compiledName;
     }
     
-    private String uncachedGetSymbolName(Symbol s) {
+    private String uncachedGetCompiledName(Symbol s) {
         switch (s) {
             case Symbol.ClassSymbol classSymbol -> {
                 return classSymbol.getQualifiedName().toString().replace(".", "_");
@@ -91,7 +91,7 @@ public class NameCompiler {
                     return s.name.toString();
                 }
             }
-            case null, default -> {
+            default -> {
                 return s.name.toString();
             }
         }
@@ -109,20 +109,22 @@ public class NameCompiler {
     }
 
     private String getMethodName(Symbol.MethodSymbol s) {
-        String baseName = s.name.toString();
-
+        StringBuilder baseName = new StringBuilder();
+        
+                
         ClassNameStats result = getGetClassNameStats(s.enclClass(), s.name);
-        if (baseName.contentEquals("<init>")) {
+        if (s.name.equals(s.name.table.names.init)) {
             Symbol.ClassSymbol enclosingClass = s.enclClass();
-            baseName = getConstructorName(enclosingClass);
+            baseName.append(getConstructorName(enclosingClass));
         }
         else {
+            baseName.append(s.name);
             if (result.sameNameFields()) {
-                baseName = methodPrefix + baseName;
+                baseName.insert(0, methodPrefix);
             }
         }
         if (result.methodsWithThisName() == 1) {
-            return baseName;
+            return baseName.toString();
         }
         List<Type> argTypes;
         if (s.type instanceof MethodType m) {
@@ -130,14 +132,13 @@ public class NameCompiler {
         } else if (s.type instanceof DelegatedType dt){
             argTypes = dt.getParameterTypes();
         } else {
-            // Throw an exception
             throw new IllegalArgumentException(s.toString());
         }
-        baseName = (argTypes.isEmpty()) ? baseName : baseName+"_";
+        baseName = new StringBuilder(argTypes.isEmpty() ? baseName.toString() : baseName + "_");
         for (var param : argTypes) {
-            baseName += typeMangling(param);
+            baseName.append(typeMangling(param));
         }
-        return baseName;
+        return baseName.toString();
     }
 
     private static ClassNameStats getGetClassNameStats(Symbol.ClassSymbol clazz, com.sun.tools.javac.util.Name name) {

--- a/verifier/src/main/java/com/aws/jverify/verifier/NameCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/NameCompiler.java
@@ -109,36 +109,41 @@ public class NameCompiler {
     }
 
     private String getMethodName(Symbol.MethodSymbol s) {
-        StringBuilder baseName = new StringBuilder();
-        
+        StringBuilder result = new StringBuilder();
                 
-        ClassNameStats result = getGetClassNameStats(s.enclClass(), s.name);
+        ClassNameStats classStats = getGetClassNameStats(s.enclClass(), s.name);
         if (s.name.equals(s.name.table.names.init)) {
             Symbol.ClassSymbol enclosingClass = s.enclClass();
-            baseName.append(getConstructorName(enclosingClass));
+            result.append(getConstructorName(enclosingClass));
         }
         else {
-            baseName.append(s.name);
-            if (result.sameNameFields()) {
-                baseName.insert(0, methodPrefix);
+            if (classStats.sameNameFields()) {
+                result.append(methodPrefix);
             }
+            result.append(s.name);
         }
-        if (result.methodsWithThisName() == 1) {
-            return baseName.toString();
+        if (classStats.methodsWithThisName() == 1) {
+            return result.toString();
         }
+        addArgumentTypes(s, result);
+        return result.toString();
+    }
+
+    private static void addArgumentTypes(Symbol.MethodSymbol method, StringBuilder result) {
         List<Type> argTypes;
-        if (s.type instanceof MethodType m) {
+        if (method.type instanceof MethodType m) {
             argTypes = m.getParameterTypes();
-        } else if (s.type instanceof DelegatedType dt){
+        } else if (method.type instanceof DelegatedType dt) {
             argTypes = dt.getParameterTypes();
         } else {
-            throw new IllegalArgumentException(s.toString());
+            throw new IllegalArgumentException(method.toString());
         }
-        baseName = new StringBuilder(argTypes.isEmpty() ? baseName.toString() : baseName + "_");
-        for (var param : argTypes) {
-            baseName.append(typeMangling(param));
+        if (!argTypes.isEmpty()) {
+            result.append("_");
+            for (var param : argTypes) {
+                result.append(typeMangling(param));
+            }
         }
-        return baseName.toString();
     }
 
     private static ClassNameStats getGetClassNameStats(Symbol.ClassSymbol clazz, com.sun.tools.javac.util.Name name) {

--- a/verifier/src/main/java/com/aws/jverify/verifier/NameCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/NameCompiler.java
@@ -23,40 +23,17 @@ public class NameCompiler {
     public static final String CTOR_PREFIX = "_ctor_";
 
     // Map from symbols to mangled names
+    private final Map<com.sun.tools.javac.util.Name, Integer> classNameOccurrences = new HashMap<>();
     private final Map<Symbol, String> symbolStringMap;
     private final Map<String, Symbol> reverseSymbolStringMap;
-
-    private static String typeMangling(com.sun.tools.javac.code.Type type) {
-        switch (type.getTag()) {
-            case VOID : {return "v";}
-            case BYTE : {return "b";}
-            case CHAR : {return "c";}
-            case SHORT: {return "s";}
-            case INT : {return "i";}
-            case LONG : {return "l";}
-            case FLOAT :{return "f";}
-            case DOUBLE : {return "d";}
-            case BOOLEAN: {return "z";}
-            case CLASS: {
-                var classTypeStr = ((ClassType) type).toString();
-                // Changing '.' to '_' so that the mangled name is a valid Dafny name
-                // TODO: test this for more complicated class names, e.g. when JCTypeApply is supported
-                return "C" + classTypeStr.replace('.','_');
-            }
-            case ARRAY : {
-                var arrayType = (ArrayType) type;
-                var componentType = arrayType.getComponentType();
-                return "A" + typeMangling(componentType);
-            }
-            default : {
-                return type.toString();
-            }
-        }
-    }
 
     public NameCompiler() {
         this.symbolStringMap = new HashMap<>();
         this.reverseSymbolStringMap = new HashMap<>();
+    }
+    
+    public void registerClass(Symbol.ClassSymbol classSymbol) {
+        classNameOccurrences.merge(classSymbol.name, 1, (a, b) -> a + 1);
     }
 
     public String safeGetOriginalName(String name) {
@@ -79,7 +56,10 @@ public class NameCompiler {
     private String uncachedGetCompiledName(Symbol s) {
         switch (s) {
             case Symbol.ClassSymbol classSymbol -> {
-                return classSymbol.getQualifiedName().toString().replace(".", "_");
+                if (classNameOccurrences.get(classSymbol.name) > 1) {
+                    return classSymbol.getQualifiedName().toString().replace(".", "_");
+                }
+                return classSymbol.name.toString();
             }
             case Symbol.MethodSymbol m -> {
                 return getMethodName(m);
@@ -141,7 +121,35 @@ public class NameCompiler {
         if (!argTypes.isEmpty()) {
             result.append("_");
             for (var param : argTypes) {
-                result.append(typeMangling(param));
+                result.append(getShortTypeName(param));
+            }
+        }
+    }
+
+    private static String getShortTypeName(com.sun.tools.javac.code.Type type) {
+        switch (type.getTag()) {
+            case VOID : {return "v";}
+            case BYTE : {return "b";}
+            case CHAR : {return "c";}
+            case SHORT: {return "s";}
+            case INT : {return "i";}
+            case LONG : {return "l";}
+            case FLOAT :{return "f";}
+            case DOUBLE : {return "d";}
+            case BOOLEAN: {return "z";}
+            case CLASS: {
+                var classTypeStr = type.toString();
+                // Changing '.' to '_' so that the mangled name is a valid Dafny name
+                // TODO: test this for more complicated class names, e.g. when JCTypeApply is supported
+                return "C" + classTypeStr.replace('.','_');
+            }
+            case ARRAY : {
+                var arrayType = (ArrayType) type;
+                var componentType = arrayType.getComponentType();
+                return "A" + getShortTypeName(componentType);
+            }
+            default : {
+                return type.toString();
             }
         }
     }

--- a/verifier/src/main/java/com/aws/jverify/verifier/NameMangler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/NameMangler.java
@@ -1,10 +1,13 @@
 package com.aws.jverify.verifier;
 
+import com.aws.jverify.generated.Name;
 import com.sun.tools.javac.code.Symbol;
 
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Type.*;
+import jdk.jshell.execution.Util;
 
+import javax.xml.transform.OutputKeys;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.List;
@@ -81,11 +84,11 @@ public class NameMangler {
                 return classSymbol.getQualifiedName().toString().replace(".", "_");
             }
             case Symbol.MethodSymbol m -> {
-                return mangleMethodName(s);
+                return getMethodName(m);
             }
             case Symbol.VarSymbol varSymbol -> {
                 if (varSymbol.getKind().isField()) {
-                    return mangleFieldName(s);
+                    return mangleFieldName(varSymbol);
                 } else { // Local variable, do not mangle
                     return s.name.toString();
                 }
@@ -96,21 +99,32 @@ public class NameMangler {
         }
     }
 
-    private String mangleFieldName(Symbol s) {
+    private String mangleFieldName(Symbol.VarSymbol s) {
         if (s.name.contentEquals("this")) {
             return s.name.toString();
         }
-        return fieldPrefix + s.name.toString();
+        var classStats = getGetClassNameStats(s.enclClass(), s.name);
+        if (classStats.methodsWithThisName > 0) {
+            return fieldPrefix + s.name.toString();
+        }
+        return s.name.toString();
     }
 
-    private String mangleMethodName(Symbol s) {
+    private String getMethodName(Symbol.MethodSymbol s) {
         String baseName = s.name.toString();
+
+        ClassNameStats result = getGetClassNameStats(s.enclClass(), s.name);
         if (baseName.contentEquals("<init>")) {
             Symbol.ClassSymbol enclosingClass = s.enclClass();
             baseName = getConstructorName(enclosingClass);
         }
         else {
-            baseName = methodPrefix + baseName;
+            if (result.sameNameFields()) {
+                baseName = methodPrefix + baseName;
+            }
+        }
+        if (result.methodsWithThisName() == 1) {
+            return baseName;
         }
         List<Type> argTypes;
         if (s.type instanceof MethodType m) {
@@ -127,6 +141,22 @@ public class NameMangler {
         }
         return baseName;
     }
+
+    private static ClassNameStats getGetClassNameStats(Symbol.ClassSymbol clazz, com.sun.tools.javac.util.Name name) {
+        boolean sameNameFields = false;
+        int methodsWithThisName = 0;
+        for(var member : clazz.members().getSymbolsByName(name)) {
+            if (member instanceof Symbol.VarSymbol) {
+                sameNameFields = true;
+            }
+            if (member instanceof Symbol.MethodSymbol) {
+                methodsWithThisName += 1;
+            }
+        }
+        return new ClassNameStats(sameNameFields, methodsWithThisName);
+    }
+
+    private record ClassNameStats(boolean sameNameFields, int methodsWithThisName) {}
 
     public static String getConstructorName(Symbol.ClassSymbol enclosingClass) {
         return CTOR_PREFIX + enclosingClass.name.toString();

--- a/verifier/src/main/resources/additional.dfy
+++ b/verifier/src/main/resources/additional.dfy
@@ -19,5 +19,5 @@ function JString(s: string): jstring
 
 type byte = x | 0 <= x < 256
 
-type Float = real
-type Double = real
+type float = real
+type double = real

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/Allocate.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/Allocate.java
@@ -8,7 +8,6 @@ import static com.aws.jverify.JVerify.*;
 // Class that test the support of array allocation and accesses
 @JVerifyTest(dafnyVerified = 5, dafnyErrors = 0)
 class Allocate {
-
     public static IntPair allocateInReturn(int a, int b) {
         postcondition((IntPair p) -> fresh(p) &&  p.getA() == a);
         return new IntPair(a, b);
@@ -18,7 +17,6 @@ class Allocate {
         IntPair p = allocateInReturn(a,2);
         check(p.getA() == a);
     }
-
 }
 
 class IntPair {

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/Arrays.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/Arrays.java
@@ -38,7 +38,7 @@ class Arrays {
 
     static void pointArrayOfSize10() {
         Point[] a = new Point[10];
-//                  ^^^^^^^^^^^^^ Error: unless an initializer is provided for the array elements, a new array of 'com_aws_jverify_verifier_tests_Point' must have empty size
+//                  ^^^^^^^^^^^^^ Error: unless an initializer is provided for the array elements, a new array of 'Point' must have empty size
         a[0]=new Point(1,2);
         for (int i = 1; i < a.length; i++) {
             modifies(a);

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/ClassesExtendingClassesErrors.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/ClassesExtendingClassesErrors.java
@@ -13,14 +13,14 @@ class ExtenderErrors extends ExtendeeErrors {
     @Pure
     @Override
     public int pureVirtual(int input) {
-//             ^^^^^^^^^^^ Error: fully defined function 'Z_pureVirtual_i' is inherited from trait 'com_aws_jverify_verifier_tests_ExtendeeErrors' and is not allowed to be re-declared
+//             ^^^^^^^^^^^ Error: fully defined function 'pureVirtual' is inherited from trait 'ExtendeeErrors' and is not allowed to be re-declared
  
         return 3;
     }
     
     @Override
     public int impureVirtual() {
-//             ^^^^^^^^^^^^^ Error: fully defined method 'Z_impureVirtual' is inherited from trait 'com_aws_jverify_verifier_tests_ExtendeeErrors' and is not allowed to be re-declared
+//             ^^^^^^^^^^^^^ Error: fully defined method 'impureVirtual' is inherited from trait 'ExtendeeErrors' and is not allowed to be re-declared
 // Will be allowed in the future, and then we should move this to the Verification test
         postcondition((Integer r) -> r >= 20);
         return 20;


### PR DESCRIPTION
### What was changed?
- Renamed `MethodCompiler` to `BlockCompiler`, in preparation for creating an actual `MethodCompiler` in another PR
- Only qualify type names when that type name occurs more than once in the compiled output
- Only append parameter types to a method name if that method has overrides
- Only append field or method prefixes to either if there is a name collision
- No longer use the term `mangling` when determining compiled names, since we try to keep the original names.

### How has this been tested?
- Manually inspected names of generated code, to ensure this helps debuggability
- Relies on existing tests to ensure nothing breaks

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/aws/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
