### PR TITLE
Enable defining a @Contract in different locations

### DIFF
--- a/examples/src/test/java/com/aws/jverify/examples/SourceContract.java
+++ b/examples/src/test/java/com/aws/jverify/examples/SourceContract.java
@@ -9,7 +9,7 @@ import static com.aws.jverify.JVerify.*;
 
 @Contract(Foo.class)
 @JVerifyTest(dafnyVerified = 17, dafnyErrors = 0)
-public class ExternalContract implements Foo {
+public class SourceContract implements Foo {
     int erasedValue;
     
     public int foo(int x) {
@@ -18,8 +18,8 @@ public class ExternalContract implements Foo {
         throw new ContractException();
     }
     
-    public ExternalContract selfType() {
-      postcondition((ExternalContract r) -> r.erasedValue == 3);
+    public SourceContract selfType() {
+      postcondition((SourceContract r) -> r.erasedValue == 3);
       erasedValue = 3;
       return this;
     }

--- a/library/src/main/java/com/aws/jverify/JVerify.java
+++ b/library/src/main/java/com/aws/jverify/JVerify.java
@@ -2,7 +2,6 @@ package com.aws.jverify;
 
 import java.util.Optional;
 import java.util.function.BiPredicate;
-import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 import java.util.function.IntPredicate;
 import java.util.function.Predicate;

--- a/verifier/src/main/java/com/aws/jverify/verifier/compiler/JavaToDafnyCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/compiler/JavaToDafnyCompiler.java
@@ -40,7 +40,6 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 public class JavaToDafnyCompiler {
-
     public static final boolean Ghostness = true;
     public static final String REFERENCE_OR_VALUE_OBJECT_NAME = "Object";
     public static final String JVERIFY_CLASS = JVerify.class.getName();

--- a/verifier/src/main/java/com/aws/jverify/verifier/compiler/Reporter.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/compiler/Reporter.java
@@ -23,15 +23,6 @@ public class Reporter {
     public JCDiagnostic.Factory diagnosticFactory;
     public JCTree.JCCompilationUnit compilationUnit;
     public final Stack<IOrigin> contextOrigins = new Stack<>();
-    private final Map<Symbol, Symbol> mappedSymbols = new HashMap<>();
-    
-    public Symbol getOriginal(Symbol symbol) {
-        return mappedSymbols.getOrDefault(symbol, symbol);
-    }
-    
-    public void mapSymbol(Symbol original, Symbol neww) {
-        mappedSymbols.put(neww, original);
-    }
 
     public static Reporter instance(Context context) {
         Reporter instance = context.get(Reporter.class);

--- a/verifier/src/main/java/com/aws/jverify/verifier/compiler/TypeDeclarationCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/compiler/TypeDeclarationCompiler.java
@@ -246,7 +246,7 @@ public class TypeDeclarationCompiler {
             if (varFlags.contains(Modifier.FINAL)) {
                 var rhs = compiler.expressionCompiler.toExpr(variableDecl.getInitializer());
                 var isStatic = varFlags.contains(Modifier.STATIC);
-                return new ConstantField(origin, fieldName, null, false, type, rhs, isStatic, false);
+                return new ConstantField(origin, fieldName, null, JavaToDafnyCompiler.Ghostness, type, rhs, isStatic, false);
             }
 
             // Keep this variable declaration in the initializers list to be added to constructors laters
@@ -388,7 +388,8 @@ public class TypeDeclarationCompiler {
         applyInvariants(method.mods, method.sym, contract);
         var dafnyTypeParameters = translateTypeParameters(method.getTypeParameters());
 
-        Function result = new Function(origin, name, null, JavaToDafnyCompiler.Ghostness, null, dafnyTypeParameters,
+        Function result = new Function(origin, name, null, JavaToDafnyCompiler.Ghostness, 
+                null, dafnyTypeParameters,
                 ins, contract.preconditions, contract.postconditions, contract.getReads(),
                 contract.getDecreases(), isStatic, false, makeReturnFormal(origin, returnType),
                 returnType, contract.pureBody, null, null);

--- a/verifier/src/main/java/com/aws/jverify/verifier/compiler/simplifications/ExternalContractCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/compiler/simplifications/ExternalContractCompiler.java
@@ -46,8 +46,10 @@ public class ExternalContractCompiler {
     private final JVerifyUtils jverifyUtils;
     private final JavacElements elements;
     private final Reporter reporter;
-    private final Set<Symbol.ClassSymbol> symbolsWithContracts = new HashSet<>();
+    private final Map<Symbol.ClassSymbol, JCTree.JCClassDecl> contracteeSymbolToLibraryContractDecl = new HashMap<>();
     private final Map<Symbol, Symbol> contractSymbolToContractee = new HashMap<>();
+    private final Set<Symbol> contractees = new HashSet<>();
+    private final Set<Symbol.ClassSymbol> sourceContractedSymbols = new HashSet<>();
 
     public ExternalContractCompiler(Context context) {
         this.names = Names.instance(context);
@@ -97,11 +99,6 @@ public class ExternalContractCompiler {
                     classesToRemove.add(classDecl);
                     return;
                 }
-                
-                if (!symbolsWithContracts.add(contracteeSymbol)) {
-                    reporter.reportError(contractAnnotation, "duplicateContract", contracteeSymbol.name);
-                    return;
-                }
 
                 com.sun.tools.javac.util.List<Symbol.TypeVariableSymbol> typeParameters = contracteeSymbol.getTypeParameters();
                 if (typeParameters.size() != classDecl.sym.getTypeParameters().size()) {
@@ -120,9 +117,15 @@ public class ExternalContractCompiler {
                 contractSymbolToContractee.put(classDecl.sym, contracteeSymbol);
                 
                 var contracteeSource = (JCTree.JCClassDecl)index.getTree(contracteeSymbol);
-                if (contracteeSource == null) {
+                if (contracteeSource == null || contracteeSymbolToLibraryContractDecl.containsKey(contracteeSymbol)) {
                     handleLibraryContract(classDecl, contracteeSymbol);
                 } else {
+                    if (!sourceContractedSymbols.add(contracteeSymbol)) {
+                        classesToRemove.add(classDecl);
+                        reporter.reportError(contractAnnotation, "duplicateContract", contracteeSymbol.name);
+                        return;
+                    }
+                    
                     if (JavaToDafnyCompiler.typeHasSource(index, contracteeSymbol) && !JavaToDafnyCompiler.isInterfaceOrAbstract(contracteeSymbol)) {
                         reporter.reportError(contractAnnotation, "concreteTypeWithExternalContract", contracteeSymbol.name);
                         classesToRemove.add(classDecl);
@@ -188,38 +191,54 @@ public class ExternalContractCompiler {
         }
 
         private void handleLibraryContract(JCTree.JCClassDecl classDecl, Symbol.ClassSymbol contracteeSymbol) {
-            classDecl.type.tsym = contracteeSymbol;
-            
-            var newMembers =  new ArrayList<JCTree>();
+            classDecl.type.tsym = contracteeSymbol; // Required before calling 'findContractee'
+
+            List<JCTree> newMembers;
+            JCTree.JCClassDecl declToAddTo;
+            var existingDecl = contracteeSymbolToLibraryContractDecl.get(contracteeSymbol);
+            if (existingDecl == null) {
+                newMembers = List.nil();
+                declToAddTo = classDecl;
+                contracteeSymbolToLibraryContractDecl.put(contracteeSymbol, classDecl);
+            } else {
+                newMembers = existingDecl.defs;
+                declToAddTo = existingDecl;
+            }
             for(var member : classDecl.getMembers()) {
                 if (member instanceof JCTree.JCMethodDecl methodDecl) {
-                    handleLibraryContractMethod(classDecl, contracteeSymbol, methodDecl, newMembers);
+                    newMembers = handleLibraryContractMethod(classDecl, contracteeSymbol, methodDecl, newMembers);
                 } else if (member instanceof JCTree.JCVariableDecl field) {
-                    handleLibraryContractField(contracteeSymbol, member, field, newMembers);
+                    newMembers = handleLibraryContractField(contracteeSymbol, member, field, newMembers);
                 } else {
-                    newMembers.add(member);
+                    newMembers = newMembers.append(member);
                 }
             }
-            classDecl.defs = List.from(newMembers);
+            declToAddTo.defs = List.from(newMembers);
 
-            var oldSymbol = classDecl.sym;
-            oldSymbol.name = contracteeSymbol.name;
-            classDecl.sym = contracteeSymbol;
-            classDecl.type = contracteeSymbol.type;
+            if (existingDecl == null) {
+                var contracterSymbol = classDecl.sym;
+                contracterSymbol.name = contracteeSymbol.name;
+                classDecl.sym = contracteeSymbol;
+                classDecl.type = contracteeSymbol.type;
+                moveContractAnnotation(contracteeSymbol, contracterSymbol);
 
-            moveContractAnnotation(contracteeSymbol, oldSymbol);
-
-            index.put(classDecl.sym, enter.classEnv(classDecl, topLevelEnv));
+                index.put(contracteeSymbol, enter.classEnv(classDecl, topLevelEnv));
+            } else {
+                classesToRemove.add(classDecl);
+            }
         }
 
-        private void handleLibraryContractField(Symbol.ClassSymbol contracteeSymbol, JCTree member, JCTree.JCVariableDecl field, ArrayList<JCTree> newMembers) {
-            var baseField = contracteeSymbol.members().getSymbolsByName(field.name, s -> s.getKind() == ElementKind.FIELD).iterator();
+        private List<JCTree> handleLibraryContractField(Symbol.ClassSymbol contracteeSymbol, JCTree member, 
+                                                JCTree.JCVariableDecl field,
+                                                List<JCTree> newMembers) {
+            var baseField = contracteeSymbol.members().
+                    getSymbolsByName(field.name, s -> s.getKind() == ElementKind.FIELD).iterator();
             if (baseField.hasNext()) {
                 Symbol.VarSymbol contractedFieldSymbol = (Symbol.VarSymbol) baseField.next();
                 contractSymbolToContractee.put(field.sym, contractedFieldSymbol);
                 field.sym = contractedFieldSymbol;
             }
-            newMembers.add(member);
+            return newMembers.append(member);
         }
 
         /**
@@ -233,25 +252,31 @@ public class ExternalContractCompiler {
             contracteeSymbol.setDeclarationAttributes(newAnnotations.toList());
         }
 
-        private void handleLibraryContractMethod(JCTree.JCClassDecl classDecl, Symbol.ClassSymbol contracteeSymbol, JCTree.JCMethodDecl methodDecl, ArrayList<JCTree> newMembers) {
-            var contracterSymbol = methodDecl.sym;
+        private List<JCTree> handleLibraryContractMethod(JCTree.JCClassDecl classDecl, 
+                                                         Symbol.ClassSymbol contracteeSymbol, 
+                                                         JCTree.JCMethodDecl methodDecl, 
+                                                         List<JCTree> newMembers) {
+            var methodSymbol = methodDecl.sym;
 
-            if (JavaToDafnyCompiler.isSynthetic(index, methodDecl, contracterSymbol) || (methodDecl.mods.flags & Flags.GENERATEDCONSTR) != 0) {
-                return;
+            if (JavaToDafnyCompiler.isSynthetic(index, methodDecl, methodSymbol) || (methodDecl.mods.flags & Flags.GENERATEDCONSTR) != 0) {
+                return newMembers;
             }
 
-            var baseMethod = findContractee(contracteeSymbol, contracterSymbol, types);
-            if (baseMethod != null) {
-                updateLibraryContractAnnotations(methodDecl, baseMethod);
-                newMembers.add(methodDecl);
-                index.put(methodDecl.sym, enter.classEnv(classDecl, enter.getTopLevelEnv(reporter.compilationUnit)));
-                contractSymbolToContractee.put(methodDecl.sym, baseMethod);
-                methodDecl.sym = baseMethod;
-            } else {
+            var contractee = findContractee(contracteeSymbol, methodSymbol, types);
+            if (contractee == null) {
                 reporter.reportError(methodDecl, "unusedContractMethod", methodToString(methodDecl));
-                return;
+                return newMembers;
             }
-
+            if (!contractees.add(contractee)) {
+                // TODO warning duplicate?
+                return newMembers;
+            }
+            
+            index.put(methodDecl.sym, enter.classEnv(classDecl, enter.getTopLevelEnv(reporter.compilationUnit)));
+            contractSymbolToContractee.put(methodDecl.sym, contractee);
+            updateLibraryContractAnnotations(methodDecl, contractee);
+            methodDecl.sym = contractee;
+            return newMembers.append(methodDecl);
         }
 
         private void updateLibraryContractAnnotations(JCTree.JCMethodDecl contracter, 

--- a/verifier/src/main/java/com/aws/jverify/verifier/compiler/simplifications/ImmutableTypeCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/compiler/simplifications/ImmutableTypeCompiler.java
@@ -10,6 +10,7 @@ import com.sun.tools.javac.code.Flags;
 import com.sun.tools.javac.code.Symtab;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.TreeInfo;
+import com.sun.tools.javac.util.Names;
 
 import javax.lang.model.type.TypeKind;
 import java.util.ArrayList;
@@ -19,10 +20,14 @@ import java.util.stream.Collectors;
 public class ImmutableTypeCompiler {
     final TypeDeclarationCompiler typeDeclarationCompiler;
     final JavaToDafnyCompiler compiler;
+    private final Symtab symtab;
+    private final Names names;
 
     public ImmutableTypeCompiler(TypeDeclarationCompiler typeDeclarationCompiler) {
         this.typeDeclarationCompiler = typeDeclarationCompiler;
         this.compiler = typeDeclarationCompiler.compiler;
+        symtab = Symtab.instance(compiler.context);
+        names = Names.instance(compiler.context);
     }
 
     public TopLevelDeclWithMembers translate(JCTree.JCClassDecl classDecl, IOrigin origin, Name name) {
@@ -95,7 +100,7 @@ public class ImmutableTypeCompiler {
                     Name fieldName = compiler.getName(variableDecl, variableDecl.sym);
                     var fieldOrigin = compiler.declToOrigin(variableDecl, fieldName);
                     Type type = compiler.translateType(variableDecl.vartype.type, compiler.toOrigin(variableDecl.vartype), variableDecl.getModifiers());
-                    members.add(new ConstantField(fieldOrigin, fieldName, null, true, type, null, false, false));
+                    members.add(new ConstantField(fieldOrigin, fieldName, null, JavaToDafnyCompiler.Ghostness, type, null, false, false));
                 }
                 continue;
             } 

--- a/verifier/src/main/java/com/aws/jverify/verifier/compiler/simplifications/JVerifyGhostExpressionCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/compiler/simplifications/JVerifyGhostExpressionCompiler.java
@@ -80,7 +80,7 @@ public class JVerifyGhostExpressionCompiler {
             case "get" -> {
                 var seq = expressionCompiler.toExpr(receiver);
                 var index = expressionCompiler.toExpr(args.getFirst());
-                return new SeqSelectExpr(compiler.toOrigin(invocation), true, seq, index, null, null);
+                return new SeqSelectExpr(origin, true, seq, index, null, null);
             }
             case "drop" -> {
                 return toSubsequence(origin, receiver, args.getFirst(), null);

--- a/verifier/src/main/java/com/aws/jverify/verifier/compiler/simplifications/MissingContractCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/compiler/simplifications/MissingContractCompiler.java
@@ -151,6 +151,7 @@ public class MissingContractCompiler {
             if (tree.sym.isEnum()) {
                 return;
             }
+            visitReference(tree.sym, tree);
             super.visitClassDef(tree);
         }
 

--- a/verifier/src/main/resources/builtin-contracts.java
+++ b/verifier/src/main/resources/builtin-contracts.java
@@ -7,26 +7,15 @@ import java.math.BigInteger;
 import com.aws.jverify.Contract;
 import com.aws.jverify.ContractException;
 import com.aws.jverify.Pure;
-import static com.aws.jverify.JVerify.check;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.SequencedCollection;
-import java.util.Map;
-import java.util.Set;
 import java.util.function.IntPredicate;
 import java.util.function.Predicate;
-import java.util.function.Function;
-import java.util.function.Consumer;
-import java.util.Collection;
-import java.util.List;
-import java.util.SequencedCollection;
-
-import java.util.Optional;
 
 @Contract(Comparable.class)
 class ComparableContract<T> {
@@ -264,7 +253,7 @@ abstract class MapContract<K, V> implements Map<K, V> {
                 size() == r.size() &&
                         r.elements ==
                                 JVerify.Set.all((K k) -> elements.contains(k))
-                                        .map((K k) -> (java.util.Map.Entry<K,V>)new MapEntry<K, V>(k, elements.get(k))));
+                                        .map((K k) -> Map.entry(k, elements.get(k))));
         throw new ContractException();
     }
 
@@ -286,30 +275,6 @@ abstract class MapEntryContract<K, V> implements Map.Entry<K, V> {
     @Override
     @Pure
     public V getValue() {
-        throw new ContractException();
-    }
-}
-
-// It would be better to use Map.entry(key, value) directly,
-// but that currently doesn't work because we end up with <K, V> type parameters
-// on both Map and Map.entry, and while Java ignores the outer type parameters
-// for static methods, Dafny gets confused and doesn't resolve.
-record MapEntry<K, V>(K key, V value) implements Map.Entry<K, V> {
-    @Override
-    @Pure
-    public K getKey() {
-        return key;
-    }
-
-    @Override
-    @Pure
-    public V getValue() {
-        return value;
-    }
-
-    @Override
-    @Verify(false)
-    public V setValue(V value) {
         throw new ContractException();
     }
 }

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/javasupport/records/RecordsErrors.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/javasupport/records/RecordsErrors.java
@@ -2,6 +2,7 @@ package com.aws.jverify.verifier.tests.javasupport.records;
 
 import com.aws.jverify.Contract;
 import com.aws.jverify.Modifiable;
+import com.aws.jverify.Nullable;
 import com.aws.jverify.testengine.JVerifyTest;
 
 @JVerifyTest(exitCode = 2)
@@ -72,7 +73,13 @@ class RecordsErrors {
     
     @Contract(value = WantsContract.class, immutable = true)
 //  ^ error: class 'WantsContract' must not have an externally defined contract because all its contracts can be defined internally
-    class WantsContractContract {}
+    static class WantsContractContract {}
     
-    class WantsContract {}
+    static class WantsContract {}
+
+    // This is a limitation of the current implementation; we'd like to allow matching Java semantics more precisely.
+    static boolean nullableString(@Nullable DoorStuck s) {
+//                                ^ error: nullable record type is not supported
+        return s == null;
+    }
 }

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/javasupport/records/RecordsVerified.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/javasupport/records/RecordsVerified.java
@@ -5,7 +5,7 @@ import com.aws.jverify.testengine.JVerifyTest;
 
 import static com.aws.jverify.JVerify.*;
 
-@JVerifyTest(exitCode = 4, dafnyVerified = 27, dafnyErrors = 4)
+@JVerifyTest(exitCode = 4, dafnyVerified = 36, dafnyErrors = 4)
 class RecordsVerified {
     static void unitRecord() {
         var _ = new UnitRecord();
@@ -64,15 +64,15 @@ class RecordsVerified {
     }
 
     static void recursiveRecords() {
-        var nodeC = new BasicConsList("C", null);
+        var nodeC = new BasicConsList(3, null);
         var contC = new Wrapper<>(nodeC);
-        var nodeB = new BasicConsList("B", contC);
+        var nodeB = new BasicConsList(2, contC);
         var contB = new Wrapper<>(nodeB);
-        var nodeA = new BasicConsList("A", contB);
+        var nodeA = new BasicConsList(1, contB);
 
-        check(nodeA.head().equals("A"));
-        check(nodeB.head().equals("B"));
-        check(nodeC.head().equals("C"));
+        check(nodeA.head() == 1);
+        check(nodeB.head() == 2);
+        check(nodeC.head() == 3);
 
         check(nodeA.tail() == null);
 //      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Error: assertion could not be proved
@@ -122,7 +122,7 @@ record Pair<A, B>(A a, B b) {}
 record UnusedTypeParameter<A, B>(int x) {}
 
 /** Recursion */
-record BasicConsList(String head, @Nullable Wrapper<BasicConsList> tail) {}
+record BasicConsList(int head, @Nullable Wrapper<BasicConsList> tail) {}
 
 /** Members */
 @SuppressWarnings("ManualMinMaxCalculation")

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/javasupport/statements/TranslationErrors.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/javasupport/statements/TranslationErrors.java
@@ -131,12 +131,6 @@ class TranslationErrors {
         return i == 0;
     }
 
-    // This is a limitation of the current implementation; we'd like to allow matching Java semantics more precisely.
-    static boolean nullableString(@Nullable String s) {
-//                                ^ error: nullable String type is not supported
-        return s == null;
-    }
-
     record IntWrapper(int value) {}
 
     @SuppressWarnings("unused")

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/jcl/CollectionsTest.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/jcl/CollectionsTest.java
@@ -1,4 +1,4 @@
-// ^ /builtin-contracts.java(90:36-90:50) Related location: this proposition could not be proved
+// ^ /builtin-contracts.java(79:36-79:50) Related location: this proposition could not be proved
 package com.aws.jverify.verifier.tests.jcl;
 
 import com.aws.jverify.testengine.JVerifyTest;


### PR DESCRIPTION
### What was changed?
- Enable using `@Contract` on the same target type multiple times. 
- TODO: This requires changing the way the Uri part of source locations is sent to Dafny, since instead of multiple top level files, there needs to be a single tree within which the Uri can be changed at arbitrary subtrees.

### How has this been tested?

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/aws/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
