### PR TITLE
Verify printed Dafny by default in the test engine

### DIFF
--- a/test-engine/src/main/java/com/aws/jverify/testengine/JVerifyTest.java
+++ b/test-engine/src/main/java/com/aws/jverify/testengine/JVerifyTest.java
@@ -53,5 +53,5 @@ public @interface JVerifyTest {
 
     String[] additionalFiles() default {};
     
-    boolean verifyPrintedDafny() default false;
+    boolean verifyPrintedDafny() default true;
 }

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/AvoidNameCollisionsTest.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/AvoidNameCollisionsTest.java
@@ -7,7 +7,7 @@ import java.util.function.IntPredicate;
 
 import static com.aws.jverify.JVerify.postcondition;
 
-@JVerifyTest(exitCode = 0, dafnyVerified = 10, dafnyErrors = 0, verifyPrintedDafny = true)
+@JVerifyTest(exitCode = 0, dafnyVerified = 10, dafnyErrors = 0)
 public class AvoidNameCollisionsTest {
 
     void set(int set, int r_set) {}

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/OverloadsTest.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/OverloadsTest.java
@@ -5,7 +5,7 @@ import com.aws.jverify.testengine.JVerifyTest;
 
 import static com.aws.jverify.JVerify.*;
 
-@JVerifyTest(exitCode = 4, dafnyVerified = 14, dafnyErrors = 1, verifyPrintedDafny = true)
+@JVerifyTest(exitCode = 4, dafnyVerified = 14, dafnyErrors = 1)
 class OverloadsTest {
     
     private int f;

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/expressions/lambdas/Lambdas.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/expressions/lambdas/Lambdas.java
@@ -11,7 +11,7 @@ import static com.aws.jverify.JVerify.postcondition;
 import static com.aws.jverify.JVerify.precondition;
 
 @SuppressWarnings({"FieldMayBeFinal", "Convert2MethodRef", "ConstantValue"})
-@JVerifyTest(exitCode = 4, dafnyVerified = 40, dafnyErrors = 3, verifyPrintedDafny = true)
+@JVerifyTest(exitCode = 4, dafnyVerified = 40, dafnyErrors = 3)
 public class Lambdas {
 
     // TODO: bring back once we support static fields

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/expressions/lambdas/PolymorphicLambdas.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/expressions/lambdas/PolymorphicLambdas.java
@@ -4,7 +4,7 @@ import com.aws.jverify.Contract;
 import com.aws.jverify.testengine.JVerifyTest;
 
 @SuppressWarnings("Convert2MethodRef")
-@JVerifyTest(dafnyVerified = 15, dafnyErrors = 0, verifyPrintedDafny = true)
+@JVerifyTest(dafnyVerified = 15, dafnyErrors = 0)
 public class PolymorphicLambdas {
 
     static class Anything {}

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/localClasses/LocalAndAnonymousClasses.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/localClasses/LocalAndAnonymousClasses.java
@@ -9,7 +9,7 @@ import static com.aws.jverify.JVerify.postcondition;
 import static com.aws.jverify.JVerify.precondition;
 
 @SuppressWarnings({"Convert2Lambda", "Anonymous2MethodRef", "ConstantValue", "NewObjectEquality"})
-@JVerifyTest(exitCode = 4, dafnyVerified = 44, dafnyErrors = 4, verifyPrintedDafny = true)
+@JVerifyTest(exitCode = 4, dafnyVerified = 44, dafnyErrors = 4)
 public class LocalAndAnonymousClasses {
 
     void noCaptures() {

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/localClasses/PolymorphicAnonymousClasses.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/localClasses/PolymorphicAnonymousClasses.java
@@ -2,8 +2,7 @@ package com.aws.jverify.verifier.tests.localClasses;
 
 import com.aws.jverify.testengine.JVerifyTest;
 
-@JVerifyTest(exitCode = 0, dafnyVerified = 22, dafnyErrors = 0,
-        verifyPrintedDafny = true)
+@JVerifyTest(exitCode = 0, dafnyVerified = 22, dafnyErrors = 0)
 public class PolymorphicAnonymousClasses {
 
     @SuppressWarnings("InnerClassMayBeStatic")

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/statements/VerifyStatements.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/statements/VerifyStatements.java
@@ -6,7 +6,7 @@ import com.aws.jverify.testengine.JVerifyTest;
 import static com.aws.jverify.JVerify.*;
 
 @SuppressWarnings({"ConditionalBreakInInfiniteLoop", "StatementWithEmptyBody", "ConstantValue"})
-@JVerifyTest(exitCode = 0, dafnyVerified = 17, dafnyErrors = 0, verifyPrintedDafny = true)
+@JVerifyTest(exitCode = 0, dafnyVerified = 17, dafnyErrors = 0)
 class VerifyStatements {
     void whileWithBreak() {
         var x = 0;

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/verification/MethodContractsVerification.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/verification/MethodContractsVerification.java
@@ -7,7 +7,7 @@ import java.util.function.IntPredicate;
 
 import static com.aws.jverify.JVerify.postcondition;
 
-@JVerifyTest(exitCode = 0, dafnyVerified = 7, dafnyErrors = 0, verifyPrintedDafny = true)
+@JVerifyTest(exitCode = 0, dafnyVerified = 7, dafnyErrors = 0)
 public class MethodContractsVerification {
     
     public int methodReferencePostCondition() {


### PR DESCRIPTION
### What was changed?
Switched the default on `JVerifyTest.verifyPrintedDafny`, since the current test suite doesn't hit any bugs that would block this.

### How has this been tested?
Existing tests.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/aws/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
