### PR TITLE
Allow static method reference in const

### DIFF
--- a/verifier/src/main/java/com/aws/jverify/verifier/compiler/dafnygenerator/base/BaseDafnyGenerator.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/compiler/dafnygenerator/base/BaseDafnyGenerator.java
@@ -652,6 +652,8 @@ public class BaseDafnyGenerator implements DafnyGenerator {
             return getOwnAndEnclosedTypeParameters(methodSymbol);
         } else if (symbol instanceof Symbol.PackageSymbol) {
             return Stream.empty();
+        } else if (symbol instanceof Symbol.VarSymbol varSymbol) {
+            return getOwnAndEnclosedTypeParameters(varSymbol.owner);
         }
         throw new RuntimeException();
     }

--- a/verifier/src/main/java/com/aws/jverify/verifier/compiler/simplifications/LambdaToAnonymousClassCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/compiler/simplifications/LambdaToAnonymousClassCompiler.java
@@ -69,6 +69,18 @@ public class LambdaToAnonymousClassCompiler extends TreeTranslator {
         currentContainer = previous;
     }
 
+    @Override
+    public void visitVarDef(JCVariableDecl tree) {
+        if (currentContainer instanceof Symbol.ClassSymbol) {
+            var previous = currentContainer;
+            currentContainer = tree.sym;
+            super.visitVarDef(tree);
+            currentContainer = previous;
+        } else {
+            super.visitVarDef(tree);
+        }
+    }
+
     private JCNewClass transformLambdaToAnonymousClass(JCLambda lambda) {
         maker.pos = lambda.pos;
         
@@ -105,8 +117,8 @@ public class LambdaToAnonymousClassCompiler extends TreeTranslator {
         boolean hasNoEnclosingType = (currentContainer.flags() & STATIC) != 0;
         if (hasNoEnclosingType) {
             flags |= STATIC;
-
         }
+        
         var classSymbol = new Symbol.ClassSymbol(flags, name, currentContainer);
 
         // Flatname should be globally unique. Qualified class name plus line and column achieves that.

--- a/verifier/src/main/java/com/aws/jverify/verifier/compiler/simplifications/MethodReferenceToLambdaCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/compiler/simplifications/MethodReferenceToLambdaCompiler.java
@@ -39,13 +39,15 @@ public class MethodReferenceToLambdaCompiler extends TreeTranslator {
         var paramTypes = types.findDescriptorType(reference.type).getParameterTypes();
         var params = getParameters(paramTypes).toList();
 
+        Type target = null;
         JCTree.JCExpression methodCall = switch (reference.kind) {
             case STATIC ->
                 // Static method reference: Class::method -> (args) -> Class.method(args)
                     replaceColonsWithDot(reference, params);
-            case BOUND ->
+            case BOUND -> {
                 // Bound instance method: obj::method -> (args) -> obj.method(args)
-                    replaceColonsWithDot(reference, params);
+                yield replaceColonsWithDot(reference, params);
+            }
             case UNBOUND ->
                 // Unbound instance method: Class::method -> (obj, args) -> obj.method(args)
                     addImplicitReceiverArgument(reference, params);
@@ -59,6 +61,7 @@ public class MethodReferenceToLambdaCompiler extends TreeTranslator {
 
         make.pos = reference.pos;
         var lambda = make.Lambda(params, methodCall);
+        lambda.target = reference.target;
         lambda.type = reference.type;
         return lambda;
     }

--- a/verifier/src/main/resources/com/aws/jverify/dafny.properties
+++ b/verifier/src/main/resources/com/aws/jverify/dafny.properties
@@ -1,2 +1,2 @@
 dafnyVersion=4.11.1
-dafnyRef=0b87be38cec8f9ac6a18ef0faba40cdba8251fa7
+dafnyRef=a6812be4a411168a4a66b4a7ca6aa5aa86cb656f

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/javasupport/lambdas/Lambdas.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/javasupport/lambdas/Lambdas.java
@@ -13,6 +13,18 @@ import static com.aws.jverify.JVerify.precondition;
 @SuppressWarnings({"FieldMayBeFinal", "Convert2MethodRef", "ConstantValue"})
 @JVerifyTest(exitCode = 4, dafnyVerified = 89, dafnyErrors = 3, verifyPrintedDafny = true)
 public class Lambdas {
+    private static final SomethingDoer containsMethodReference = Lambdas::staticDoSomething;
+    private static final SomethingDoer containsLambda = (int x, int y) -> staticDoSomething(x, y);
+    private static final SomethingDoer containsInnerClass = new SomethingDoer() {
+        @Override
+        public int doSomething(int x, int y) {
+            return 0;
+        }
+    };
+    
+    static int staticDoSomething(int x, int y) {
+        return 3;
+    }
 
     // TODO: bring back once we support static fields
 //    private static int STATIC_FIELD = 100;

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/javasupport/lambdas/Lambdas.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/javasupport/lambdas/Lambdas.java
@@ -11,7 +11,7 @@ import static com.aws.jverify.JVerify.postcondition;
 import static com.aws.jverify.JVerify.precondition;
 
 @SuppressWarnings({"FieldMayBeFinal", "Convert2MethodRef", "ConstantValue"})
-@JVerifyTest(exitCode = 4, dafnyVerified = 89, dafnyErrors = 3, verifyPrintedDafny = true)
+@JVerifyTest(exitCode = 4, dafnyVerified = 99, dafnyErrors = 3, verifyPrintedDafny = true)
 public class Lambdas {
     private static final SomethingDoer containsMethodReference = Lambdas::staticDoSomething;
     private static final SomethingDoer containsLambda = (int x, int y) -> staticDoSomething(x, y);


### PR DESCRIPTION
### What was changed?
- Allow lambda in static final variable initializer
- Allow static method reference in static final variable initializer

### How has this been tested?
- Add tests

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/aws/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
