### PR TITLE
Allow to define a mutable contract for external interfaces

### DIFF
--- a/verifier/src/main/java/com/aws/jverify/verifier/compiler/ClassCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/compiler/ClassCompiler.java
@@ -205,7 +205,7 @@ public class ClassCompiler {
             superTraits.add(new UserDefinedType(origin, new NameSegment(origin, JavaToDafnyCompiler.REFERENCE_OR_VALUE_OBJECT_NAME, null)));
         }
 
-        // If the class has a contract annotated with @Mutable, it must be considered as mutable itself
+        // If the class has a contract annotated with @Modifiable, it must be considered as mutable itself
         var contractMutable = typeForWhichCurrentClassIsDefiningContract != null
                 && compiler.isAnnotated(classDecl.type, Modifiable.class);
 

--- a/verifier/src/main/java/com/aws/jverify/verifier/compiler/ClassCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/compiler/ClassCompiler.java
@@ -68,7 +68,6 @@ public class ClassCompiler {
                         return List.of();
                     }
 
-
                     typeForWhichCurrentClassIsDefiningContract = contractee;
                     name = compiler.getName(classDecl, typeForWhichCurrentClassIsDefiningContract);
                 }
@@ -165,6 +164,7 @@ public class ClassCompiler {
             }
         }
         var externalContract = compiler.externalContractCompiler.externalContracts.get(classDecl.sym);
+
         if (externalContract != null) {
             for (var ghostField : externalContract.ghostFields()) {
                 var dafnyMember = translateField(ghostField);
@@ -205,8 +205,13 @@ public class ClassCompiler {
             superTraits.add(new UserDefinedType(origin, new NameSegment(origin, JavaToDafnyCompiler.REFERENCE_OR_VALUE_OBJECT_NAME, null)));
         }
 
+        // If the class has a contract annotated with @Mutable, it must be considered as mutable itself
+        var contractMutable = typeForWhichCurrentClassIsDefiningContract != null
+                && compiler.isAnnotated(classDecl.type, Modifiable.class);
+
         var mutable = !JavaToDafnyCompiler.isInterface(definingSymbol)
-                || compiler.isAnnotated(definingSymbol.type, Modifiable.class);
+                || compiler.isAnnotated(definingSymbol.type, Modifiable.class)
+                || contractMutable;
         if (mutable) {
             superTraits.add(new UserDefinedType(origin, new NameSegment(origin, DAFNY_REFERENCE_BASE_TYPE, null)));
         }


### PR DESCRIPTION
### What was changed?
If we want to define a contract to an Interface defined in a Jar file, this contract is currently translated into a trait that does not extend object. This is a strong limitation w.r.t. what we can express in the contract. This PR removes this limitation.

### How has this been tested?
Manually tested. No infrastructure yet to test it with JAR files in CI.


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/aws/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
