### PR TITLE
Fix link to SimpleNullCheck in user guide

### DIFF
--- a/docs/guide/src/example_usecases.md
+++ b/docs/guide/src/example_usecases.md
@@ -7,7 +7,7 @@ The code examples make use of various JVerify features that, unless you've read 
 Without instructions, JVerify will detect many common types of bugs. Here's some code that shows two `NullPointerException`s being detected by JVerify:
 
 ```java
-{{#include ../../../examples/src/test/java/org/strata/jverify/examples/NullCheck.java}}
+{{#include ../../../examples/src/test/java/org/strata/jverify/examples/SimpleNullCheck.java}}
 ```
 
 #### Prevent dereferencing null without checking it


### PR DESCRIPTION
PR #351 changed the name of the file `NullCheck.java` to `SimpleNullCheck.java`, but did not update the reference in the user guide. This PR fixes it.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/aws/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
