### PR TITLE
Fix name collisions in Strata backend

### DIFF
--- a/verifier/src/main/java/org/strata/jverify/verifier/compiler/generator/laurel/JavaToLaurelCompiler.java
+++ b/verifier/src/main/java/org/strata/jverify/verifier/compiler/generator/laurel/JavaToLaurelCompiler.java
@@ -121,6 +121,10 @@ public class JavaToLaurelCompiler {
         };
     }
 
+    private static String qualifiedMethodName(Symbol.MethodSymbol sym) {
+        return sym.outermostClass().name + "_" + sym.name;
+    }
+
     private class StaticMethodCollector extends TreeScanner {
         final List<Procedure> procedures = new ArrayList<>();
 
@@ -129,7 +133,7 @@ public class JavaToLaurelCompiler {
             if ((method.mods.flags & Flags.STATIC) != 0) {
                 // TODO: when overloaded methods are supported, disambiguate names
                 //  (e.g. by appending parameter type suffixes) to avoid duplicate procedure names in Laurel.
-                String methodName = method.name.toString();
+                String methodName = qualifiedMethodName(method.sym);
 
                 List<Parameter> params = new ArrayList<>();
                 for (var param : method.params) {
@@ -322,7 +326,7 @@ public class JavaToLaurelCompiler {
                         yield convertJVerifyCall(invocation, jverifyMethod, renames);
                     }
                     var methodSym = (Symbol.MethodSymbol) TreeInfo.symbol(invocation.getMethodSelect());
-                    String calleeName = methodSym.getSimpleName().toString();
+                    String calleeName = qualifiedMethodName(methodSym);
                     List<StmtExpr> args = new ArrayList<>();
                     for (var arg : invocation.args) {
                         args.add(convertExpression(arg, renames));

--- a/verifier/src/test/java/org/strata/jverify/verifier/tests/examples/NameCollision.java
+++ b/verifier/src/test/java/org/strata/jverify/verifier/tests/examples/NameCollision.java
@@ -1,0 +1,21 @@
+package org.strata.jverify.verifier.tests.examples;
+
+import org.strata.jverify.testengine.JVerifyTest;
+
+import static org.strata.jverify.JVerify.*;
+
+// Tests that "increment" doesn't collide with Strata's built-in heap function,
+// and that "compute" doesn't collide across classes.
+@JVerifyTest(exitCode = 0, methodsVerified = 5,
+        additionalFiles = { "./NameCollisionHelper.java" })
+class NameCollision {
+    static int increment(int x) {
+        precondition(0 <= x && x < 2147483647);
+        return x + 1;
+    }
+
+    static int compute(int x) {
+        precondition(0 <= x && x <= 1000);
+        return x * 2;
+    }
+}

--- a/verifier/src/test/java/org/strata/jverify/verifier/tests/examples/NameCollisionHelper.java
+++ b/verifier/src/test/java/org/strata/jverify/verifier/tests/examples/NameCollisionHelper.java
@@ -1,0 +1,11 @@
+package org.strata.jverify.verifier.tests.examples;
+
+import static org.strata.jverify.JVerify.*;
+
+// Helper class with same method name as NameCollision to test cross-class collision
+class NameCollisionHelper {
+    static int compute(int x) {
+        precondition(0 <= x && x <= 1000);
+        return x + 1;
+    }
+}


### PR DESCRIPTION
Use class-qualified names (`ClassName_methodName`) in the Laurel backend to avoid collisions with Strata built-ins (`increment`, `select`, `update`) and between classes with same method names.

## Tests

- `StrataNameCollision` — method named `increment` no longer collides with Strata built-in; cross-class collision with `compute` in `StrataNameCollisionHelper`