### PR TITLE
Ignore errors in library methods when fetching mapping to original java code

### DIFF
--- a/verifier/src/main/java/com/aws/jverify/verifier/Driver.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/Driver.java
@@ -28,6 +28,8 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class Driver {
+
+    public static Context context;
     public record VerificationResultsWithIntervalTreeMap(VerificationResults verificationResults, HashMap<URI, IntervalTree<Integer,
             JavaMethodVerificationStatus>> sourceFileToMethodIntervals) {}
 
@@ -54,7 +56,7 @@ public class Driver {
         var verificationResults = new VerificationResults();
 
         InstrumentLower.installModification();
-        Context context = new Context();
+        context = new Context();
         TypesWithoutErasure.preRegister(context);
         context.put(VerifierOptions.class, verifierOptions);
 
@@ -120,9 +122,7 @@ public class Driver {
                     continue;
                 }
 
-                var relativeURIstring = relativeUri.toString();
-                if (relativeURIstring.equals(SourceFile.URIprefix + JavaToDafnyCompiler.builtinFile) ||
-                        relativeURIstring.equals(SourceFile.URIprefix + JavaToDafnyCompiler.objectFile)) {
+                if (context.get(JavaToDafnyCompiler.class) != null && context.get(JavaToDafnyCompiler.class).isLibrary(relativeUri)) {
                     continue;
                 }
 

--- a/verifier/src/main/java/com/aws/jverify/verifier/Driver.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/Driver.java
@@ -115,10 +115,17 @@ public class Driver {
                     }
                 }
                 var relativeUri = dafnyDiagnostic.getSource();
-                var failedJavaMethod = verificationResultsWithIntervalTreeMap.sourceFileToMethodIntervals.get(relativeUri)
-                        .findAtPoint((int) dafnyDiagnostic.getLineNumber());
-                if (failedJavaMethod != null) {
-                    failedJavaMethod.setVerificationStatus(JavaMethodVerificationStatus.VerificationStatus.Failed);
+                if (relativeUri != null) {
+                    var relativeURIstring = relativeUri.toString();
+                    if (!relativeURIstring.equals(SourceFile.URIprefix + JavaToDafnyCompiler.builtinFile) &&
+                        !relativeURIstring.equals(SourceFile.URIprefix + JavaToDafnyCompiler.objectFile)) {
+
+                        var failedJavaMethod = verificationResultsWithIntervalTreeMap.sourceFileToMethodIntervals.get(relativeUri)
+                                .findAtPoint((int) dafnyDiagnostic.getLineNumber());
+                        if (failedJavaMethod != null) {
+                            failedJavaMethod.setVerificationStatus(JavaMethodVerificationStatus.VerificationStatus.Failed);
+                        }
+                    }
                 }
             }
         }
@@ -296,7 +303,7 @@ public class Driver {
         }
         
         if (verifierOptions.verbose()) {
-            System.out.println("Dafny options: " + String.join(", ", processBuilder.command()));
+            System.out.println("Dafny options: " + String.join(" ", processBuilder.command()));
         }
 
         try {

--- a/verifier/src/main/java/com/aws/jverify/verifier/Driver.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/Driver.java
@@ -115,17 +115,21 @@ public class Driver {
                     }
                 }
                 var relativeUri = dafnyDiagnostic.getSource();
-                if (relativeUri != null) {
-                    var relativeURIstring = relativeUri.toString();
-                    if (!relativeURIstring.equals(SourceFile.URIprefix + JavaToDafnyCompiler.builtinFile) &&
-                        !relativeURIstring.equals(SourceFile.URIprefix + JavaToDafnyCompiler.objectFile)) {
 
-                        var failedJavaMethod = verificationResultsWithIntervalTreeMap.sourceFileToMethodIntervals.get(relativeUri)
-                                .findAtPoint((int) dafnyDiagnostic.getLineNumber());
-                        if (failedJavaMethod != null) {
-                            failedJavaMethod.setVerificationStatus(JavaMethodVerificationStatus.VerificationStatus.Failed);
-                        }
-                    }
+                if (relativeUri == null) {
+                    continue;
+                }
+
+                var relativeURIstring = relativeUri.toString();
+                if (relativeURIstring.equals(SourceFile.URIprefix + JavaToDafnyCompiler.builtinFile) ||
+                        relativeURIstring.equals(SourceFile.URIprefix + JavaToDafnyCompiler.objectFile)) {
+                    continue;
+                }
+
+                var failedJavaMethod = verificationResultsWithIntervalTreeMap.sourceFileToMethodIntervals.get(relativeUri)
+                        .findAtPoint((int) dafnyDiagnostic.getLineNumber());
+                if (failedJavaMethod != null) {
+                    failedJavaMethod.setVerificationStatus(JavaMethodVerificationStatus.VerificationStatus.Failed);
                 }
             }
         }
@@ -134,8 +138,19 @@ public class Driver {
             outputWriter.write(verificationResultsWithIntervalTreeMap.verificationResults.getDafnyFinishedMessage());
         }
 
-        if (verificationResultsWithIntervalTreeMap.sourceFileToMethodIntervals != null &&
-                verificationResultsWithIntervalTreeMap.verificationResults.getExitCode() != CommandLine.ExitCode.USAGE) {
+
+        /*
+         * checks for the following:
+         *  - the presence of non-library methods,
+         *  - lack of errors in generated Dafny code
+         *  - Dafny did not fail to run
+         *  - lack of errors in Dafny run
+         */
+        if (verificationResultsWithIntervalTreeMap.sourceFileToMethodIntervals != null //there exists
+                && verificationResultsWithIntervalTreeMap.verificationResults.getExitCode() != CommandLine.ExitCode.USAGE
+                && verificationResultsWithIntervalTreeMap.verificationResults.getExitCode() != -1
+                && verificationResultsWithIntervalTreeMap.verificationResults.getExitCode() != getExitCodeFromDafny(2)
+        ) {
             outputWriter.write('\n');
             String bullet = "• ";
 

--- a/verifier/src/main/java/com/aws/jverify/verifier/Driver.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/Driver.java
@@ -122,7 +122,7 @@ public class Driver {
                     continue;
                 }
 
-                if (context.get(JavaToDafnyCompiler.class) != null && context.get(JavaToDafnyCompiler.class).isLibrary(relativeUri)) {
+                if (context.get(JavaToDafnyCompiler.class).isLibrary(relativeUri)) {
                     continue;
                 }
 

--- a/verifier/src/main/java/com/aws/jverify/verifier/SourceFile.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/SourceFile.java
@@ -7,6 +7,8 @@ import java.nio.file.Path;
 public class SourceFile extends SimpleJavaFileObject {
     final String content;
 
+    public static String URIprefix = "string://";
+
     /**
      * Constructs a {@link SourceFile} with the given path and content.
      * <p>
@@ -16,7 +18,7 @@ public class SourceFile extends SimpleJavaFileObject {
      * in order to ensure correct functionality across different operating systems.
      */
     public SourceFile(String path, String content) {
-        super(URI.create("string://" + path), Kind.SOURCE);
+        super(URI.create(URIprefix + path), Kind.SOURCE);
         this.content = content;
     }
 

--- a/verifier/src/main/java/com/aws/jverify/verifier/SourceFile.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/SourceFile.java
@@ -7,8 +7,6 @@ import java.nio.file.Path;
 public class SourceFile extends SimpleJavaFileObject {
     final String content;
 
-    public static String URIprefix = "string://";
-
     /**
      * Constructs a {@link SourceFile} with the given path and content.
      * <p>
@@ -18,7 +16,7 @@ public class SourceFile extends SimpleJavaFileObject {
      * in order to ensure correct functionality across different operating systems.
      */
     public SourceFile(String path, String content) {
-        super(URI.create(URIprefix + path), Kind.SOURCE);
+        super(URI.create("string://" + path), Kind.SOURCE);
         this.content = content;
     }
 

--- a/verifier/src/main/java/com/aws/jverify/verifier/compiler/frontend/JavaToDafnyCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/compiler/frontend/JavaToDafnyCompiler.java
@@ -29,6 +29,7 @@ import javax.tools.DiagnosticCollector;
 import javax.tools.DiagnosticListener;
 import javax.tools.JavaFileObject;
 import java.io.File;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
@@ -80,6 +81,11 @@ public class JavaToDafnyCompiler {
 
     public boolean isLibrary(JCTree.JCCompilationUnit compilationUnit) {
         return builtinSources.contains(compilationUnit.getSourceFile());
+    }
+
+    public boolean isLibrary(URI sourceURI) {
+        return builtinSources.stream()
+                .anyMatch( file -> file.toUri().equals(sourceURI));
     }
 
 


### PR DESCRIPTION
### What was changed?
Added check for source of error message to ensure it is from a non-library source when fetching mapping to original Java code

### How has this been tested?
Locally tested using code snippet in [this issue](https://github.com/aws/jverify/issues/352)

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/aws/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
