### PR TITLE
Fix deploy pages flow

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -31,7 +31,7 @@ jobs:
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1
         with:
-          mdbook-version: 'latest'
+          mdbook-version: '0.4.52'
 
       - name: Build
         working-directory: docs/guide


### PR DESCRIPTION
### What was changed?
Fix deploy pages flow, which was broken since an mdBook update: https://github.com/aws/jverify/actions/workflows/deploy-pages.yml

### How has this been tested?
Manually tested that the configured static version builds and looks good

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/aws/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
