### PR TITLE
Add contracts to some String methods

### DIFF
--- a/library/src/main/java/com/aws/jverify/JVerify.java
+++ b/library/src/main/java/com/aws/jverify/JVerify.java
@@ -88,6 +88,10 @@ public class JVerify {
         throw new VerificationMethodExecutedException();
     }
 
+    public static <T> boolean exists(Function<T, Boolean> predicate) {
+        throw new VerificationMethodExecutedException();
+    }
+
     public static <T1, T2> boolean forall(BiFunction<T1, T2, Boolean> predicate) {
         throw new VerificationMethodExecutedException();
     }

--- a/verifier/src/main/java/com/aws/jverify/verifier/compiler/ExpressionCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/compiler/ExpressionCompiler.java
@@ -85,6 +85,20 @@ public class ExpressionCompiler {
         return new NestedMatchExpr(origin, source, translatedCases, true, null);
     }
 
+    // Given a symbol, assumed to be a MethodSymbol, returns a new MethodSymbol with
+    // same name but with a new argument type prepended.
+    static private Symbol addReceiverType(Symbol sym, com.sun.tools.javac.code.Type typ) {
+        // Create a new symbol with same name but different type (one new argument)
+        var methodType = (com.sun.tools.javac.code.Type.MethodType) sym.type;
+        var newArgTypes = methodType.argtypes.prepend(typ);
+        var newMethodType =
+                new com.sun.tools.javac.code.Type.MethodType(
+                        newArgTypes, methodType.restype, methodType.thrown, null);
+        return new Symbol.MethodSymbol((long)0, sym.name,
+                newMethodType,
+                sym.owner);
+    }
+
     public Expression toExpr(JCTree.JCExpression expr) {
         return toExpr(expr, null);
     }
@@ -159,15 +173,18 @@ public class ExpressionCompiler {
 
                 var methodSymbol = TreeInfo.symbol(invocation.getMethodSelect());
                 var argBindings = invocation.getArguments().stream().map(a -> new ActualBinding(null, toExpr(a), false)).toList();
-
+                final com.sun.tools.javac.code.Type receiverType;
                 final Expression receiver;
                 if (invocation.getMethodSelect() instanceof JCTree.JCFieldAccess fieldAccess) {
                     receiver = toExpr(fieldAccess.selected);
+                    receiverType = fieldAccess.selected.type;
                 } else if (invocation.getMethodSelect() instanceof JCTree.JCIdent) {
                     receiver = null;
+                    receiverType = null;
                 } else {
                     compiler.reportError(invocation, "notSupported", "call via method reference");
                     receiver = JavaToDafnyCompiler.getHole(origin);
+                    receiverType = null;
                 }
 
                 if (methodSymbol.owner instanceof Symbol.ClassSymbol ownerClass
@@ -203,16 +220,12 @@ public class ExpressionCompiler {
                             yield new SeqSelectExpr(origin, false, receiver,
                                     argBindings.getFirst().getActual(), endIndex, null);
                         }
-                        case "indexOf" -> {
-                                var strSeg = new NameSegment(origin,"String", null);
-                                var callee = new ExprDotName(origin, strSeg, new Name(origin, "indexOf_Cjava_lang_Stringi"), null);
-                                var newArgBindings = new ArrayList<>(argBindings);
-                                newArgBindings.addFirst(new ActualBinding(null, receiver, false));
-                            yield new ApplySuffix(origin, callee, null, new ActualBindings(newArgBindings), null);
-                        }
-                        case "startsWith" -> {
-                            var strSeg = new NameSegment(origin,"String", null);
-                            var callee = new ExprDotName(origin, strSeg, new Name(origin, "startsWith_Cjava_lang_StringCjava_lang_String"), null);
+                        case "indexOf", "startsWith" -> {
+                            var strSeg = new NameSegment(origin, ownerClass.name.toString(), null);
+                            var newCalleeSymbol = addReceiverType(methodSymbol, receiverType);
+                            var calleeNameStr = compiler.nameCompiler.getCompiledName(newCalleeSymbol);
+                            var calleeName = new Name(origin, calleeNameStr);
+                            var callee = new ExprDotName(origin, strSeg,calleeName , null);
                             var newArgBindings = new ArrayList<>(argBindings);
                             newArgBindings.addFirst(new ActualBinding(null, receiver, false));
                             yield new ApplySuffix(origin, callee, null, new ActualBindings(newArgBindings), null);

--- a/verifier/src/main/java/com/aws/jverify/verifier/compiler/ExpressionCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/compiler/ExpressionCompiler.java
@@ -14,6 +14,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.TypeKind;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -185,7 +186,8 @@ public class ExpressionCompiler {
 
                 if (methodSymbol.owner instanceof Symbol.ClassSymbol ownerClass
                         && ownerClass.fullname.contentEquals(String.class.getName())) {
-                    return switch (methodSymbol.name.toString()) {
+                    return
+                        switch (methodSymbol.name.toString()) {
                         case "charAt" -> new SeqSelectExpr(origin, true, receiver,
                                 argBindings.getFirst().getActual(), null, null);
                         case "equals" -> new BinaryExpr(origin, BinaryExprOpcode.Eq, receiver,
@@ -200,6 +202,20 @@ public class ExpressionCompiler {
                                     : new UnaryOpExpr(origin, receiver, UnaryOpExprOpcode.Cardinality);
                             yield new SeqSelectExpr(origin, false, receiver,
                                     argBindings.getFirst().getActual(), endIndex, null);
+                        }
+                        case "indexOf" -> {
+                                var strSeg = new NameSegment(origin,"String", null);
+                                var callee = new ExprDotName(origin, strSeg, new Name(origin, "indexOf_Cjava_lang_Stringi"), null);
+                                var newArgBindings = new ArrayList<>(argBindings);
+                                newArgBindings.addFirst(new ActualBinding(null, receiver, false));
+                            yield new ApplySuffix(origin, callee, null, new ActualBindings(newArgBindings), null);
+                        }
+                        case "startsWith" -> {
+                            var strSeg = new NameSegment(origin,"String", null);
+                            var callee = new ExprDotName(origin, strSeg, new Name(origin, "startsWith_Cjava_lang_StringCjava_lang_String"), null);
+                            var newArgBindings = new ArrayList<>(argBindings);
+                            newArgBindings.addFirst(new ActualBinding(null, receiver, false));
+                            yield new ApplySuffix(origin, callee, null, new ActualBindings(newArgBindings), null);
                         }
                         default -> {
                             compiler.reportError(invocation, "notSupported", "String method " + methodSymbol);
@@ -465,15 +481,22 @@ public class ExpressionCompiler {
             case "contains" -> {
                 var element = toExpr(args.getFirst());
                 var seq = toExpr(receiver);
-                return new BinaryExpr(compiler.toOrigin(invocation), BinaryExprOpcode.In, element, seq);
+                return new BinaryExpr(origin, BinaryExprOpcode.In, element, seq);
             }
             case "old" -> {
                 var element = toExpr(args.getFirst());
-                return new OldExpr(compiler.toOrigin(invocation), element, null);
+                return new OldExpr(origin, element, null);
             }
             case "fresh" -> {
                 var element = toExpr(args.getFirst());
-                return new FreshExpr(compiler.toOrigin(invocation), element, null);
+                return new FreshExpr(origin, element, null);
+            }
+            case "implies" -> {
+                var antecedent = toExpr(args.getFirst());
+                var consequent = toExpr(args.getLast());
+                var notAntecedent = new UnaryOpExpr(origin, antecedent, UnaryOpExprOpcode.Not);
+                return new BinaryExpr(origin,BinaryExprOpcode.Or, notAntecedent, consequent);
+
             }
         }
 

--- a/verifier/src/main/java/com/aws/jverify/verifier/compiler/ExpressionCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/compiler/ExpressionCompiler.java
@@ -203,8 +203,7 @@ public class ExpressionCompiler {
 
                 if (methodSymbol.owner instanceof Symbol.ClassSymbol ownerClass
                         && ownerClass.fullname.contentEquals(String.class.getName())) {
-                    return
-                        switch (methodSymbol.name.toString()) {
+                    return switch (methodSymbol.name.toString()) {
                         case "charAt" -> new SeqSelectExpr(origin, true, receiver,
                                 argBindings.getFirst().getActual(), null, null);
                         case "equals" -> new BinaryExpr(origin, BinaryExprOpcode.Eq, receiver,

--- a/verifier/src/main/java/com/aws/jverify/verifier/compiler/ExpressionCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/compiler/ExpressionCompiler.java
@@ -220,7 +220,7 @@ public class ExpressionCompiler {
                             yield new SeqSelectExpr(origin, false, receiver,
                                     argBindings.getFirst().getActual(), endIndex, null);
                         }
-                        case "indexOf", "startsWith" -> {
+                        case "indexOf", "startsWith","concat" -> {
                             var strSeg = new NameSegment(origin, ownerClass.name.toString(), null);
                             var newCalleeSymbol = addReceiverType(methodSymbol, receiverType);
                             var calleeNameStr = compiler.nameCompiler.getCompiledName(newCalleeSymbol);

--- a/verifier/src/main/resources/builtin-contracts.java
+++ b/verifier/src/main/resources/builtin-contracts.java
@@ -1,15 +1,16 @@
 package com.aws.jverify.builtin;
 
 import com.aws.jverify.*;
-import static com.aws.jverify.JVerify.*;
+
 import java.math.BigInteger;
 import com.aws.jverify.Contract;
 import com.aws.jverify.ContractException;
-import static com.aws.jverify.JVerify.check;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.SequencedCollection;
+
+import static com.aws.jverify.JVerify.*;
 
 @Contract(Object.class)
 class ObjectContract {
@@ -63,6 +64,24 @@ class DoubleContract {
 class LongContract {
     public static final long MIN_VALUE = 0x8000000000000000L;
     public static final long MAX_VALUE = 0x7fffffffffffffffL;
+}
+
+@Contract(String.class)
+class StringContract {
+    @Pure
+    public static int indexOf(String s, int c) {
+        postcondition((Integer result) -> result == -1 || (0 <= result && result < s.length() && s.charAt(result) == c));
+        postcondition((Integer result) -> implies(result == -1, forall((Integer j) -> implies(0<=j&&j<s.length(),s.charAt(j)!=c))));
+        postcondition((Integer result) -> implies(result >= 0, forall((Integer j) -> implies(0<=j&&j<result,s.charAt(j)!=c))));
+        throw new ContractException();
+    }
+    @Pure
+    public static boolean startsWith(String s, String prefix) {
+        postcondition((Boolean b) -> implies(prefix.length() > s.length(),b==false));
+        postcondition((Boolean b) -> implies(prefix.length() <= s.length() && forall((Integer i) -> implies(0<=i && i<prefix.length(), prefix.charAt(i) == s.charAt(i))), b==true));
+        postcondition((Boolean b) -> implies(prefix.length() <= s.length() && exists((Integer i) -> 0<=i && i<prefix.length() && prefix.charAt(i) != s.charAt(i)), b==false));
+        throw  new ContractException();
+    }
 }
 
 class HelperForBigIntegerContract {

--- a/verifier/src/main/resources/builtin-contracts.java
+++ b/verifier/src/main/resources/builtin-contracts.java
@@ -209,4 +209,12 @@ class StringContract {
         postcondition((Boolean b) -> implies(prefix.length() <= s.length() && exists((Integer i) -> 0<=i && i<prefix.length() && prefix.charAt(i) != s.charAt(i)), b==false));
         throw  new ContractException();
     }
+
+    @Pure
+    public static String concat(String s1, String s2) {
+        postcondition((String s) -> s.length() == s1.length() + s2.length());
+        postcondition((String s) -> forall((Integer i) -> implies(0<=i&&i<s1.length(), s.charAt(i) == s1.charAt(i))));
+        postcondition((String s) -> forall((Integer i) -> implies(0<=i&&i<s2.length(), s.charAt(s1.length()+i) == s2.charAt(i))));
+        throw new ContractException();
+    }
 }

--- a/verifier/src/main/resources/builtin-contracts.java
+++ b/verifier/src/main/resources/builtin-contracts.java
@@ -3,8 +3,6 @@ package com.aws.jverify.builtin;
 import com.aws.jverify.*;
 
 import java.math.BigInteger;
-import com.aws.jverify.Contract;
-import com.aws.jverify.ContractException;
 
 import java.util.Collection;
 import java.util.List;
@@ -64,24 +62,6 @@ class DoubleContract {
 class LongContract {
     public static final long MIN_VALUE = 0x8000000000000000L;
     public static final long MAX_VALUE = 0x7fffffffffffffffL;
-}
-
-@Contract(String.class)
-class StringContract {
-    @Pure
-    public static int indexOf(String s, int c) {
-        postcondition((Integer result) -> result == -1 || (0 <= result && result < s.length() && s.charAt(result) == c));
-        postcondition((Integer result) -> implies(result == -1, forall((Integer j) -> implies(0<=j&&j<s.length(),s.charAt(j)!=c))));
-        postcondition((Integer result) -> implies(result >= 0, forall((Integer j) -> implies(0<=j&&j<result,s.charAt(j)!=c))));
-        throw new ContractException();
-    }
-    @Pure
-    public static boolean startsWith(String s, String prefix) {
-        postcondition((Boolean b) -> implies(prefix.length() > s.length(),b==false));
-        postcondition((Boolean b) -> implies(prefix.length() <= s.length() && forall((Integer i) -> implies(0<=i && i<prefix.length(), prefix.charAt(i) == s.charAt(i))), b==true));
-        postcondition((Boolean b) -> implies(prefix.length() <= s.length() && exists((Integer i) -> 0<=i && i<prefix.length() && prefix.charAt(i) != s.charAt(i)), b==false));
-        throw  new ContractException();
-    }
 }
 
 class HelperForBigIntegerContract {
@@ -211,4 +191,22 @@ class BigIntegerContract  {
         throw new ContractException();
     }
 
+}
+
+@Contract(String.class)
+class StringContract {
+    @Pure
+    public static int indexOf(String s, int c) {
+        postcondition((Integer result) -> result == -1 || (0 <= result && result < s.length() && s.charAt(result) == c));
+        postcondition((Integer result) -> implies(result == -1, forall((Integer j) -> implies(0<=j&&j<s.length(),s.charAt(j)!=c))));
+        postcondition((Integer result) -> implies(result >= 0, forall((Integer j) -> implies(0<=j&&j<result,s.charAt(j)!=c))));
+        throw new ContractException();
+    }
+    @Pure
+    public static boolean startsWith(String s, String prefix) {
+        postcondition((Boolean b) -> implies(prefix.length() > s.length(),b==false));
+        postcondition((Boolean b) -> implies(prefix.length() <= s.length() && forall((Integer i) -> implies(0<=i && i<prefix.length(), prefix.charAt(i) == s.charAt(i))), b==true));
+        postcondition((Boolean b) -> implies(prefix.length() <= s.length() && exists((Integer i) -> 0<=i && i<prefix.length() && prefix.charAt(i) != s.charAt(i)), b==false));
+        throw  new ContractException();
+    }
 }

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/BigIntegers.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/BigIntegers.java
@@ -1,5 +1,5 @@
-// ^ /builtin-contracts.java(117:22-117:51) Related location: this proposition could not be proved
-// ^ /builtin-contracts.java(117:55-117:84) Related location: this proposition could not be proved
+// ^ /builtin-contracts.java(116:22-116:51) Related location: this proposition could not be proved
+// ^ /builtin-contracts.java(116:55-116:84) Related location: this proposition could not be proved
 
 package com.aws.jverify.verifier.tests;
 

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/Strings.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/Strings.java
@@ -10,7 +10,7 @@ import static com.aws.jverify.JVerify.*;
         "OnlyOneElementUsed",
         "StringOperationCanBeSimplified"
 })
-@JVerifyTest(exitCode = 4, dafnyVerified = 11, dafnyErrors = 5)
+@JVerifyTest(exitCode = 4, dafnyVerified = 11, dafnyErrors = 6)
 class Strings {
     static void stringConcat(String str) {
         check((str + str).length() == 2 * str.length());
@@ -115,6 +115,17 @@ class Strings {
         check(s1.startsWith(s3));
         String s4 = s2.substring(1);
         check(s2.startsWith(s4));
+//      ^^^^^^^^^^^^^^^^^^^^^^^^ Error: assertion might not hold
+
+    }
+
+    static void testConcat(String s1, String s2) {
+        precondition(s1.length() == 3 && s2.length() == 5);
+        precondition(!s2.startsWith(s1));
+        String s3 = s1.concat(s2);
+        check(s3.length() == 8);
+        check(s3.startsWith(s1));
+        check(s3.startsWith(s2));
 //      ^^^^^^^^^^^^^^^^^^^^^^^^ Error: assertion might not hold
 
     }

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/Strings.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/Strings.java
@@ -10,7 +10,7 @@ import static com.aws.jverify.JVerify.*;
         "OnlyOneElementUsed",
         "StringOperationCanBeSimplified"
 })
-@JVerifyTest(exitCode = 4, dafnyVerified = 10, dafnyErrors = 3)
+@JVerifyTest(exitCode = 4, dafnyVerified = 11, dafnyErrors = 5)
 class Strings {
     static void stringConcat(String str) {
         check((str + str).length() == 2 * str.length());
@@ -85,5 +85,37 @@ class Strings {
         check(cat.charAt(0) == dog.charAt(0));
         check(cat.charAt(1) + 5 == dog.charAt(1));
         check((cat + dog).length() == 4);
+    }
+
+    static void testIndexOf() {
+        var hello = "hello";
+
+        check(hello.charAt(4) == 'o');
+        check(hello.indexOf('o')==4);   // Proven thanks to the check above
+        check(hello.indexOf('e')==1);  // Not proven due to Dafny limitation
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Error: assertion might not hold
+        check(hello.indexOf('3')==-1); // Proven without any help
+    }
+
+    static void testSubstring() {
+        var hello = "hello";
+        var he = "he";
+        var hellohello = "hellohello";
+        var hi = "f";
+        check(hello.startsWith(he));
+        check(!hello.startsWith(hellohello));
+        check(hi.charAt(0) != hello.charAt(0));
+        check(!hello.startsWith(hi));
+    }
+
+    static void testSubstring2(String s1, String s2) {
+        precondition(s1.startsWith(s2));
+        precondition(s2.length() > 3);
+        String s3 = s2.substring(0,1);
+        check(s1.startsWith(s3));
+        String s4 = s2.substring(1);
+        check(s2.startsWith(s4));
+//      ^^^^^^^^^^^^^^^^^^^^^^^^ Error: assertion might not hold
+
     }
 }


### PR DESCRIPTION
### What was changed?
Adding a `StringContract` class in `builtin-contracts.java` that defines contracts for some`String` methods by changing them to static methods taking an extra parameter (`this`). Modification in the `ExpressionCompiler` to transform calls to these methods like this:
`s1.substring(s2);`
into
`String.substring(s1,s2);`

### How has this been tested?
Extended Strings.java test


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/aws/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
