### PR TITLE
Rename ValueObject to Object and Object to ModifiableObject

### DIFF
--- a/verifier/src/main/java/com/aws/jverify/verifier/compiler/ClassCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/compiler/ClassCompiler.java
@@ -195,7 +195,8 @@ public class ClassCompiler {
                     // Contains because when we're verifying the built-in file itself, the path is different.
                     !this.compiler.compilationUnit.getSourceFile().getName().contains(JavaToDafnyCompiler.builtinFile)) {
                 // the above condition should be replaced with true once we stop translating boxed primitives to unboxed ones.
-                bounds = bounds.append(new UserDefinedType(origin, new NameSegment(origin, "ValueObject", null)));
+                bounds = bounds.append(new UserDefinedType(origin, 
+                        new NameSegment(origin, JavaToDafnyCompiler.REFERENCE_OR_VALUE_OBJECT_NAME, null)));
             }
             return new TypeParameter(origin,
                     name, null, TPVarianceSyntax.NonVariant_Strict,

--- a/verifier/src/main/java/com/aws/jverify/verifier/compiler/JavaToDafnyCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/compiler/JavaToDafnyCompiler.java
@@ -16,11 +16,8 @@ import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symtab;
 import com.sun.tools.javac.code.TypeMetadata;
 import com.sun.tools.javac.code.Types;
-import com.sun.tools.javac.comp.AttrContext;
-import com.sun.tools.javac.comp.Env;
 import com.sun.tools.javac.tree.EndPosTable;
 import com.sun.tools.javac.tree.JCTree;
-import com.sun.tools.javac.comp.Enter;
 
 import com.sun.tools.javac.tree.TreeInfo;
 import com.aws.jverify.generated.*;
@@ -44,6 +41,7 @@ import java.util.stream.Collectors;
 
 public class JavaToDafnyCompiler {
     public static final String JVERIFY_CLASS = JVerify.class.getName();
+    public static final String REFERENCE_OR_VALUE_OBJECT_NAME = "Object";
     public final Context context;
 
     public final Set<Symbol.MethodSymbol> symbolsWithAContract = new HashSet<>();
@@ -486,7 +484,7 @@ public class JavaToDafnyCompiler {
                 if (isAnnotated(modifiers, com.aws.jverify.Immutable.class)) {
                     Symtab symtab = Symtab.instance(context);
                     if (classType.tsym == symtab.objectType.tsym) {
-                        return new UserDefinedType(origin, new NameSegment(origin, "ValueObject", null));
+                        return new UserDefinedType(origin, new NameSegment(origin, REFERENCE_OR_VALUE_OBJECT_NAME, null));
                     } else {
                         reportError(origin, "notSupported", "@Immutable on a type other than Object");
                     }

--- a/verifier/src/main/java/com/aws/jverify/verifier/compiler/simplifications/NameCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/compiler/simplifications/NameCompiler.java
@@ -2,6 +2,7 @@ package com.aws.jverify.verifier.compiler.simplifications;
 
 import com.sun.tools.javac.code.Symbol;
 
+import com.sun.tools.javac.code.Symtab;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Type.*;
 
@@ -112,6 +113,11 @@ public class NameCompiler {
     }
 
     private String getClassName(Symbol.ClassSymbol classSymbol) {
+
+        var symtab = Symtab.instance(this.contractCompiler.compiler.context);
+        if (classSymbol.type == symtab.objectType) {
+            return "ModifiableObject";
+        }
         var newTarget = contractCompiler.contractClassToContractee.get(classSymbol);
         if (newTarget != null) {
             return uncachedGetCompiledName(newTarget);

--- a/verifier/src/main/java/com/aws/jverify/verifier/compiler/simplifications/workaround/ClassesExtendingClassesCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/compiler/simplifications/workaround/ClassesExtendingClassesCompiler.java
@@ -10,9 +10,9 @@ import com.sun.tools.javac.code.Symtab;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Stream;
 
 public class ClassesExtendingClassesCompiler {
+    public static final String DAFNY_REFERENCE_BASE_TYPE = "object";
     ClassCompiler classCompiler;
 
     public ClassesExtendingClassesCompiler(ClassCompiler classCompiler) {
@@ -82,12 +82,13 @@ public class ClassesExtendingClassesCompiler {
         Symtab symtab = Symtab.instance(classCompiler.compiler.context);
         if (classSymbol == symtab.objectType.tsym || classSymbol == symtab.recordType.tsym) {
             superTraits.clear();
-            superTraits.add(new UserDefinedType(origin, new NameSegment(origin, "ValueObject", null)));
+            superTraits.add(new UserDefinedType(origin, 
+                    new NameSegment(origin, JavaToDafnyCompiler.REFERENCE_OR_VALUE_OBJECT_NAME, null)));
         }
         
         if ((!JavaToDafnyCompiler.isInterface(classSymbol) && classSymbol != symtab.recordType.tsym) 
                 || classCompiler.compiler.isAnnotated(classSymbol.type, Modifiable.class)) {
-            superTraits.add(new UserDefinedType(origin, new NameSegment(origin, "object", null)));
+            superTraits.add(new UserDefinedType(origin, new NameSegment(origin, DAFNY_REFERENCE_BASE_TYPE, null)));
         }
 
         var trait = new TraitDecl(origin, name, null, typeParameters, traitMembers, superTraits, false);

--- a/verifier/src/main/resources/additional.dfy
+++ b/verifier/src/main/resources/additional.dfy
@@ -1,4 +1,4 @@
-trait ValueObject {}
+trait Object {}
 
 type nat15 = x: int16 | x >= 0
 type int16 = x: int | -0x8000 <= x <= 0x7fff

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/PolymorphismDafnyResolutionErrors.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/PolymorphismDafnyResolutionErrors.java
@@ -7,6 +7,6 @@ public class PolymorphismDafnyResolutionErrors {
     
     public static <T> void refObjectIsNotTop(T value) {
         Object o = value;
-//      ^^^^^^^^^^^^^^^^^ Error: RHS (of type T) not assignable to LHS (of type Object)
+//      ^^^^^^^^^^^^^^^^^ Error: RHS (of type T) not assignable to LHS (of type ModifiableObject)
     }
 }

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/PolymorphismDafnyResolutionErrors2.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/PolymorphismDafnyResolutionErrors2.java
@@ -11,6 +11,6 @@ public class PolymorphismDafnyResolutionErrors2 {
         @Immutable Object a = new Object();
         Object b = new Object();
         var c = a == b;
-//              ^ Error: == can only be applied to expressions of types that support equality (got ValueObject)
+//              ^ Error: == can only be applied to expressions of types that support equality (got Object)
     }
 }

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/RecordsDafnyResolutionError.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/RecordsDafnyResolutionError.java
@@ -11,6 +11,6 @@ class RecordsDafnyResolutionError {
     record Foo() {}
     static void assignRecordToRefObject() {
         Object o = new Foo();
-//      ^^^^^^^^^^^^^^^^^^^^^ Error: RHS (of type Foo) not assignable to LHS (of type Object)
+//      ^^^^^^^^^^^^^^^^^^^^^ Error: RHS (of type Foo) not assignable to LHS (of type ModifiableObject)
     }
 }

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/WildcardsDafnyResolution.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/WildcardsDafnyResolution.java
@@ -24,13 +24,13 @@ public class WildcardsDafnyResolution {
 
     static void innerSuperUsage(Container<Object> objects, Turtle dog) {
         Container<? super Animal> animals = objects;
-//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Error: RHS (of type Container<Object>) not assignable to LHS (of type Container<Animal>) (non-variant type parameter 'T' would require Animal = Object)
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Error: RHS (of type Container<ModifiableObject>) not assignable to LHS (of type Container<Animal>) (non-variant type parameter 'T' would require Animal = Object)
         animals.sett(dog);
     }
 
     void animalSetterUser(Container<Object> objects, Turtle dog) {
         animalSetter(objects, dog);
-//                   ^^^^^^^ Error: incorrect argument type at index 0 for method in-parameter 'animals' (expected Container<Animal>, found Container<Object>) (non-variant type parameter 'T' would require Animal = Object)
+//                   ^^^^^^^ Error: incorrect argument type at index 0 for method in-parameter 'animals' (expected Container<Animal>, found Container<ModifiableObject>) (non-variant type parameter 'T' would require Animal = Object)
     }
 
     @Verify(false)
@@ -40,7 +40,7 @@ public class WildcardsDafnyResolution {
     
     static void alwaysTruerUser(Container<Animal> animals, Container<Object> objects) {
         alwaysTruer(animals);
-//                  ^^^^^^^ Error: incorrect argument type for method in-parameter 'container' (expected Container<Object>, found Container<Animal>) (non-variant type parameter 'T' would require Object = Animal)
+//                  ^^^^^^^ Error: incorrect argument type for method in-parameter 'container' (expected Container<ModifiableObject>, found Container<Animal>) (non-variant type parameter 'T' would require Object = Animal)
         alwaysTruer(objects);
     }
     


### PR DESCRIPTION
### What was changed?
- Rename ValueObject to Object and Object to ModifiableObject

### How has this been tested?
- Updated existing tests

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/aws/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
