### PR TITLE
Refactor use of classNameOccurrenceCounts.computeIfAbsent

### DIFF
--- a/verifier/src/main/java/com/aws/jverify/verifier/NameCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/NameCompiler.java
@@ -78,7 +78,8 @@ public class NameCompiler {
     private String uncachedGetCompiledName(Symbol s) {
         switch (s) {
             case Symbol.ClassSymbol classSymbol -> {
-                if (classNameOccurrenceCounts.computeIfAbsent(classSymbol.name, _ -> 2) > 1) {
+                var occurrenceCount = classNameOccurrenceCounts.get(classSymbol.name);
+                if (occurrenceCount == null || occurrenceCount > 1) {
                     return classSymbol.getQualifiedName().toString().replace(".", "_");
                 }
                 return classSymbol.name.toString();


### PR DESCRIPTION
### What was changed?
- Refactor use of `classNameOccurrenceCounts.computeIfAbsent`

### How has this been tested?
- Covered by existing test `MultiPackageTest.java`

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/aws/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
