### PR TITLE
Skip java method count when verification errors out

### DIFF
--- a/verifier/src/main/java/com/aws/jverify/verifier/Driver.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/Driver.java
@@ -126,7 +126,8 @@ public class Driver {
             outputWriter.write(verificationResultsWithIntervalTreeMap.verificationResults.getDafnyFinishedMessage());
         }
 
-        if (verificationResultsWithIntervalTreeMap.sourceFileToIntervalTreeMap != null) {
+        if (verificationResultsWithIntervalTreeMap.sourceFileToIntervalTreeMap != null &&
+                verificationResultsWithIntervalTreeMap.verificationResults.getExitCode() != CommandLine.ExitCode.USAGE) {
             outputWriter.write('\n');
             String bullet = "• ";
 


### PR DESCRIPTION
### What was changed?
Skipping java method count print (which was otherwise printing 'all methods verified' due to lack of failure messages associated with methods) when we encountered error in the verification process, say, due to unsupported features. 

### How has this been tested?
Was tested locally.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/aws/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
