### PR TITLE
Change String encoding into a data-type

### DIFF
--- a/library/src/main/java/com/aws/jverify/JVerify.java
+++ b/library/src/main/java/com/aws/jverify/JVerify.java
@@ -88,6 +88,10 @@ public class JVerify {
         throw new VerificationMethodExecutedException();
     }
 
+    public static <T> boolean exists(Function<T, Boolean> predicate) {
+        throw new VerificationMethodExecutedException();
+    }
+
     public static <T1, T2> boolean forall(BiFunction<T1, T2, Boolean> predicate) {
         throw new VerificationMethodExecutedException();
     }

--- a/library/src/main/java/com/aws/jverify/JVerify.java
+++ b/library/src/main/java/com/aws/jverify/JVerify.java
@@ -88,6 +88,7 @@ public class JVerify {
         throw new VerificationMethodExecutedException();
     }
 
+
     public static <T1, T2> boolean forall(BiFunction<T1, T2, Boolean> predicate) {
         throw new VerificationMethodExecutedException();
     }

--- a/library/src/main/java/com/aws/jverify/JVerify.java
+++ b/library/src/main/java/com/aws/jverify/JVerify.java
@@ -88,7 +88,6 @@ public class JVerify {
         throw new VerificationMethodExecutedException();
     }
 
-
     public static <T1, T2> boolean forall(BiFunction<T1, T2, Boolean> predicate) {
         throw new VerificationMethodExecutedException();
     }

--- a/test-engine/src/main/java/com/aws/jverify/testengine/JVerifyTestEngine.java
+++ b/test-engine/src/main/java/com/aws/jverify/testengine/JVerifyTestEngine.java
@@ -180,6 +180,9 @@ public class JVerifyTestEngine extends HierarchicalTestEngine<EngineExecutionCon
                 .flatMap(diagnostic -> diagnostic instanceof DafnyDiagnostic dafnyDiagnostic
                         ? dafnyDiagnostic.flattenRelated()
                         : Stream.of(diagnostic))
+                .filter(d -> d instanceof DafnyDiagnostic dafnyDiagnostic
+                        ? !dafnyDiagnostic.location.filename().contentEquals("additional.dfy")
+                        : true)
                 .map(d -> diagnosticAsAnnotatedRange(sourceFile.toUri(), d))
                 .sorted()
                 .toList();

--- a/test-engine/src/main/java/com/aws/jverify/testengine/JVerifyTestEngine.java
+++ b/test-engine/src/main/java/com/aws/jverify/testengine/JVerifyTestEngine.java
@@ -180,6 +180,8 @@ public class JVerifyTestEngine extends HierarchicalTestEngine<EngineExecutionCon
                 .flatMap(diagnostic -> diagnostic instanceof DafnyDiagnostic dafnyDiagnostic
                         ? dafnyDiagnostic.flattenRelated()
                         : Stream.of(diagnostic))
+                // Remove diagnostics from "additional.dfy" file as they cannot be checked now by
+                // our test engine. And we probably want to localize them elsewhere anyway
                 .filter(d -> d instanceof DafnyDiagnostic dafnyDiagnostic
                         ? !dafnyDiagnostic.location.filename().contentEquals("additional.dfy")
                         : true)

--- a/verifier/src/main/java/com/aws/jverify/verifier/compiler/ExpressionCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/compiler/ExpressionCompiler.java
@@ -14,13 +14,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.TypeKind;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.stream.Stream;
 
 public class ExpressionCompiler {
      public final JavaToDafnyCompiler compiler;
+
+     private static final Set<String> supportedStringMethods = Set.of("equals", "concat", "startsWith", "substring", "isEmpty", "charAt", "length", "indexOf");
 
     public ExpressionCompiler(JavaToDafnyCompiler compiler) {
         this.compiler = compiler;
@@ -82,6 +82,20 @@ public class ExpressionCompiler {
 
         var source = toExpr(switchExpr.getExpression());
         return new NestedMatchExpr(origin, source, translatedCases, true, null);
+    }
+
+    // Given a symbol, assumed to be a MethodSymbol, returns a new MethodSymbol with
+    // same name but with a new argument type prepended.
+    static private Symbol addReceiverType(Symbol sym, com.sun.tools.javac.code.Type typ) {
+        // Create a new symbol with same name but different type (one new argument)
+        var methodType = (com.sun.tools.javac.code.Type.MethodType) sym.type;
+        var newArgTypes = methodType.argtypes.prepend(typ);
+        var newMethodType =
+                new com.sun.tools.javac.code.Type.MethodType(
+                        newArgTypes, methodType.restype, methodType.thrown, null);
+        return new Symbol.MethodSymbol((long)0, sym.name,
+                newMethodType,
+                sym.owner);
     }
 
     public Expression toExpr(JCTree.JCExpression expr) {
@@ -314,27 +328,10 @@ public class ExpressionCompiler {
 
         if (methodSymbol.owner instanceof Symbol.ClassSymbol ownerClass
                 && ownerClass.fullname.contentEquals(String.class.getName())) {
-            return switch (methodSymbol.name.toString()) {
-                case "charAt" -> new SeqSelectExpr(origin, true, receiver,
-                        argBindings.getFirst().getActual(), null, null);
-                case "equals" -> new BinaryExpr(origin, BinaryExprOpcode.Eq, receiver,
-                        argBindings.getFirst().getActual());
-                case "isEmpty" -> new BinaryExpr(origin, BinaryExprOpcode.Eq, receiver,
-                        new SeqDisplayExpr(origin, List.of()));
-                case "length" -> new UnaryOpExpr(
-                        origin, receiver, UnaryOpExprOpcode.Cardinality);
-                case "substring" -> {
-                    var endIndex = argBindings.size() == 2
-                            ? argBindings.get(1).getActual()
-                            : new UnaryOpExpr(origin, receiver, UnaryOpExprOpcode.Cardinality);
-                    yield new SeqSelectExpr(origin, false, receiver,
-                            argBindings.getFirst().getActual(), endIndex, null);
-                }
-                default -> {
+                 if (!supportedStringMethods.contains(methodSymbol.name.toString())) {
                     compiler.reportError(invocation, "notSupported", "String method " + methodSymbol);
-                    yield compiler.getHole(origin);
+                    return compiler.getHole(origin);
                 }
-            };
         }
 
         var target = toExpr(invocation.getMethodSelect());
@@ -358,6 +355,13 @@ public class ExpressionCompiler {
         var opName = operator.name.toString();
         if (leftType.getTag() == TypeTag.FLOAT || leftType.getTag() == TypeTag.DOUBLE) {
             compiler.reportError(node, "notSupported", "operator " + operator);
+        }
+
+        if (opName.equals("+") && leftType.toString().contentEquals(String.class.getName())) {
+            var callee = new ExprDotName(origin, left, new Name(origin, "concat"), null);
+            var arg = List.of(new ActualBinding(null, right, false));
+            return new ApplySuffix(origin, callee, null,
+                    new ActualBindings(arg), null);
         }
 
         if (opName.equals("==") || opName.equals("!=")) {
@@ -447,7 +451,6 @@ public class ExpressionCompiler {
         return List.of(symtab.stringType, symtab.recordType);
     }
 
-
     /**
      * Translates the given string literal to a Dafny expression (of type {@code jstring}).
      * For ease of debugging, the translation is the equivalent Dafny string literal
@@ -468,7 +471,8 @@ public class ExpressionCompiler {
                 // Fallback to sequence of numeric values
                 var charExprs = stringValue.chars().boxed()
                         .map(c -> (Expression) new LiteralExpr(origin, c)).toList();
-                return new SeqDisplayExpr(origin, charExprs);
+                return new ApplySuffix(origin, new NameSegment(origin, "JS", null), null,
+                        new ActualBindings(List.of(new ActualBinding(null, new SeqDisplayExpr(origin, charExprs), false))), null);
             }
         }
 

--- a/verifier/src/main/java/com/aws/jverify/verifier/compiler/ExpressionCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/compiler/ExpressionCompiler.java
@@ -83,21 +83,7 @@ public class ExpressionCompiler {
         var source = toExpr(switchExpr.getExpression());
         return new NestedMatchExpr(origin, source, translatedCases, true, null);
     }
-
-    // Given a symbol, assumed to be a MethodSymbol, returns a new MethodSymbol with
-    // same name but with a new argument type prepended.
-    static private Symbol addReceiverType(Symbol sym, com.sun.tools.javac.code.Type typ) {
-        // Create a new symbol with same name but different type (one new argument)
-        var methodType = (com.sun.tools.javac.code.Type.MethodType) sym.type;
-        var newArgTypes = methodType.argtypes.prepend(typ);
-        var newMethodType =
-                new com.sun.tools.javac.code.Type.MethodType(
-                        newArgTypes, methodType.restype, methodType.thrown, null);
-        return new Symbol.MethodSymbol((long)0, sym.name,
-                newMethodType,
-                sym.owner);
-    }
-
+    
     public Expression toExpr(JCTree.JCExpression expr) {
         return toExpr(expr, null);
     }

--- a/verifier/src/main/java/com/aws/jverify/verifier/compiler/ExpressionCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/compiler/ExpressionCompiler.java
@@ -14,13 +14,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.TypeKind;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.stream.Stream;
 
 public class ExpressionCompiler {
      public final JavaToDafnyCompiler compiler;
+
+     private static final Set<String> supportedStringMethods = Set.of("equals", "concat", "startsWith", "substring", "isEmpty", "charAt", "length", "indexOf");
 
     public ExpressionCompiler(JavaToDafnyCompiler compiler) {
         this.compiler = compiler;
@@ -314,27 +314,10 @@ public class ExpressionCompiler {
 
         if (methodSymbol.owner instanceof Symbol.ClassSymbol ownerClass
                 && ownerClass.fullname.contentEquals(String.class.getName())) {
-            return switch (methodSymbol.name.toString()) {
-                case "charAt" -> new SeqSelectExpr(origin, true, receiver,
-                        argBindings.getFirst().getActual(), null, null);
-                case "equals" -> new BinaryExpr(origin, BinaryExprOpcode.Eq, receiver,
-                        argBindings.getFirst().getActual());
-                case "isEmpty" -> new BinaryExpr(origin, BinaryExprOpcode.Eq, receiver,
-                        new SeqDisplayExpr(origin, List.of()));
-                case "length" -> new UnaryOpExpr(
-                        origin, receiver, UnaryOpExprOpcode.Cardinality);
-                case "substring" -> {
-                    var endIndex = argBindings.size() == 2
-                            ? argBindings.get(1).getActual()
-                            : new UnaryOpExpr(origin, receiver, UnaryOpExprOpcode.Cardinality);
-                    yield new SeqSelectExpr(origin, false, receiver,
-                            argBindings.getFirst().getActual(), endIndex, null);
-                }
-                default -> {
+                 if (!supportedStringMethods.contains(methodSymbol.name.toString())) {
                     compiler.reportError(invocation, "notSupported", "String method " + methodSymbol);
-                    yield compiler.getHole(origin);
+                    return compiler.getHole(origin);
                 }
-            };
         }
 
         var target = toExpr(invocation.getMethodSelect());
@@ -358,6 +341,13 @@ public class ExpressionCompiler {
         var opName = operator.name.toString();
         if (leftType.getTag() == TypeTag.FLOAT || leftType.getTag() == TypeTag.DOUBLE) {
             compiler.reportError(node, "notSupported", "operator " + operator);
+        }
+
+        if (opName.equals("+") && leftType.toString().contentEquals(String.class.getName())) {
+            var callee = new ExprDotName(origin, left, new Name(origin, "concat"), null);
+            var arg = List.of(new ActualBinding(null, right, false));
+            return new ApplySuffix(origin, callee, null,
+                    new ActualBindings(arg), null);
         }
 
         if (opName.equals("==") || opName.equals("!=")) {
@@ -447,7 +437,6 @@ public class ExpressionCompiler {
         return List.of(symtab.stringType, symtab.recordType);
     }
 
-
     /**
      * Translates the given string literal to a Dafny expression (of type {@code jstring}).
      * For ease of debugging, the translation is the equivalent Dafny string literal
@@ -468,7 +457,8 @@ public class ExpressionCompiler {
                 // Fallback to sequence of numeric values
                 var charExprs = stringValue.chars().boxed()
                         .map(c -> (Expression) new LiteralExpr(origin, c)).toList();
-                return new SeqDisplayExpr(origin, charExprs);
+                return new ApplySuffix(origin, new NameSegment(origin, "JS", null), null,
+                        new ActualBindings(List.of(new ActualBinding(null, new SeqDisplayExpr(origin, charExprs), false))), null);
             }
         }
 

--- a/verifier/src/main/java/com/aws/jverify/verifier/compiler/ExpressionCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/compiler/ExpressionCompiler.java
@@ -83,7 +83,7 @@ public class ExpressionCompiler {
         var source = toExpr(switchExpr.getExpression());
         return new NestedMatchExpr(origin, source, translatedCases, true, null);
     }
-    
+
     public Expression toExpr(JCTree.JCExpression expr) {
         return toExpr(expr, null);
     }
@@ -268,14 +268,13 @@ public class ExpressionCompiler {
             return new ApplySuffix(origin, new NameSegment(origin, fieldName, null),
                     null, new ActualBindings(List.of()), null);
         } else {
-            Expression selectedDafnyExpr = toExpr(fieldAccess.selected);
             boolean methodContainerTypeIsParameter = fieldAccess.selected.type instanceof com.sun.tools.javac.code.Type.TypeVar;
             if (methodContainerTypeIsParameter) {
                 var classType = fieldAccess.sym.enclClass().type;
                 // Dafny needs an explicit cast otherwise it won't find the members from the type parameter bounds
-                selectedDafnyExpr = new ConversionExpr(origin, selectedDafnyExpr, compiler.translateType(classType, origin), "");
+                selectedExpr = new ConversionExpr(origin, selectedExpr, compiler.translateType(classType, origin), "");
             }
-            return new ExprDotName(origin, selectedDafnyExpr, compiler.getName(fieldAccess, fieldName), null);
+            return new ExprDotName(origin, selectedExpr, compiler.getName(fieldAccess, fieldName), null);
         }
     }
 
@@ -288,14 +287,9 @@ public class ExpressionCompiler {
         var methodSymbol = TreeInfo.symbol(invocation.getMethodSelect());
         var argBindings = invocation.getArguments().stream().map(a -> new ActualBinding(null, toExpr(a), false)).toList();
 
-        final Expression receiver;
-        if (invocation.getMethodSelect() instanceof JCTree.JCFieldAccess fieldAccess) {
-            receiver = toExpr(fieldAccess.selected);
-        } else if (invocation.getMethodSelect() instanceof JCTree.JCIdent) {
-            receiver = null;
-        } else {
+        if (!((invocation.getMethodSelect() instanceof JCTree.JCFieldAccess fieldAccess) ||
+             (invocation.getMethodSelect() instanceof JCTree.JCIdent))) {
             compiler.reportError(invocation, "notSupported", "call via method reference");
-            receiver = JavaToDafnyCompiler.getHole(origin);
         }
 
         if (methodSymbol.owner instanceof Symbol.ClassSymbol ownerClass
@@ -306,6 +300,14 @@ public class ExpressionCompiler {
                     .filter(comp -> comp.name.equals(methodSymbol.name))
                     .findAny();
             if (component.isPresent()) {
+                final Expression receiver;
+                if (invocation.getMethodSelect() instanceof JCTree.JCFieldAccess fieldAccess) {
+                    receiver = toExpr(fieldAccess.selected);
+                } else if (invocation.getMethodSelect() instanceof JCTree.JCIdent) {
+                    receiver = null;
+                } else {
+                    receiver = JavaToDafnyCompiler.getHole(origin);
+                }
                 var fieldNameStr = compiler.nameCompiler.getCompiledName(component.get());
                 var fieldName = compiler.getName(invocation.getMethodSelect(), fieldNameStr);
                 return new ExprDotName(origin, receiver, fieldName, null);

--- a/verifier/src/main/java/com/aws/jverify/verifier/compiler/JavaToDafnyCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/compiler/JavaToDafnyCompiler.java
@@ -478,11 +478,13 @@ public class JavaToDafnyCompiler {
                 var className = classType.asElement().flatName();
                 if (className.toString().equals(String.class.getName())) {
                     if (!isNullable) {
-                        return new UserDefinedType(origin, new NameSegment(origin, "jstring", null));
+                        return new UserDefinedType(origin, new NameSegment(origin, "DString", null));
                     }
                     reportError(origin, "notSupported", "nullable String type");
                     return null;
                 }
+
+
 
                 if (isRecord(classType) && isNullable) {
                     reportError(origin, "notSupported", "nullable record type");

--- a/verifier/src/main/resources/additional.dfy
+++ b/verifier/src/main/resources/additional.dfy
@@ -9,13 +9,52 @@ type int64 = x: int | -0x8000_0000_0000_0000 <= x <= 0x7fff_ffff_ffff_ffff
 
 // Base type is int and not char, because Java's char allows surrogates and Dafny's char does not
 type char16 = i: int | 0x0000 <= i <= 0xffff
-type jstring = seq<char16>
+datatype DString = JS(elements: seq<char16>) {
+    function indexOf_i(c: char16) : (result:int32)
+        ensures -1 <= result < |this.elements|
+        ensures (result == -1 <==> forall i | 0 <= i < |this.elements| :: this.elements[i] != c)
+        ensures (result >= 0 <==> this.elements[result] == c &&   forall j| 0 <= j && j < result :: this.elements[j] != c)
 
-function JString(s: string): jstring
+     function length() : int {
+        |this.elements|
+        }
+      function charAt(x: int) : char16 {
+        this.elements[x]
+      }
+      function isEmpty() : bool {
+        this.elements == []
+      }
+      function concat(other: DString) : DString {
+        JS(this.elements + other.elements)
+      }
+    function substring_i(start: int) : DString
+      requires start >= 0 && start < |this.elements|
+    {
+      JS(this.elements[start..])
+    }
+    function substring_ii(start: int, end:int) : DString
+        requires start >= 0 && start <= end && end < |this.elements|
+    {
+      JS(this.elements[start..end])
+    }
+    function equals(other: DString) : (b: bool)
+    {
+      this.elements == other.elements
+    }
+
+    function startsWith_Cjava_lang_String(other : DString) : (b : bool)
+        ensures( |other.elements| > |this.elements| ==> b==false)
+        ensures( |other.elements| <= |this.elements| && (forall i | 0 <= i < |other.elements| :: other.elements[i] == this.elements[i]) ==> b == true)
+        ensures( |other.elements| <= |this.elements| && (exists i | 0 <= i < |other.elements| :: other.elements[i] != this.elements[i]) ==> b == false)
+
+}
+
+function JString(s: string): DString
   requires forall i | 0 <= i < |s| :: 0x0000 <= s[i] as int <= 0xffff
 {
-  seq(|s|, i requires 0 <= i < |s| => s[i] as char16)
+  JS(seq(|s|, i requires 0 <= i < |s| => s[i] as char16))
 }
+
 
 type byte = x | 0 <= x < 256
 

--- a/verifier/src/main/resources/additional.dfy
+++ b/verifier/src/main/resources/additional.dfy
@@ -13,12 +13,14 @@ datatype DString = JS(elements: seq<char16>) {
     function indexOf_i(c: char16) : (result:int32)
         ensures -1 <= result < |this.elements|
         ensures (result == -1 <==> forall i | 0 <= i < |this.elements| :: this.elements[i] != c)
-        ensures (result >= 0 <==> this.elements[result] == c &&   forall j| 0 <= j && j < result :: this.elements[j] != c)
+        ensures (result >= 0 && result<|this.elements| ==> this.elements[result] == c &&   forall j| 0 <= j && j < result :: this.elements[j] != c)
 
      function length() : int {
         |this.elements|
         }
-      function charAt(x: int) : char16 {
+      function charAt(x: int) : char16
+        requires 0<=x<|this.elements|
+      {
         this.elements[x]
       }
       function isEmpty() : bool {

--- a/verifier/src/main/resources/additional.dfy
+++ b/verifier/src/main/resources/additional.dfy
@@ -31,12 +31,12 @@ datatype DString = JS(elements: seq<char16>) {
         JS(this.elements + other.elements)
       }
     function substring_i(start: int) : DString
-      requires start >= 0 && start < |this.elements|
+      requires start >= 0 && start <= |this.elements|
     {
       JS(this.elements[start..])
     }
     function substring_ii(start: int, end:int) : DString
-        requires start >= 0 && start <= end && end < |this.elements|
+        requires start >= 0 && start <= end && end <= |this.elements|
     {
       JS(this.elements[start..end])
     }

--- a/verifier/src/main/resources/builtin-contracts.java
+++ b/verifier/src/main/resources/builtin-contracts.java
@@ -1,5 +1,7 @@
 package com.aws.jverify.builtin;
 
+import com.aws.jverify.*;
+import static com.aws.jverify.JVerify.*;
 
 import java.math.BigInteger;
 import com.aws.jverify.Contract;

--- a/verifier/src/main/resources/builtin-contracts.java
+++ b/verifier/src/main/resources/builtin-contracts.java
@@ -1,7 +1,6 @@
 package com.aws.jverify.builtin;
 
-import com.aws.jverify.*;
-import static com.aws.jverify.JVerify.*;
+
 import java.math.BigInteger;
 import com.aws.jverify.Contract;
 import com.aws.jverify.ContractException;

--- a/verifier/src/main/resources/builtin-contracts.java
+++ b/verifier/src/main/resources/builtin-contracts.java
@@ -1,15 +1,14 @@
 package com.aws.jverify.builtin;
 
 import com.aws.jverify.*;
-import static com.aws.jverify.JVerify.*;
+
 import java.math.BigInteger;
-import com.aws.jverify.Contract;
-import com.aws.jverify.ContractException;
-import static com.aws.jverify.JVerify.check;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.SequencedCollection;
+
+import static com.aws.jverify.JVerify.*;
 
 @Contract(Object.class)
 class ObjectContract {
@@ -193,3 +192,4 @@ class BigIntegerContract  {
     }
 
 }
+

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/BigIntegers.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/BigIntegers.java
@@ -1,5 +1,5 @@
-// ^ /builtin-contracts.java(117:22-117:51) Related location: this proposition could not be proved
-// ^ /builtin-contracts.java(117:55-117:84) Related location: this proposition could not be proved
+// ^ /builtin-contracts.java(116:22-116:51) Related location: this proposition could not be proved
+// ^ /builtin-contracts.java(116:55-116:84) Related location: this proposition could not be proved
 
 package com.aws.jverify.verifier.tests;
 

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/BigIntegers.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/BigIntegers.java
@@ -1,6 +1,3 @@
-// ^ /builtin-contracts.java(116:22-116:51) Related location: this proposition could not be proved
-// ^ /builtin-contracts.java(116:55-116:84) Related location: this proposition could not be proved
-
 package com.aws.jverify.verifier.tests;
 
 import com.aws.jverify.testengine.JVerifyTest;
@@ -15,7 +12,7 @@ import static com.aws.jverify.JVerify.*;
         "OnlyOneElementUsed",
         "StringOperationCanBeSimplified"
 })
-@JVerifyTest(exitCode = 4, dafnyVerified = 2, dafnyErrors = 4, useBuiltinContracts = true)
+@JVerifyTest(exitCode = 4, dafnyVerified = 2, dafnyErrors = 2, useBuiltinContracts = true)
 class BigIntegers {
     static void testConstructors() {
         BigInteger bi = new BigInteger("23");
@@ -46,12 +43,9 @@ class BigIntegers {
 
     // Needs a bigger fuel on stringToInt function
     static void testConstructorNegative() {
-        BigInteger bi = new BigInteger("234");
-        check(bi.intValue() == 234);
-//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Error: assertion might not hold
-//            ^^^^^^^^^^^^^ Error: function precondition could not be proved
-//            ^^^^^^^^^^^^^ Error: function precondition could not be proved
-// There are two failing preconditions (both on line 117 of builtin-contracts.java, the LHS and the RHS of the &&), that's why this is reported twice.
+        BigInteger bi = new BigInteger("23456");
+        check(bi.intValue() == 23456);
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Error: assertion might not hold
     }
 
     // Test all arithmetic operations on BigIntegers

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/Strings.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/Strings.java
@@ -92,12 +92,7 @@ class Strings {
 
         check(hello.charAt(4) == 'o');
         check(hello.indexOf('o')==4);   // Proven thanks to the check above
-<<<<<<< HEAD
         check(hello.indexOf('e')==1);
-=======
-        check(hello.indexOf('e')==1);  // Not proven due to Dafny limitation
-//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Error: assertion might not hold
->>>>>>> 4e55ad50e732048c504519219c15d2a001528ada
         check(hello.indexOf('3')==-1); // Proven without any help
     }
 

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/Strings.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/Strings.java
@@ -10,7 +10,7 @@ import static com.aws.jverify.JVerify.*;
         "OnlyOneElementUsed",
         "StringOperationCanBeSimplified"
 })
-@JVerifyTest(exitCode = 4, dafnyVerified = 12, dafnyErrors = 5)
+@JVerifyTest(exitCode = 4, dafnyVerified = 11, dafnyErrors = 6)
 class Strings {
     static void stringConcat(String str) {
         check((str + str).length() == 2 * str.length());

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/Strings.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/Strings.java
@@ -93,6 +93,9 @@ class Strings {
         check(hello.charAt(4) == 'o');
         check(hello.indexOf('o')==4);   // Proven thanks to the check above
         check(hello.indexOf('e')==1);
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ // Error: assertion might not hold
+// The assertion above fails in CI but not on a local machine, instability probably due to the recursive function
+// indexOf that may require too much verifier capacity
         check(hello.indexOf('3')==-1); // Proven without any help
     }
 

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/Strings.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/Strings.java
@@ -93,7 +93,7 @@ class Strings {
         check(hello.charAt(4) == 'o');
         check(hello.indexOf('o')==4);   // Proven thanks to the check above
         check(hello.indexOf('e')==1);
-//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ // Error: assertion might not hold
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Error: assertion might not hold
 // The assertion above fails in CI but not on a local machine, instability probably due to the recursive function
 // indexOf that may require too much verifier capacity
         check(hello.indexOf('3')==-1); // Proven without any help

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/Strings.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/Strings.java
@@ -10,7 +10,7 @@ import static com.aws.jverify.JVerify.*;
         "OnlyOneElementUsed",
         "StringOperationCanBeSimplified"
 })
-@JVerifyTest(exitCode = 4, dafnyVerified = 11, dafnyErrors = 6)
+@JVerifyTest(exitCode = 4, dafnyVerified = 12, dafnyErrors = 5)
 class Strings {
     static void stringConcat(String str) {
         check((str + str).length() == 2 * str.length());
@@ -92,8 +92,7 @@ class Strings {
 
         check(hello.charAt(4) == 'o');
         check(hello.indexOf('o')==4);   // Proven thanks to the check above
-        check(hello.indexOf('e')==1);  // Not proven due to Dafny limitation
-//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Error: assertion might not hold
+        check(hello.indexOf('e')==1);
         check(hello.indexOf('3')==-1); // Proven without any help
     }
 

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/Strings.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/Strings.java
@@ -1,8 +1,3 @@
-// ^ /additional.dfy(25:22-25:24) Related location: this proposition could not be proved
-// ^ /additional.dfy(42:20-42:22) Related location: this proposition could not be proved
-
-
-
 package com.aws.jverify.verifier.tests;
 
 import com.aws.jverify.testengine.JVerifyTest;
@@ -37,7 +32,7 @@ class Strings {
 
     static void stringNotEqual() {
         check("hello world".equals("helloworld"));
-//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Error: assertion might not hold
+//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Error: assertion might not hold
     }
 
     static void stringIsEmpty(String str) {
@@ -46,7 +41,7 @@ class Strings {
 
     static void stringNotEmpty() {
         check("full".isEmpty());
-//      ^^^^^^^^^^^^^^^^^^^^^^^ Error: assertion might not hold
+//            ^^^^^^^^^^^^^^^^ Error: assertion might not hold
     }
 
     static boolean stringLengthEven(String str) {

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/Strings.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/Strings.java
@@ -1,3 +1,8 @@
+// ^ /additional.dfy(25:22-25:24) Related location: this proposition could not be proved
+// ^ /additional.dfy(42:20-42:22) Related location: this proposition could not be proved
+
+
+
 package com.aws.jverify.verifier.tests;
 
 import com.aws.jverify.testengine.JVerifyTest;
@@ -10,7 +15,7 @@ import static com.aws.jverify.JVerify.*;
         "OnlyOneElementUsed",
         "StringOperationCanBeSimplified"
 })
-@JVerifyTest(exitCode = 4, dafnyVerified = 10, dafnyErrors = 3)
+@JVerifyTest(exitCode = 4, dafnyVerified = 11, dafnyErrors = 6)
 class Strings {
     static void stringConcat(String str) {
         check((str + str).length() == 2 * str.length());
@@ -85,5 +90,48 @@ class Strings {
         check(cat.charAt(0) == dog.charAt(0));
         check(cat.charAt(1) + 5 == dog.charAt(1));
         check((cat + dog).length() == 4);
+    }
+
+    static void testIndexOf() {
+        var hello = "hello";
+
+        check(hello.charAt(4) == 'o');
+        check(hello.indexOf('o')==4);   // Proven thanks to the check above
+        check(hello.indexOf('e')==1);  // Not proven due to Dafny limitation
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Error: assertion might not hold
+        check(hello.indexOf('3')==-1); // Proven without any help
+    }
+
+    static void testSubstring() {
+        var hello = "hello";
+        var he = "he";
+        var hellohello = "hellohello";
+        var hi = "f";
+        check(hello.startsWith(he));
+        check(!hello.startsWith(hellohello));
+        check(hi.charAt(0) != hello.charAt(0));
+        check(!hello.startsWith(hi));
+    }
+
+    static void testSubstring2(String s1, String s2) {
+        precondition(s1.startsWith(s2));
+        precondition(s2.length() > 3);
+        String s3 = s2.substring(0,1);
+        check(s1.startsWith(s3));
+        String s4 = s2.substring(1);
+        check(s2.startsWith(s4));
+//      ^^^^^^^^^^^^^^^^^^^^^^^^ Error: assertion might not hold
+
+    }
+
+    static void testConcat(String s1, String s2) {
+        precondition(s1.length() == 3 && s2.length() == 5);
+        precondition(!s2.startsWith(s1));
+        String s3 = s1.concat(s2);
+        check(s3.length() == 8);
+        check(s3.startsWith(s1));
+        check(s3.startsWith(s2));
+//      ^^^^^^^^^^^^^^^^^^^^^^^^ Error: assertion might not hold
+
     }
 }


### PR DESCRIPTION
### What was changed?
Convert Java `String` into a data-type containing a `seq<char16> `and implementation of the Java methods in this datatype. This allows for a more uniform handling of the `String` class in `ExpressionCompiler.java`

Minor change: ensure that toExpr is only called once per method invocation, to avoid duplicate error messages.

### How has this been tested?
Extended the `Strings.java` test


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/aws/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
