### PR TITLE
Add support to Bigintegers through external contracts

### DIFF
--- a/test-engine/src/main/java/com/aws/jverify/testengine/JVerifyTest.java
+++ b/test-engine/src/main/java/com/aws/jverify/testengine/JVerifyTest.java
@@ -43,6 +43,8 @@ public @interface JVerifyTest {
      */
     boolean verifyByDefault() default true;
 
+    boolean useBuiltinContracts() default true;
+
     int exitCode() default 0;
 
     int dafnyVerified() default -1;

--- a/test-engine/src/main/java/com/aws/jverify/testengine/JVerifyTestEngine.java
+++ b/test-engine/src/main/java/com/aws/jverify/testengine/JVerifyTestEngine.java
@@ -286,7 +286,7 @@ public class JVerifyTestEngine extends HierarchicalTestEngine<EngineExecutionCon
                 Path.of("../build/temp.dfy"),
                 Path.of("../build/temp.dbin"),
                 true,
-                true,
+                annotation.useBuiltinContracts(),
                 true,
                 new String[] {
                         "--use-basename-for-filename",
@@ -309,7 +309,8 @@ public class JVerifyTestEngine extends HierarchicalTestEngine<EngineExecutionCon
     public static JVerifyTest makeJVerifyTestAnnotation(boolean verifyByDefault, int exitCode, 
                                                         int dafnyVerified, int dafnyErrors,
                                                         boolean resolvePrintedDafny,
-                                                        boolean avoidNameCollisions) {
+                                                        boolean avoidNameCollisions,
+                                                        boolean useBuiltinContracts) {
         return new JVerifyTest() {
             @Override
             public Class<? extends Annotation> annotationType() {
@@ -324,6 +325,11 @@ public class JVerifyTestEngine extends HierarchicalTestEngine<EngineExecutionCon
             @Override
             public boolean verifyByDefault() {
                 return verifyByDefault;
+            }
+
+            @Override
+            public boolean useBuiltinContracts() {
+                return useBuiltinContracts;
             }
 
             @Override

--- a/verifier/src/main/java/com/aws/jverify/verifier/compiler/simplifications/ExternalContractCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/compiler/simplifications/ExternalContractCompiler.java
@@ -24,6 +24,7 @@ public class ExternalContractCompiler {
     final JavaToDafnyCompiler compiler;
     public final Map<Symbol.ClassSymbol, List<JCTree.JCClassDecl>> declarationsForSymbolContract = new HashMap<>();
     public final Map<Symbol.ClassSymbol, ExternalTypeContract> externalContracts = new HashMap<>();
+    public Map<com.sun.tools.javac.code.Type, com.sun.tools.javac.code.Type> contractClassTypeToContracteeType = new HashMap<>();
     public LinkedHashMap<Symbol.ClassSymbol, Symbol.ClassSymbol> contractClassToContractee = new LinkedHashMap<>();
 
     public ExternalContractCompiler(JavaToDafnyCompiler compiler) {
@@ -75,6 +76,7 @@ public class ExternalContractCompiler {
             }
 
             this.contractClassToContractee.put(classDecl.sym, contracteeSymbol);
+            this.contractClassTypeToContracteeType.put(classDecl.sym.type, contracteeSymbol.type);
         }
     }
 

--- a/verifier/src/main/java/com/aws/jverify/verifier/compiler/simplifications/NameCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/compiler/simplifications/NameCompiler.java
@@ -135,7 +135,7 @@ public class NameCompiler {
         return result.toString();
     }
 
-    private static void addArgumentTypes(Symbol.MethodSymbol method, StringBuilder result) {
+    private void addArgumentTypes(Symbol.MethodSymbol method, StringBuilder result) {
         List<Type> argTypes;
         if (method.type instanceof MethodType m) {
             argTypes = m.getParameterTypes();
@@ -152,7 +152,7 @@ public class NameCompiler {
         }
     }
 
-    private static String getShortTypeName(com.sun.tools.javac.code.Type type) {
+    private String getShortTypeName(com.sun.tools.javac.code.Type type) {
         switch (type.getTag()) {
             case VOID : {return "v";}
             case BYTE : {return "b";}
@@ -164,7 +164,14 @@ public class NameCompiler {
             case DOUBLE : {return "d";}
             case BOOLEAN: {return "z";}
             case CLASS: {
-                var classTypeStr = type.toString();
+                var newType = this.contractCompiler.contractClassTypeToContracteeType.get(type);
+                String classTypeStr;
+                if (newType != null) {
+                    classTypeStr = newType.toString();
+                }
+                else {
+                    classTypeStr = type.toString();
+                }
                 // Changing '.' to '_' so that the new name is a valid Dafny name
                 // TODO: test this for more complicated class names, e.g. when JCTypeApply is supported
                 return "C" + classTypeStr.replace('.','_');
@@ -180,10 +187,14 @@ public class NameCompiler {
         }
     }
 
-    private static ClassNameStats getGetClassNameStats(Symbol.ClassSymbol clazz, com.sun.tools.javac.util.Name name) {
+    private ClassNameStats getGetClassNameStats(Symbol.ClassSymbol clazz, com.sun.tools.javac.util.Name name) {
         boolean sameNameFields = false;
         int methodsWithThisName = 0;
-        for(var member : clazz.members().getSymbolsByName(name)) {
+        var newClazz = this.contractCompiler.contractClassToContractee.get(clazz);
+        if (newClazz == null) {
+            newClazz = clazz;
+        }
+        for(var member : newClazz.members().getSymbolsByName(name)) {
             if (member instanceof Symbol.VarSymbol) {
                 sameNameFields = true;
             }

--- a/verifier/src/main/resources/builtin-contracts.java
+++ b/verifier/src/main/resources/builtin-contracts.java
@@ -102,41 +102,41 @@ class HelperForBigIntegerContract {
 
 @Contract(BigInteger.class)
 class BigIntegerContract  {
-    // Ghost field holding the value of the BigInteger
-    @Unbounded int ghostV;
+    // Field holding the value of the BigInteger
+    @Unbounded int intValue;
 
     BigIntegerContract(String val) {
         precondition(HelperForBigIntegerContract.isValidString(val));
-        postcondition(ghostV == HelperForBigIntegerContract.stringToInt(val));
+        postcondition(intValue == HelperForBigIntegerContract.stringToInt(val));
         throw new ContractException();
     }
 
     @Pure
     int intValue() {
         reads(this);
-        precondition(ghostV >= Integer.MIN_VALUE && ghostV <= Integer.MAX_VALUE);
-        postcondition((Integer b) -> b == ghostV);
+        precondition(intValue >= Integer.MIN_VALUE && intValue <= Integer.MAX_VALUE);
+        postcondition((Integer b) -> b == intValue);
         throw new ContractException();
     }
 
     BigIntegerContract add(BigIntegerContract v) {
-        postcondition((BigIntegerContract b) -> fresh(b) && b.ghostV == this.ghostV + v.ghostV);
+        postcondition((BigIntegerContract b) -> fresh(b) && b.intValue == this.intValue + v.intValue);
         throw new ContractException();
     }
 
     BigIntegerContract subtract(BigIntegerContract v) {
-        postcondition((BigIntegerContract b) -> fresh(b) && b.ghostV == this.ghostV - v.ghostV);
+        postcondition((BigIntegerContract b) -> fresh(b) && b.intValue == this.intValue - v.intValue);
         throw new ContractException();
     }
 
     BigIntegerContract multiply(BigIntegerContract v) {
-        postcondition((BigIntegerContract b) -> fresh(b) && b.ghostV == this.ghostV * v.ghostV);
+        postcondition((BigIntegerContract b) -> fresh(b) && b.intValue == this.intValue * v.intValue);
         throw new ContractException();
     }
 
     BigIntegerContract divide(BigIntegerContract v) {
-        precondition(v.ghostV != 0);
-        postcondition((BigIntegerContract b) -> fresh(b) && b.ghostV == this.ghostV / v.ghostV);
+        precondition(v.intValue != 0);
+        postcondition((BigIntegerContract b) -> fresh(b) && b.intValue == this.intValue / v.intValue);
         throw new ContractException();
     }
 
@@ -144,51 +144,51 @@ class BigIntegerContract  {
     int compareTo(BigIntegerContract v) {
         reads(this);
         reads(v);
-        postcondition((Integer r) -> (r < 0 && this.ghostV < v.ghostV) || (r == 0 && this.ghostV == v.ghostV) || (r > 0 && this.ghostV > v.ghostV));
+        postcondition((Integer r) -> (r < 0 && this.intValue < v.intValue) || (r == 0 && this.intValue == v.intValue) || (r > 0 && this.intValue > v.intValue));
         throw new ContractException();
     }
 
     BigIntegerContract abs() {
-        postcondition((BigIntegerContract b) -> fresh(b) && b.ghostV == (this.ghostV < 0 ? -this.ghostV : this.ghostV));
+        postcondition((BigIntegerContract b) -> fresh(b) && b.intValue == (this.intValue < 0 ? -this.intValue : this.intValue));
         throw new ContractException();
     }
 
     BigIntegerContract min(BigIntegerContract v) {
-        postcondition((BigIntegerContract b) -> fresh(b) && b.ghostV == (this.ghostV < v.ghostV ? this.ghostV : v.ghostV));
+        postcondition((BigIntegerContract b) -> fresh(b) && b.intValue == (this.intValue < v.intValue ? this.intValue : v.intValue));
         throw new ContractException();
     }
 
     BigIntegerContract max(BigIntegerContract v) {
-        postcondition((BigIntegerContract b) -> fresh(b) && b.ghostV == (this.ghostV > v.ghostV ? this.ghostV : v.ghostV));
+        postcondition((BigIntegerContract b) -> fresh(b) && b.intValue == (this.intValue > v.intValue ? this.intValue : v.intValue));
         throw new ContractException();
     }
 
     BigIntegerContract mod(BigIntegerContract v) {
-        precondition(v.ghostV != 0);
-        postcondition((BigIntegerContract b) -> fresh(b) && b.ghostV == this.ghostV % v.ghostV);
+        precondition(v.intValue != 0);
+        postcondition((BigIntegerContract b) -> fresh(b) && b.intValue == this.intValue % v.intValue);
         throw new ContractException();
     }
 
     BigIntegerContract negate() {
-        postcondition((BigIntegerContract b) -> fresh(b) && b.ghostV == -this.ghostV);
+        postcondition((BigIntegerContract b) -> fresh(b) && b.intValue == -this.intValue);
         throw new ContractException();
     }
 
     BigIntegerContract pow(int exponent) {
         precondition(exponent >= 0);
-        postcondition((BigIntegerContract b) -> fresh(b) && b.ghostV == HelperForBigIntegerContract.pow(ghostV, exponent));
+        postcondition((BigIntegerContract b) -> fresh(b) && b.intValue == HelperForBigIntegerContract.pow(intValue, exponent));
         throw new ContractException();
     }
 
     static BigIntegerContract valueOf(long val) {
-        postcondition((BigIntegerContract b) -> b.ghostV == val);
+        postcondition((BigIntegerContract b) -> b.intValue == val);
         throw new ContractException();
     }
 
     @Pure
     public int signum() {
         reads(this);
-        postcondition((Integer b) -> b == (ghostV < 0 ? -1 : ghostV == 0 ? 0 : 1));
+        postcondition((Integer b) -> b == (intValue < 0 ? -1 : intValue == 0 ? 0 : 1));
         throw new ContractException();
     }
 

--- a/verifier/src/main/resources/builtin-contracts.java
+++ b/verifier/src/main/resources/builtin-contracts.java
@@ -1,7 +1,11 @@
 package com.aws.jverify.builtin;
 
+import com.aws.jverify.*;
+import static com.aws.jverify.JVerify.*;
+import java.math.BigInteger;
 import com.aws.jverify.Contract;
 import com.aws.jverify.ContractException;
+import static com.aws.jverify.JVerify.check;
 
 import java.util.Collection;
 import java.util.List;
@@ -59,4 +63,133 @@ class DoubleContract {
 class LongContract {
     public static final long MIN_VALUE = 0x8000000000000000L;
     public static final long MAX_VALUE = 0x7fffffffffffffffL;
+}
+
+class HelperForBigIntegerContract {
+    @Erased
+    @Pure
+    static boolean isAllDigits(String v) {
+        return forall((Integer i) -> !(0<=i && i<v.length()) || (v.charAt(i) >= '0' && v.charAt(i) <= '9'));
+    }
+
+    @Erased
+    @Pure
+     static boolean isValidString(String v) {
+        return (v.length() == 0 ||
+                ((v.charAt(0) == '+' || v.charAt(0) == '-') && isAllDigits(v.substring(1))) ||
+                isAllDigits(v));
+    }
+    @Erased
+    @Pure
+    static @Unbounded int stringToInt(String v) {
+        decreases(v.length());
+        return
+                v.length() == 0 ? 0 :
+                        (v.charAt(0) == '+' ?
+                        stringToInt(v.substring(1)) :
+                        (v.charAt(0) == '-' ? -stringToInt(v.substring(1)) :
+                                (v.charAt(v.length()-1)-'0') + 10*stringToInt(v.substring(0,v.length()-1))
+                                ));
+    }
+
+    @Erased
+    @Pure
+    static @Unbounded int pow(@Unbounded int x, @Nat int n) {
+        decreases(n);
+        return (n == 0 ? 1 : x * pow(x, n-1));
+    }
+}
+
+@Contract(BigInteger.class)
+class BigIntegerContract  {
+    // Ghost field holding the value of the BigInteger
+    @Unbounded int ghostV;
+
+    BigIntegerContract(String val) {
+        precondition(HelperForBigIntegerContract.isValidString(val));
+        postcondition(ghostV == HelperForBigIntegerContract.stringToInt(val));
+        throw new ContractException();
+    }
+
+    @Pure
+    int intValue() {
+        reads(this);
+        precondition(ghostV >= Integer.MIN_VALUE && ghostV <= Integer.MAX_VALUE);
+        postcondition((Integer b) -> b == ghostV);
+        throw new ContractException();
+    }
+
+    BigIntegerContract add(BigIntegerContract v) {
+        postcondition((BigIntegerContract b) -> fresh(b) && b.ghostV == this.ghostV + v.ghostV);
+        throw new ContractException();
+    }
+
+    BigIntegerContract subtract(BigIntegerContract v) {
+        postcondition((BigIntegerContract b) -> fresh(b) && b.ghostV == this.ghostV - v.ghostV);
+        throw new ContractException();
+    }
+
+    BigIntegerContract multiply(BigIntegerContract v) {
+        postcondition((BigIntegerContract b) -> fresh(b) && b.ghostV == this.ghostV * v.ghostV);
+        throw new ContractException();
+    }
+
+    BigIntegerContract divide(BigIntegerContract v) {
+        precondition(v.ghostV != 0);
+        postcondition((BigIntegerContract b) -> fresh(b) && b.ghostV == this.ghostV / v.ghostV);
+        throw new ContractException();
+    }
+
+    @Pure
+    int compareTo(BigIntegerContract v) {
+        reads(this);
+        reads(v);
+        postcondition((Integer r) -> (r < 0 && this.ghostV < v.ghostV) || (r == 0 && this.ghostV == v.ghostV) || (r > 0 && this.ghostV > v.ghostV));
+        throw new ContractException();
+    }
+
+    BigIntegerContract abs() {
+        postcondition((BigIntegerContract b) -> fresh(b) && b.ghostV == (this.ghostV < 0 ? -this.ghostV : this.ghostV));
+        throw new ContractException();
+    }
+
+    BigIntegerContract min(BigIntegerContract v) {
+        postcondition((BigIntegerContract b) -> fresh(b) && b.ghostV == (this.ghostV < v.ghostV ? this.ghostV : v.ghostV));
+        throw new ContractException();
+    }
+
+    BigIntegerContract max(BigIntegerContract v) {
+        postcondition((BigIntegerContract b) -> fresh(b) && b.ghostV == (this.ghostV > v.ghostV ? this.ghostV : v.ghostV));
+        throw new ContractException();
+    }
+
+    BigIntegerContract mod(BigIntegerContract v) {
+        precondition(v.ghostV != 0);
+        postcondition((BigIntegerContract b) -> fresh(b) && b.ghostV == this.ghostV % v.ghostV);
+        throw new ContractException();
+    }
+
+    BigIntegerContract negate() {
+        postcondition((BigIntegerContract b) -> fresh(b) && b.ghostV == -this.ghostV);
+        throw new ContractException();
+    }
+
+    BigIntegerContract pow(int exponent) {
+        precondition(exponent >= 0);
+        postcondition((BigIntegerContract b) -> fresh(b) && b.ghostV == HelperForBigIntegerContract.pow(ghostV, exponent));
+        throw new ContractException();
+    }
+
+    static BigIntegerContract valueOf(long val) {
+        postcondition((BigIntegerContract b) -> b.ghostV == val);
+        throw new ContractException();
+    }
+
+    @Pure
+    public int signum() {
+        reads(this);
+        postcondition((Integer b) -> b == (ghostV < 0 ? -1 : ghostV == 0 ? 0 : 1));
+        throw new ContractException();
+    }
+
 }

--- a/verifier/src/test/java/com/aws/jverify/verifier/TestExamples.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/TestExamples.java
@@ -29,7 +29,7 @@ public class TestExamples {
     
     private void verifyPath(Path path, int exitCode, int dafnyVerified, int dafnyErrors) throws IOException {
         var markedSource = Files.readString(Path.of("../examples/src/test/java/com/aws/jverify/examples/").resolve(path));
-        var annotation = JVerifyTestEngine.makeJVerifyTestAnnotation(true, exitCode, dafnyVerified, dafnyErrors, false, false);
+        var annotation = JVerifyTestEngine.makeJVerifyTestAnnotation(true, exitCode, dafnyVerified, dafnyErrors, false, false, true);
         JVerifyTestEngine.testMarkedSource(new SourceFile(path, markedSource), annotation);
     }
 }

--- a/verifier/src/test/java/com/aws/jverify/verifier/TestVerifier.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/TestVerifier.java
@@ -50,7 +50,7 @@ public class TestVerifier {
     @Test
     public void javaError() throws IOException {
         var source = Common.getResourceFile(getClass(), "/JavaError.java");
-        var annotation = JVerifyTestEngine.makeJVerifyTestAnnotation(true, 2, -1, -1, false, false);
+        var annotation = JVerifyTestEngine.makeJVerifyTestAnnotation(true, 2, -1, -1, false, false, true);
         testMarkedSource(new SourceFile("JavaError.java", source), annotation);
     }
 

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/BigIntegers.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/BigIntegers.java
@@ -1,5 +1,5 @@
-// ^ /builtin-contracts.java(117:22-117:49) Related location: this proposition could not be proved
-// ^ /builtin-contracts.java(117:53-117:80) Related location: this proposition could not be proved
+// ^ /builtin-contracts.java(117:22-117:51) Related location: this proposition could not be proved
+// ^ /builtin-contracts.java(117:55-117:84) Related location: this proposition could not be proved
 
 package com.aws.jverify.verifier.tests;
 
@@ -15,34 +15,46 @@ import static com.aws.jverify.JVerify.*;
         "OnlyOneElementUsed",
         "StringOperationCanBeSimplified"
 })
-@JVerifyTest(exitCode = 4, dafnyVerified = 1, dafnyErrors = 4)
+@JVerifyTest(exitCode = 4, dafnyVerified = 2, dafnyErrors = 4)
 class BigIntegers {
-    static void test1() {
+    static void testConstructors() {
         BigInteger bi = new BigInteger("23");
         check(bi.intValue() == 23);
         BigInteger bbi = new BigInteger("1");
-        BigInteger res = bbi.add(bi);
-        check(res.intValue() == 24);
-        BigInteger bbi2 = BigInteger.valueOf(12345);
-        check(bbi2.intValue() == 12345);
+        check(bbi.intValue() == 1);
         BigInteger biNeg = new BigInteger("-2");
         check(biNeg.intValue() == -2);
+        BigInteger bbi2 = BigInteger.valueOf(12345);
+        check(bbi2.intValue() == 12345);
+    }
+
+    static void testComparisons() {
+        BigInteger bi = new BigInteger("23");
+        BigInteger biNeg = new BigInteger("-2");
         BigInteger biZero = BigInteger.valueOf(0);
         check(bi.signum() == 1);
         check(biNeg.signum() == -1);
         check(biZero.signum() == 0);
+        int cmp = bi.compareTo(biNeg);
+        check(cmp > 0);
+        BigInteger biAgain = new BigInteger("23");
+        cmp = bi.compareTo(biAgain);
+        check(cmp == 0);
+        cmp = biNeg.compareTo(biZero);
+        check(cmp < 0);
     }
 
     // Needs a bigger fuel on stringToInt function
-    static void test2() {
+    static void testConstructorNegative() {
         BigInteger bi = new BigInteger("234");
         check(bi.intValue() == 234);
 //      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Error: assertion might not hold
 //            ^^^^^^^^^^^^^ Error: function precondition could not be proved
 //            ^^^^^^^^^^^^^ Error: function precondition could not be proved
-// Remy: there are two failing preconditions (both on line 122 of builtin-contracts.java, the LHS and the RHS of the &&), that's why this is reported twice. 
+// There are two failing preconditions (both on line 117 of builtin-contracts.java, the LHS and the RHS of the &&), that's why this is reported twice.
     }
 
+    // Test all arithmetic operations on BigIntegers
     static void testArith() {
         BigInteger bi = new BigInteger("23");
         BigInteger two = new BigInteger("2");

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/BigIntegers.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/BigIntegers.java
@@ -1,0 +1,73 @@
+// ^ /builtin-contracts.java(117:22-117:49) Related location: this proposition could not be proved
+// ^ /builtin-contracts.java(117:53-117:80) Related location: this proposition could not be proved
+
+package com.aws.jverify.verifier.tests;
+
+import com.aws.jverify.testengine.JVerifyTest;
+
+import java.math.BigInteger;
+
+import static com.aws.jverify.JVerify.*;
+
+@SuppressWarnings({
+        "ConstantValue",
+        "SizeReplaceableByIsEmpty",
+        "OnlyOneElementUsed",
+        "StringOperationCanBeSimplified"
+})
+@JVerifyTest(exitCode = 4, dafnyVerified = 1, dafnyErrors = 4)
+class BigIntegers {
+    static void test1() {
+        BigInteger bi = new BigInteger("23");
+        check(bi.intValue() == 23);
+        BigInteger bbi = new BigInteger("1");
+        BigInteger res = bbi.add(bi);
+        check(res.intValue() == 24);
+        BigInteger bbi2 = BigInteger.valueOf(12345);
+        check(bbi2.intValue() == 12345);
+        BigInteger biNeg = new BigInteger("-2");
+        check(biNeg.intValue() == -2);
+        BigInteger biZero = BigInteger.valueOf(0);
+        check(bi.signum() == 1);
+        check(biNeg.signum() == -1);
+        check(biZero.signum() == 0);
+    }
+
+    // Needs a bigger fuel on stringToInt function
+    static void test2() {
+        BigInteger bi = new BigInteger("234");
+        check(bi.intValue() == 234);
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Error: assertion might not hold
+//            ^^^^^^^^^^^^^ Error: function precondition could not be proved
+//            ^^^^^^^^^^^^^ Error: function precondition could not be proved
+// Remy: there are two failing preconditions (both on line 122 of builtin-contracts.java, the LHS and the RHS of the &&), that's why this is reported twice. 
+    }
+
+    static void testArith() {
+        BigInteger bi = new BigInteger("23");
+        BigInteger two = new BigInteger("2");
+        BigInteger twentyFive = bi.add(two);
+        check(twentyFive.intValue() == 25);
+        BigInteger twentyOne = bi.subtract(two);
+        check(twentyOne.intValue() == 21);
+        BigInteger fortySix = bi.multiply(two);
+        check(fortySix.intValue() == 46);
+        BigInteger eleven = bi.divide(two);
+        check(eleven.intValue() == 11);
+        BigInteger one = bi.mod(two);
+        check(one.intValue() == 1);
+        BigInteger large = bi.pow(2);
+        check(large.intValue() == 529);
+        BigInteger minusTwentyThree = bi.negate();
+        check(minusTwentyThree.intValue() == -23);
+        BigInteger twentyThree = bi.abs();
+        check(twentyThree.intValue() == 23);
+        BigInteger twentyThreeAgain = minusTwentyThree.abs();
+        check(twentyThreeAgain.intValue() == 23);
+        BigInteger minusTwo = new BigInteger("-2");
+        BigInteger fail = bi.add(minusTwo);
+        check(fail.intValue() == 25);
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Error: assertion might not hold
+    }
+
+}

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/ExternalContractGhostField.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/ExternalContractGhostField.java
@@ -6,27 +6,27 @@ import com.aws.jverify.Pure;
 import com.aws.jverify.Unbounded;
 import com.aws.jverify.testengine.JVerifyTest;
 
-import java.math.BigInteger;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.aws.jverify.JVerify.*;
 
-@JVerifyTest(exitCode = 0, dafnyVerified = 8, dafnyErrors = 0)
+@JVerifyTest(exitCode = 0, dafnyVerified = 6, dafnyErrors = 0)
 public class ExternalContractGhostField {
-    static void test(BigIntegerContract v) {
+    static void test(AtomicIntegerContract v) {
         precondition(v.value == 1);
-        var b = v.add(v);
-        check(b.intValue() == 2);
+        var b = v.addAndGet(v.get());
+        check(b == 2);
     }
 }
 
-@Contract(BigInteger.class)
-class BigIntegerContract {
+@Contract(AtomicInteger.class)
+class AtomicIntegerContract {
     
     @Unbounded
     int value;
     
     @Pure
-    int intValue() {
+    int get() {
         reads(this);
         //noinspection ConstantValue
         precondition(value >= Integer.MIN_VALUE && value <= Integer.MAX_VALUE);
@@ -34,16 +34,17 @@ class BigIntegerContract {
         throw new ContractException();
     }
 
-    BigIntegerContract add(BigIntegerContract v) {
-        postcondition((BigIntegerContract b) -> b.value == this.value + v.value);
+    int addAndGet(int delta) {
+        postcondition((Integer b) -> b == this.value + delta);
         throw new ContractException();
     }
-    
+
     /*
     Test static pure bodyless method
-     */
+    TODO: re-add this test
     @Pure
-    public static BigInteger valueOf(long val) {
+    public static AtomicInteger valueOf(long val) {
         throw new ContractException();
     }
+     */
 }

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/ExternalContractGhostField.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/ExternalContractGhostField.java
@@ -6,45 +6,43 @@ import com.aws.jverify.Pure;
 import com.aws.jverify.Unbounded;
 import com.aws.jverify.testengine.JVerifyTest;
 
-import java.util.concurrent.atomic.AtomicInteger;
+import java.math.BigInteger;
 
 import static com.aws.jverify.JVerify.*;
 
-@JVerifyTest(exitCode = 0, dafnyVerified = 6, dafnyErrors = 0)
+@JVerifyTest(useBuiltinContracts = false, exitCode = 0, dafnyVerified = 8, dafnyErrors = 0)
 public class ExternalContractGhostField {
-    static void test(AtomicIntegerContract v) {
+    static void test(DummyBigIntegerContract v) {
         precondition(v.value == 1);
-        var b = v.addAndGet(v.get());
-        check(b == 2);
+        var b = v.add(v);
+        check(b.intValue() == 2);
     }
 }
 
-@Contract(AtomicInteger.class)
-class AtomicIntegerContract {
+@Contract(BigInteger.class)
+class DummyBigIntegerContract {
     
     @Unbounded
     int value;
     
     @Pure
-    int get() {
+    int intValue() {
         reads(this);
         //noinspection ConstantValue
-        precondition(value >= Integer.MIN_VALUE && value <= Integer.MAX_VALUE);
+        precondition(value >= -10 && value <= 10);
         postcondition((Integer r) -> r == value);
         throw new ContractException();
     }
 
-    int addAndGet(int delta) {
-        postcondition((Integer b) -> b == this.value + delta);
+    DummyBigIntegerContract add(DummyBigIntegerContract delta) {
+        postcondition((DummyBigIntegerContract b) -> b.value == this.value + delta.value);
         throw new ContractException();
     }
 
-    /*
-    Test static pure bodyless method
-    TODO: re-add this test
+
+    // Test static pure bodyless method
     @Pure
-    public static AtomicInteger valueOf(long val) {
+    public static DummyBigIntegerContract valueOf(long val) {
         throw new ContractException();
     }
-     */
 }


### PR DESCRIPTION
### What was changed?
Adds a class BigIntegerContract in our builtin-contracts.java file.
Adds contracts to most of the BigInteger functions.

### How has this been tested?
Added a test BigIntegers.java


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/aws/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
