### PR TITLE
Improve support for missing const contracts

### DIFF
--- a/verifier/src/main/java/com/aws/jverify/verifier/compiler/JavaToDafnyCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/compiler/JavaToDafnyCompiler.java
@@ -637,7 +637,7 @@ public class JavaToDafnyCompiler {
     public static Function equalsFunctionDeclaration(IOrigin origin) {
         var otherIn = new Formal(origin, new Name(origin, "obj"), new UserDefinedType(origin, new NameSegment(origin, REFERENCE_OR_VALUE_OBJECT_NAME, null)),
                 false, true, null, null, false, false, false, null);
-        return new Function(origin, new Name(origin, "equals"), null, false, null, List.of(),
+        return new Function(origin, new Name(origin, "equals"), null, true, null, List.of(),
                 List.of(otherIn),
                 List.of(), List.of(), new Specification<>(List.of(), null),
                 new Specification<>(List.of(), null), false, false, null, new BoolType(origin),

--- a/verifier/src/main/java/com/aws/jverify/verifier/compiler/TypeDeclarationCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/compiler/TypeDeclarationCompiler.java
@@ -245,11 +245,11 @@ public class TypeDeclarationCompiler {
         Type type = compiler.translateType(variableDecl.type, 
                 compiler.toOrigin(variableDecl.vartype), variableDecl.getModifiers()
         );
-        
+
+        var isStatic = varFlags.contains(Modifier.STATIC);
         if (variableDecl.getInitializer() != null) {
             if (varFlags.contains(Modifier.FINAL)) {
                 var rhs = compiler.expressionCompiler.toExpr(variableDecl.getInitializer());
-                var isStatic = varFlags.contains(Modifier.STATIC);
                 return new ConstantField(origin, fieldName, null, false, type, rhs, isStatic, false);
             }
 
@@ -258,10 +258,9 @@ public class TypeDeclarationCompiler {
         }
 
         if (varFlags.contains(Modifier.FINAL)) {
-            var isStatic = varFlags.contains(Modifier.STATIC);
             return new ConstantField(origin, fieldName, null, true, type, null, isStatic, false);
         } else {
-            return new Field(origin, fieldName, null, false, type);
+            return new Field(origin, fieldName, null, true, type);
         }
     }
 

--- a/verifier/src/main/java/com/aws/jverify/verifier/compiler/TypeDeclarationCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/compiler/TypeDeclarationCompiler.java
@@ -256,7 +256,13 @@ public class TypeDeclarationCompiler {
             // Keep this variable declaration in the initializers list to be added to constructors laters
             initializers.add(variableDecl);
         }
-        return new Field(origin, fieldName, null, false, type);
+
+        if (varFlags.contains(Modifier.FINAL)) {
+            var isStatic = varFlags.contains(Modifier.STATIC);
+            return new ConstantField(origin, fieldName, null, true, type, null, isStatic, false);
+        } else {
+            return new Field(origin, fieldName, null, false, type);
+        }
     }
 
 
@@ -350,7 +356,7 @@ public class TypeDeclarationCompiler {
                 body = null;
             }
 
-            return new Constructor(origin, name, null, false, null, dafnyTypeParameters, ins,
+            return new Constructor(origin, name, null, true, null, dafnyTypeParameters, ins,
                     contract.preconditions, contract.postconditions, contract.getReads(),
                     contract.getDecreases(), contract.getModifies(),
                     body);
@@ -365,7 +371,7 @@ public class TypeDeclarationCompiler {
                 bodyStatements = List.of(new AssumeStmt(origin, null, new LiteralExpr(origin, false)));
             }
             var body = new BlockStmt(methodOrigin, null, List.of(), bodyStatements);
-            return new Method(origin, name, null, false, null, dafnyTypeParameters,
+            return new Method(origin, name, null, true, null, dafnyTypeParameters,
                     ins, contract.preconditions, contract.postconditions, contract.getReads(),
                     contract.getDecreases(), contract.getModifies(),
                     isStatic, outs,
@@ -389,7 +395,7 @@ public class TypeDeclarationCompiler {
         }
         applyInvariants(method.mods, method.sym, contract);
         var dafnyTypeParameters = translateTypeParameters(method.getTypeParameters());
-        return new Function(origin, name, null, false, null, dafnyTypeParameters,
+        return new Function(origin, name, null, true, null, dafnyTypeParameters,
                 ins, contract.preconditions, contract.postconditions, contract.getReads(),
                 contract.getDecreases(), isStatic, false, makeReturnFormal(origin, returnType),
                 returnType, contract.pureBody, null, null);

--- a/verifier/src/main/java/com/aws/jverify/verifier/compiler/simplifications/ImmutableTypeCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/compiler/simplifications/ImmutableTypeCompiler.java
@@ -181,7 +181,7 @@ public class ImmutableTypeCompiler {
                     return new AttributedExpression(e, null, null);
                 }).toList();
             }
-            var staticFunction = new Function(constructor.getOrigin(), constructor.getNameNode(), constructor.getAttributes(), false, null,
+            var staticFunction = new Function(constructor.getOrigin(), constructor.getNameNode(), constructor.getAttributes(), true, null,
                 constructor.getTypeArgs(), constructor.getIns(), constructor.getReq(), ens, constructor.getReads(), constructor.getDecreases(),
             true, false, result, outType, null, null, null);
 

--- a/verifier/src/main/java/com/aws/jverify/verifier/compiler/simplifications/workaround/TraitWithConstructorCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/compiler/simplifications/workaround/TraitWithConstructorCompiler.java
@@ -64,7 +64,7 @@ public class TraitWithConstructorCompiler {
                         traitMembers.add(initMethod);
                     }
 
-                    var classConstructor = new Constructor(constructor.getOrigin(), constructor.getNameNode(), null, false, null,
+                    var classConstructor = new Constructor(constructor.getOrigin(), constructor.getNameNode(), null, true, null,
                             constructor.getTypeArgs(), constructor.getIns(),
                             constructor.getReq(), constructor.getEns(), constructor.getReads(),
                             constructor.getDecreases(), constructor.getMod(),

--- a/verifier/src/main/resources/additional.dfy
+++ b/verifier/src/main/resources/additional.dfy
@@ -7,7 +7,7 @@ trait Object {
     //
     // See also JavaToDafnyCompiler.equalsFunctionDeclaration
     // for more on overridding pure methods.
-    predicate equals(obj: Object)
+    ghost predicate equals(obj: Object)
 }
 
 type nat15 = x: int16 | x >= 0
@@ -52,7 +52,7 @@ datatype DString extends Object = JS(elements: seq<char16>) {
     {
       JS(this.elements[start..end])
     }
-    function equals(other: Object) : (b: bool)
+    ghost function equals(other: Object) : (b: bool)
     {
       other is DString && this.elements == (other as DString).elements
     }

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/verification/MissingContracts.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/verification/MissingContracts.java
@@ -1,15 +1,17 @@
 package com.aws.jverify.verifier.tests.verification;
 
+import com.aws.jverify.Contract;
 import com.aws.jverify.Pure;
 import com.aws.jverify.testengine.JVerifyTest;
 import com.aws.jverify.testing.GenericParent;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
 import static com.aws.jverify.JVerify.check;
 
-@JVerifyTest(exitCode = 4, dafnyVerified = 7, dafnyErrors = 1)
+@JVerifyTest(exitCode = 4, dafnyVerified = 8, dafnyErrors = 1)
 public class MissingContracts {
     
     void checkFalse() {
@@ -59,9 +61,14 @@ public class MissingContracts {
     
     void indirectReference(GenericParent gp) {}
     
-// TODO generate ghost code everywhere
-//    void missingField() {
-//        var zero = BigDecimal.ZERO;
-//    }
+    void missingField() {
+        var zero = BigDecimal.ZERO;
+//                 ^ warning: missing contract for method 'ZERO' in class 'java.math.BigDecimal'
+    }
     
+    @Contract(value = BigDecimal.class, immutable = true)
+    static class BigDecimalContract {}
+
+    @Contract(value = Number.class, immutable = true)
+    static class NumberContract {}
 }


### PR DESCRIPTION
TODO Needs an update to constructors as well

### What was changed?
- For external contracts, allow static final fields without an initializer for non-empty types

### How has this been tested?
- Added a test-case

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/aws/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
