### PR TITLE
Be robust to arrays with initializers

### DIFF
--- a/verifier/src/main/java/com/aws/jverify/verifier/compiler/BlockCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/compiler/BlockCompiler.java
@@ -5,6 +5,7 @@ import com.aws.jverify.common.Common;
 import com.aws.jverify.generated.*;
 import com.aws.jverify.verifier.compiler.simplifications.*;
 import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.TreeInfo;
 
@@ -492,11 +493,11 @@ public class BlockCompiler {
             case JCTree.JCNewArray newArray -> {
                 var arrayDimensions = newArray.getDimensions().stream().map(compiler.expressionCompiler::toExpr).toList();
                 var arrayInitializers = newArray.getInitializers();
-                var arrayJavaType = newArray.getType();
-                if (arrayJavaType instanceof JCTree.JCArrayTypeTree _) {
+                var arrayJavaType = ((com.sun.tools.javac.code.Type.ArrayType) newArray.type).elemtype;
+                if (arrayJavaType instanceof com.sun.tools.javac.code.Type.ArrayType) {
                     compiler.reportError(expr, "notSupported", "multi-dimensional arrays");
                 }
-                var arrayDafnyType = compiler.translateType(null, arrayJavaType.type, compiler.toOrigin(arrayJavaType));
+                var arrayDafnyType = compiler.translateType(null, arrayJavaType, compiler.toOrigin(newArray));
 
                 if (arrayInitializers != null && !arrayInitializers.isEmpty()) {
                     compiler.reportError(expr, "notSupported", "new array with initializers");

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/TranslationErrors.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/TranslationErrors.java
@@ -177,4 +177,9 @@ class TranslationErrors {
     }
 
     void foo() {}
+
+    void arrayWithInitializer() {
+        int[] arr = {1, 2, 3};
+//                  ^ error: new array with initializers is not supported
+    }
 }


### PR DESCRIPTION
### What was changed?
Fix crash described in #239
The reason was that according to the doc, the method getType() for a JCNewArray may return null in case of a new array with initializer

### How has this been tested?
Added a test case

Closes #239

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/aws/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
