### PR TITLE
Bump Strata submodule to latest main

### DIFF
--- a/verifier/src/main/java/com/aws/jverify/laurel/Add.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Add.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record Add(
-    SourceRange sourceRange,
-    StmtExpr lhs, StmtExpr rhs
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.add"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/And.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/And.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record And(
-    SourceRange sourceRange,
-    StmtExpr lhs, StmtExpr rhs
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.and"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/AndThen.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/AndThen.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record AndThen(
-    SourceRange sourceRange,
-    StmtExpr lhs, StmtExpr rhs
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.andThen"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/AsType.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/AsType.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record AsType(
-    SourceRange sourceRange,
-    StmtExpr target, java.lang.String typeName
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.asType"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Assert.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Assert.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record Assert(
-    SourceRange sourceRange,
-    StmtExpr cond, java.util.Optional<OptionalErrorMessage> errorMessage
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.assert"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Assign.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Assign.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record Assign(
-    SourceRange sourceRange,
-    StmtExpr target, StmtExpr value
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.assign"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Assume.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Assume.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record Assume(
-    SourceRange sourceRange,
-    StmtExpr cond
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.assume"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Block.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Block.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record Block(
-    SourceRange sourceRange,
-    java.util.List<StmtExpr> stmts
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.block"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Body.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Body.java
@@ -1,0 +1,31 @@
+package com.aws.jverify.laurel;
+
+public sealed interface Body extends Node permits Body.Body_, Body.ExternalBody {
+    public record Body_(
+        SourceRange sourceRange,
+        StmtExpr body
+    ) implements Body {
+        @Override
+        public java.lang.String operationName() { return "Laurel.body"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.body", sourceRange());
+            sexp.add($s.serialize(body()));
+            return sexp;
+        }
+    }
+
+    public record ExternalBody(
+        SourceRange sourceRange
+    ) implements Body {
+        @Override
+        public java.lang.String operationName() { return "Laurel.externalBody"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.externalBody", sourceRange());
+            return sexp;
+        }
+    }
+}

--- a/verifier/src/main/java/com/aws/jverify/laurel/BoolType.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/BoolType.java
@@ -1,8 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record BoolType(
-    SourceRange sourceRange
-) implements LaurelType {
-    @Override
-    public java.lang.String operationName() { return "Laurel.boolType"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Call.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Call.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record Call(
-    SourceRange sourceRange,
-    StmtExpr callee, java.util.List<StmtExpr> args
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.call"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Command.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Command.java
@@ -1,3 +1,63 @@
 package com.aws.jverify.laurel;
 
-public sealed interface Command extends Node permits CompositeCommand, ProcedureCommand, DatatypeCommand, ConstrainedTypeCommand {}
+public sealed interface Command extends Node permits Command.CompositeCommand, Command.ProcedureCommand, Command.DatatypeCommand, Command.ConstrainedTypeCommand {
+    public record CompositeCommand(
+        SourceRange sourceRange,
+        Composite composite
+    ) implements Command {
+        @Override
+        public java.lang.String operationName() { return "Laurel.compositeCommand"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.compositeCommand", sourceRange());
+            sexp.add($s.serialize(composite()));
+            return sexp;
+        }
+    }
+
+    public record ProcedureCommand(
+        SourceRange sourceRange,
+        Procedure procedure
+    ) implements Command {
+        @Override
+        public java.lang.String operationName() { return "Laurel.procedureCommand"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.procedureCommand", sourceRange());
+            sexp.add($s.serialize(procedure()));
+            return sexp;
+        }
+    }
+
+    public record DatatypeCommand(
+        SourceRange sourceRange,
+        Datatype datatype
+    ) implements Command {
+        @Override
+        public java.lang.String operationName() { return "Laurel.datatypeCommand"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.datatypeCommand", sourceRange());
+            sexp.add($s.serialize(datatype()));
+            return sexp;
+        }
+    }
+
+    public record ConstrainedTypeCommand(
+        SourceRange sourceRange,
+        ConstrainedType ct
+    ) implements Command {
+        @Override
+        public java.lang.String operationName() { return "Laurel.constrainedTypeCommand"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.constrainedTypeCommand", sourceRange());
+            sexp.add($s.serialize(ct()));
+            return sexp;
+        }
+    }
+}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Composite.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Composite.java
@@ -1,3 +1,21 @@
 package com.aws.jverify.laurel;
 
-public sealed interface Composite extends Node permits Composite_ {}
+public sealed interface Composite extends Node permits Composite.Of {
+    public record Of(
+        SourceRange sourceRange,
+        java.lang.String name, java.util.Optional<Extends> extending, java.util.List<Field> fields, java.util.List<Procedure> procedures
+    ) implements Composite {
+        @Override
+        public java.lang.String operationName() { return "Laurel.composite"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.composite", sourceRange());
+            sexp.add($s.serializeIdent(name()));
+            sexp.add($s.serializeOption(extending(), $s::serialize));
+            sexp.add($s.serializeSeq(fields(), "seq", $s::serialize));
+            sexp.add($s.serializeSeq(procedures(), "seq", $s::serialize));
+            return sexp;
+        }
+    }
+}

--- a/verifier/src/main/java/com/aws/jverify/laurel/CompositeCommand.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/CompositeCommand.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record CompositeCommand(
-    SourceRange sourceRange,
-    Composite composite
-) implements Command {
-    @Override
-    public java.lang.String operationName() { return "Laurel.compositeCommand"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/CompositeType.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/CompositeType.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record CompositeType(
-    SourceRange sourceRange,
-    java.lang.String name
-) implements LaurelType {
-    @Override
-    public java.lang.String operationName() { return "Laurel.compositeType"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Composite_.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Composite_.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record Composite_(
-    SourceRange sourceRange,
-    java.lang.String name, java.util.Optional<OptionalExtends> extending, java.util.List<Field> fields
-) implements Composite {
-    @Override
-    public java.lang.String operationName() { return "Laurel.composite"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/ConstrainedType.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/ConstrainedType.java
@@ -1,3 +1,22 @@
 package com.aws.jverify.laurel;
 
-public sealed interface ConstrainedType extends Node permits ConstrainedType_ {}
+public sealed interface ConstrainedType extends Node permits ConstrainedType.Of {
+    public record Of(
+        SourceRange sourceRange,
+        java.lang.String name, java.lang.String valueName, LaurelType base, StmtExpr constraint, StmtExpr witness
+    ) implements ConstrainedType {
+        @Override
+        public java.lang.String operationName() { return "Laurel.constrainedType"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.constrainedType", sourceRange());
+            sexp.add($s.serializeIdent(name()));
+            sexp.add($s.serializeIdent(valueName()));
+            sexp.add($s.serialize(base()));
+            sexp.add($s.serialize(constraint()));
+            sexp.add($s.serialize(witness()));
+            return sexp;
+        }
+    }
+}

--- a/verifier/src/main/java/com/aws/jverify/laurel/ConstrainedTypeCommand.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/ConstrainedTypeCommand.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record ConstrainedTypeCommand(
-    SourceRange sourceRange,
-    ConstrainedType ct
-) implements Command {
-    @Override
-    public java.lang.String operationName() { return "Laurel.constrainedTypeCommand"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/ConstrainedType_.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/ConstrainedType_.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record ConstrainedType_(
-    SourceRange sourceRange,
-    java.lang.String name, java.lang.String valueName, LaurelType base, StmtExpr constraint, StmtExpr witness
-) implements ConstrainedType {
-    @Override
-    public java.lang.String operationName() { return "Laurel.constrainedType"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Datatype.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Datatype.java
@@ -1,3 +1,19 @@
 package com.aws.jverify.laurel;
 
-public sealed interface Datatype extends Node permits Datatype_ {}
+public sealed interface Datatype extends Node permits Datatype.Of {
+    public record Of(
+        SourceRange sourceRange,
+        java.lang.String name, DatatypeConstructorList constructors
+    ) implements Datatype {
+        @Override
+        public java.lang.String operationName() { return "Laurel.datatype"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.datatype", sourceRange());
+            sexp.add($s.serializeIdent(name()));
+            sexp.add($s.serialize(constructors()));
+            return sexp;
+        }
+    }
+}

--- a/verifier/src/main/java/com/aws/jverify/laurel/DatatypeCommand.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/DatatypeCommand.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record DatatypeCommand(
-    SourceRange sourceRange,
-    Datatype datatype
-) implements Command {
-    @Override
-    public java.lang.String operationName() { return "Laurel.datatypeCommand"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/DatatypeConstructor.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/DatatypeConstructor.java
@@ -1,3 +1,34 @@
 package com.aws.jverify.laurel;
 
-public sealed interface DatatypeConstructor extends Node permits DatatypeConstructor_, DatatypeConstructorNoArgs {}
+public sealed interface DatatypeConstructor extends Node permits DatatypeConstructor.DatatypeConstructor_, DatatypeConstructor.DatatypeConstructorNoArgs {
+    public record DatatypeConstructor_(
+        SourceRange sourceRange,
+        java.lang.String name, java.util.List<DatatypeConstructorArg> args
+    ) implements DatatypeConstructor {
+        @Override
+        public java.lang.String operationName() { return "Laurel.datatypeConstructor"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.datatypeConstructor", sourceRange());
+            sexp.add($s.serializeIdent(name()));
+            sexp.add($s.serializeSeq(args(), "commaSepList", $s::serialize));
+            return sexp;
+        }
+    }
+
+    public record DatatypeConstructorNoArgs(
+        SourceRange sourceRange,
+        java.lang.String name
+    ) implements DatatypeConstructor {
+        @Override
+        public java.lang.String operationName() { return "Laurel.datatypeConstructorNoArgs"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.datatypeConstructorNoArgs", sourceRange());
+            sexp.add($s.serializeIdent(name()));
+            return sexp;
+        }
+    }
+}

--- a/verifier/src/main/java/com/aws/jverify/laurel/DatatypeConstructorArg.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/DatatypeConstructorArg.java
@@ -1,3 +1,19 @@
 package com.aws.jverify.laurel;
 
-public sealed interface DatatypeConstructorArg extends Node permits DatatypeConstructorArg_ {}
+public sealed interface DatatypeConstructorArg extends Node permits DatatypeConstructorArg.Of {
+    public record Of(
+        SourceRange sourceRange,
+        java.lang.String name, LaurelType argType
+    ) implements DatatypeConstructorArg {
+        @Override
+        public java.lang.String operationName() { return "Laurel.datatypeConstructorArg"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.datatypeConstructorArg", sourceRange());
+            sexp.add($s.serializeIdent(name()));
+            sexp.add($s.serialize(argType()));
+            return sexp;
+        }
+    }
+}

--- a/verifier/src/main/java/com/aws/jverify/laurel/DatatypeConstructorArg_.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/DatatypeConstructorArg_.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record DatatypeConstructorArg_(
-    SourceRange sourceRange,
-    java.lang.String name, LaurelType argType
-) implements DatatypeConstructorArg {
-    @Override
-    public java.lang.String operationName() { return "Laurel.datatypeConstructorArg"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/DatatypeConstructorList.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/DatatypeConstructorList.java
@@ -1,3 +1,18 @@
 package com.aws.jverify.laurel;
 
-public sealed interface DatatypeConstructorList extends Node permits DatatypeConstructorList_ {}
+public sealed interface DatatypeConstructorList extends Node permits DatatypeConstructorList.Of {
+    public record Of(
+        SourceRange sourceRange,
+        java.util.List<DatatypeConstructor> constructors
+    ) implements DatatypeConstructorList {
+        @Override
+        public java.lang.String operationName() { return "Laurel.datatypeConstructorList"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.datatypeConstructorList", sourceRange());
+            sexp.add($s.serializeSeq(constructors(), "commaSepList", $s::serialize));
+            return sexp;
+        }
+    }
+}

--- a/verifier/src/main/java/com/aws/jverify/laurel/DatatypeConstructorList_.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/DatatypeConstructorList_.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record DatatypeConstructorList_(
-    SourceRange sourceRange,
-    java.util.List<DatatypeConstructor> constructors
-) implements DatatypeConstructorList {
-    @Override
-    public java.lang.String operationName() { return "Laurel.datatypeConstructorList"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/DatatypeConstructorNoArgs.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/DatatypeConstructorNoArgs.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record DatatypeConstructorNoArgs(
-    SourceRange sourceRange,
-    java.lang.String name
-) implements DatatypeConstructor {
-    @Override
-    public java.lang.String operationName() { return "Laurel.datatypeConstructorNoArgs"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/DatatypeConstructor_.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/DatatypeConstructor_.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record DatatypeConstructor_(
-    SourceRange sourceRange,
-    java.lang.String name, java.util.List<DatatypeConstructorArg> args
-) implements DatatypeConstructor {
-    @Override
-    public java.lang.String operationName() { return "Laurel.datatypeConstructor"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Datatype_.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Datatype_.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record Datatype_(
-    SourceRange sourceRange,
-    java.lang.String name, DatatypeConstructorList constructors
-) implements Datatype {
-    @Override
-    public java.lang.String operationName() { return "Laurel.datatype"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Div.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Div.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record Div(
-    SourceRange sourceRange,
-    StmtExpr lhs, StmtExpr rhs
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.div"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/DivT.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/DivT.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record DivT(
-    SourceRange sourceRange,
-    StmtExpr lhs, StmtExpr rhs
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.divT"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/ElseBranch.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/ElseBranch.java
@@ -1,0 +1,18 @@
+package com.aws.jverify.laurel;
+
+public sealed interface ElseBranch extends Node permits ElseBranch.Of {
+    public record Of(
+        SourceRange sourceRange,
+        StmtExpr stmts
+    ) implements ElseBranch {
+        @Override
+        public java.lang.String operationName() { return "Laurel.elseBranch"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.elseBranch", sourceRange());
+            sexp.add($s.serialize(stmts()));
+            return sexp;
+        }
+    }
+}

--- a/verifier/src/main/java/com/aws/jverify/laurel/EnsuresClause.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/EnsuresClause.java
@@ -1,3 +1,19 @@
 package com.aws.jverify.laurel;
 
-public sealed interface EnsuresClause extends Node permits EnsuresClause_ {}
+public sealed interface EnsuresClause extends Node permits EnsuresClause.Of {
+    public record Of(
+        SourceRange sourceRange,
+        StmtExpr cond, java.util.Optional<ErrorSummary> errorMessage
+    ) implements EnsuresClause {
+        @Override
+        public java.lang.String operationName() { return "Laurel.ensuresClause"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.ensuresClause", sourceRange());
+            sexp.add($s.serialize(cond()));
+            sexp.add($s.serializeOption(errorMessage(), $s::serialize));
+            return sexp;
+        }
+    }
+}

--- a/verifier/src/main/java/com/aws/jverify/laurel/EnsuresClause_.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/EnsuresClause_.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record EnsuresClause_(
-    SourceRange sourceRange,
-    StmtExpr cond, java.util.Optional<OptionalErrorMessage> errorMessage
-) implements EnsuresClause {
-    @Override
-    public java.lang.String operationName() { return "Laurel.ensuresClause"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Eq.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Eq.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record Eq(
-    SourceRange sourceRange,
-    StmtExpr lhs, StmtExpr rhs
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.eq"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/ErrorMessage.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/ErrorMessage.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record ErrorMessage(
-    SourceRange sourceRange,
-    java.lang.String msg
-) implements OptionalErrorMessage {
-    @Override
-    public java.lang.String operationName() { return "Laurel.errorMessage"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/ErrorSummary.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/ErrorSummary.java
@@ -1,0 +1,18 @@
+package com.aws.jverify.laurel;
+
+public sealed interface ErrorSummary extends Node permits ErrorSummary.Of {
+    public record Of(
+        SourceRange sourceRange,
+        java.lang.String msg
+    ) implements ErrorSummary {
+        @Override
+        public java.lang.String operationName() { return "Laurel.errorSummary"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.errorSummary", sourceRange());
+            sexp.add($s.serializeStrlit(msg()));
+            return sexp;
+        }
+    }
+}

--- a/verifier/src/main/java/com/aws/jverify/laurel/ExistsExpr.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/ExistsExpr.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record ExistsExpr(
-    SourceRange sourceRange,
-    java.lang.String name, LaurelType ty, java.util.Optional<OptionalTrigger> trigger, StmtExpr body
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.existsExpr"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Extends.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Extends.java
@@ -1,0 +1,18 @@
+package com.aws.jverify.laurel;
+
+public sealed interface Extends extends Node permits Extends.Of {
+    public record Of(
+        SourceRange sourceRange,
+        java.util.List<java.lang.String> parents
+    ) implements Extends {
+        @Override
+        public java.lang.String operationName() { return "Laurel.extends"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.extends", sourceRange());
+            sexp.add($s.serializeSeq(parents(), "commaSepList", $s::serializeIdent));
+            return sexp;
+        }
+    }
+}

--- a/verifier/src/main/java/com/aws/jverify/laurel/ExternalBody.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/ExternalBody.java
@@ -1,8 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record ExternalBody(
-    SourceRange sourceRange
-) implements OptionalBody {
-    @Override
-    public java.lang.String operationName() { return "Laurel.externalBody"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Field.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Field.java
@@ -1,3 +1,35 @@
 package com.aws.jverify.laurel;
 
-public sealed interface Field extends Node permits MutableField, ImmutableField {}
+public sealed interface Field extends Node permits Field.MutableField, Field.ImmutableField {
+    public record MutableField(
+        SourceRange sourceRange,
+        java.lang.String name, LaurelType fieldType
+    ) implements Field {
+        @Override
+        public java.lang.String operationName() { return "Laurel.mutableField"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.mutableField", sourceRange());
+            sexp.add($s.serializeIdent(name()));
+            sexp.add($s.serialize(fieldType()));
+            return sexp;
+        }
+    }
+
+    public record ImmutableField(
+        SourceRange sourceRange,
+        java.lang.String name, LaurelType fieldType
+    ) implements Field {
+        @Override
+        public java.lang.String operationName() { return "Laurel.immutableField"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.immutableField", sourceRange());
+            sexp.add($s.serializeIdent(name()));
+            sexp.add($s.serialize(fieldType()));
+            return sexp;
+        }
+    }
+}

--- a/verifier/src/main/java/com/aws/jverify/laurel/FieldAccess.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/FieldAccess.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record FieldAccess(
-    SourceRange sourceRange,
-    StmtExpr obj, java.lang.String field
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.fieldAccess"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Float64Type.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Float64Type.java
@@ -1,8 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record Float64Type(
-    SourceRange sourceRange
-) implements LaurelType {
-    @Override
-    public java.lang.String operationName() { return "Laurel.float64Type"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/ForLoop.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/ForLoop.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record ForLoop(
-    SourceRange sourceRange,
-    StmtExpr init, StmtExpr cond, StmtExpr step, java.util.List<InvariantClause> invariants, StmtExpr body
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.forLoop"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/ForallExpr.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/ForallExpr.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record ForallExpr(
-    SourceRange sourceRange,
-    java.lang.String name, LaurelType ty, java.util.Optional<OptionalTrigger> trigger, StmtExpr body
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.forallExpr"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Function.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Function.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record Function(
-    SourceRange sourceRange,
-    java.lang.String name, java.util.List<Parameter> parameters, java.util.Optional<OptionalReturnType> returnType, java.util.Optional<ReturnParameters> returnParameters, java.util.List<RequiresClause> requires, java.util.List<EnsuresClause> ensures, java.util.List<ModifiesClause> modifies, java.util.Optional<OptionalBody> body
-) implements Procedure {
-    @Override
-    public java.lang.String operationName() { return "Laurel.function"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Ge.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Ge.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record Ge(
-    SourceRange sourceRange,
-    StmtExpr lhs, StmtExpr rhs
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.ge"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Gt.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Gt.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record Gt(
-    SourceRange sourceRange,
-    StmtExpr lhs, StmtExpr rhs
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.gt"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Hole.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Hole.java
@@ -1,8 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record Hole(
-    SourceRange sourceRange
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.hole"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Identifier.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Identifier.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record Identifier(
-    SourceRange sourceRange,
-    java.lang.String name
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.identifier"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/IfThenElse.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/IfThenElse.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record IfThenElse(
-    SourceRange sourceRange,
-    StmtExpr cond, StmtExpr thenBranch, java.util.Optional<OptionalElse> elseBranch
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.ifThenElse"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/ImmutableField.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/ImmutableField.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record ImmutableField(
-    SourceRange sourceRange,
-    java.lang.String name, LaurelType fieldType
-) implements Field {
-    @Override
-    public java.lang.String operationName() { return "Laurel.immutableField"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Implies.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Implies.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record Implies(
-    SourceRange sourceRange,
-    StmtExpr lhs, StmtExpr rhs
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.implies"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Initializer.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Initializer.java
@@ -1,0 +1,18 @@
+package com.aws.jverify.laurel;
+
+public sealed interface Initializer extends Node permits Initializer.Of {
+    public record Of(
+        SourceRange sourceRange,
+        StmtExpr value
+    ) implements Initializer {
+        @Override
+        public java.lang.String operationName() { return "Laurel.initializer"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.initializer", sourceRange());
+            sexp.add($s.serialize(value()));
+            return sexp;
+        }
+    }
+}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Int.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Int.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record Int(
-    SourceRange sourceRange,
-    java.math.BigInteger n
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.int"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/IntType.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/IntType.java
@@ -1,8 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record IntType(
-    SourceRange sourceRange
-) implements LaurelType {
-    @Override
-    public java.lang.String operationName() { return "Laurel.intType"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/InvariantClause.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/InvariantClause.java
@@ -1,3 +1,18 @@
 package com.aws.jverify.laurel;
 
-public sealed interface InvariantClause extends Node permits InvariantClause_ {}
+public sealed interface InvariantClause extends Node permits InvariantClause.Of {
+    public record Of(
+        SourceRange sourceRange,
+        StmtExpr cond
+    ) implements InvariantClause {
+        @Override
+        public java.lang.String operationName() { return "Laurel.invariantClause"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.invariantClause", sourceRange());
+            sexp.add($s.serialize(cond()));
+            return sexp;
+        }
+    }
+}

--- a/verifier/src/main/java/com/aws/jverify/laurel/InvariantClause_.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/InvariantClause_.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record InvariantClause_(
-    SourceRange sourceRange,
-    StmtExpr cond
-) implements InvariantClause {
-    @Override
-    public java.lang.String operationName() { return "Laurel.invariantClause"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/InvokeOnClause.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/InvokeOnClause.java
@@ -1,0 +1,18 @@
+package com.aws.jverify.laurel;
+
+public sealed interface InvokeOnClause extends Node permits InvokeOnClause.Of {
+    public record Of(
+        SourceRange sourceRange,
+        StmtExpr trigger
+    ) implements InvokeOnClause {
+        @Override
+        public java.lang.String operationName() { return "Laurel.invokeOnClause"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.invokeOnClause", sourceRange());
+            sexp.add($s.serialize(trigger()));
+            return sexp;
+        }
+    }
+}

--- a/verifier/src/main/java/com/aws/jverify/laurel/IonSerializer.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/IonSerializer.java
@@ -6,219 +6,76 @@ import com.amazon.ion.system.*;
 public class IonSerializer {
     private final IonSystem ion;
 
-    private static final java.util.Map<String, java.util.Map<String, String>> SEPARATORS = java.util.Map.ofEntries(
-        java.util.Map.entry("Laurel.mapType", java.util.Map.ofEntries(java.util.Map.entry("keyType", "seq"), java.util.Map.entry("valueType", "seq"))),
-        java.util.Map.entry("Laurel.compositeType", java.util.Map.ofEntries(java.util.Map.entry("name", "seq"))),
-        java.util.Map.entry("Laurel.literalBool", java.util.Map.ofEntries(java.util.Map.entry("b", "seq"))),
-        java.util.Map.entry("Laurel.int", java.util.Map.ofEntries(java.util.Map.entry("n", "seq"))),
-        java.util.Map.entry("Laurel.real", java.util.Map.ofEntries(java.util.Map.entry("d", "seq"))),
-        java.util.Map.entry("Laurel.string", java.util.Map.ofEntries(java.util.Map.entry("s", "seq"))),
-        java.util.Map.entry("Laurel.optionalType", java.util.Map.ofEntries(java.util.Map.entry("varType", "seq"))),
-        java.util.Map.entry("Laurel.optionalAssignment", java.util.Map.ofEntries(java.util.Map.entry("value", "seq"))),
-        java.util.Map.entry("Laurel.varDecl", java.util.Map.ofEntries(java.util.Map.entry("name", "seq"), java.util.Map.entry("varType", "seq"), java.util.Map.entry("assignment", "seq"))),
-        java.util.Map.entry("Laurel.call", java.util.Map.ofEntries(java.util.Map.entry("callee", "seq"), java.util.Map.entry("args", "commaSepList"))),
-        java.util.Map.entry("Laurel.new", java.util.Map.ofEntries(java.util.Map.entry("name", "seq"))),
-        java.util.Map.entry("Laurel.fieldAccess", java.util.Map.ofEntries(java.util.Map.entry("obj", "seq"), java.util.Map.entry("field", "seq"))),
-        java.util.Map.entry("Laurel.identifier", java.util.Map.ofEntries(java.util.Map.entry("name", "seq"))),
-        java.util.Map.entry("Laurel.parenthesis", java.util.Map.ofEntries(java.util.Map.entry("inner", "seq"))),
-        java.util.Map.entry("Laurel.assign", java.util.Map.ofEntries(java.util.Map.entry("target", "seq"), java.util.Map.entry("value", "seq"))),
-        java.util.Map.entry("Laurel.add", java.util.Map.ofEntries(java.util.Map.entry("lhs", "seq"), java.util.Map.entry("rhs", "seq"))),
-        java.util.Map.entry("Laurel.sub", java.util.Map.ofEntries(java.util.Map.entry("lhs", "seq"), java.util.Map.entry("rhs", "seq"))),
-        java.util.Map.entry("Laurel.mul", java.util.Map.ofEntries(java.util.Map.entry("lhs", "seq"), java.util.Map.entry("rhs", "seq"))),
-        java.util.Map.entry("Laurel.div", java.util.Map.ofEntries(java.util.Map.entry("lhs", "seq"), java.util.Map.entry("rhs", "seq"))),
-        java.util.Map.entry("Laurel.mod", java.util.Map.ofEntries(java.util.Map.entry("lhs", "seq"), java.util.Map.entry("rhs", "seq"))),
-        java.util.Map.entry("Laurel.divT", java.util.Map.ofEntries(java.util.Map.entry("lhs", "seq"), java.util.Map.entry("rhs", "seq"))),
-        java.util.Map.entry("Laurel.modT", java.util.Map.ofEntries(java.util.Map.entry("lhs", "seq"), java.util.Map.entry("rhs", "seq"))),
-        java.util.Map.entry("Laurel.eq", java.util.Map.ofEntries(java.util.Map.entry("lhs", "seq"), java.util.Map.entry("rhs", "seq"))),
-        java.util.Map.entry("Laurel.neq", java.util.Map.ofEntries(java.util.Map.entry("lhs", "seq"), java.util.Map.entry("rhs", "seq"))),
-        java.util.Map.entry("Laurel.gt", java.util.Map.ofEntries(java.util.Map.entry("lhs", "seq"), java.util.Map.entry("rhs", "seq"))),
-        java.util.Map.entry("Laurel.lt", java.util.Map.ofEntries(java.util.Map.entry("lhs", "seq"), java.util.Map.entry("rhs", "seq"))),
-        java.util.Map.entry("Laurel.le", java.util.Map.ofEntries(java.util.Map.entry("lhs", "seq"), java.util.Map.entry("rhs", "seq"))),
-        java.util.Map.entry("Laurel.ge", java.util.Map.ofEntries(java.util.Map.entry("lhs", "seq"), java.util.Map.entry("rhs", "seq"))),
-        java.util.Map.entry("Laurel.and", java.util.Map.ofEntries(java.util.Map.entry("lhs", "seq"), java.util.Map.entry("rhs", "seq"))),
-        java.util.Map.entry("Laurel.or", java.util.Map.ofEntries(java.util.Map.entry("lhs", "seq"), java.util.Map.entry("rhs", "seq"))),
-        java.util.Map.entry("Laurel.andThen", java.util.Map.ofEntries(java.util.Map.entry("lhs", "seq"), java.util.Map.entry("rhs", "seq"))),
-        java.util.Map.entry("Laurel.orElse", java.util.Map.ofEntries(java.util.Map.entry("lhs", "seq"), java.util.Map.entry("rhs", "seq"))),
-        java.util.Map.entry("Laurel.implies", java.util.Map.ofEntries(java.util.Map.entry("lhs", "seq"), java.util.Map.entry("rhs", "seq"))),
-        java.util.Map.entry("Laurel.strConcat", java.util.Map.ofEntries(java.util.Map.entry("lhs", "seq"), java.util.Map.entry("rhs", "seq"))),
-        java.util.Map.entry("Laurel.not", java.util.Map.ofEntries(java.util.Map.entry("inner", "seq"))),
-        java.util.Map.entry("Laurel.neg", java.util.Map.ofEntries(java.util.Map.entry("inner", "seq"))),
-        java.util.Map.entry("Laurel.optionalTrigger", java.util.Map.ofEntries(java.util.Map.entry("trigger", "seq"))),
-        java.util.Map.entry("Laurel.forallExpr", java.util.Map.ofEntries(java.util.Map.entry("name", "seq"), java.util.Map.entry("ty", "seq"), java.util.Map.entry("trigger", "seq"), java.util.Map.entry("body", "seq"))),
-        java.util.Map.entry("Laurel.existsExpr", java.util.Map.ofEntries(java.util.Map.entry("name", "seq"), java.util.Map.entry("ty", "seq"), java.util.Map.entry("trigger", "seq"), java.util.Map.entry("body", "seq"))),
-        java.util.Map.entry("Laurel.errorMessage", java.util.Map.ofEntries(java.util.Map.entry("msg", "seq"))),
-        java.util.Map.entry("Laurel.optionalElse", java.util.Map.ofEntries(java.util.Map.entry("stmts", "seq"))),
-        java.util.Map.entry("Laurel.ifThenElse", java.util.Map.ofEntries(java.util.Map.entry("cond", "seq"), java.util.Map.entry("thenBranch", "seq"), java.util.Map.entry("elseBranch", "seq"))),
-        java.util.Map.entry("Laurel.assert", java.util.Map.ofEntries(java.util.Map.entry("cond", "seq"), java.util.Map.entry("errorMessage", "seq"))),
-        java.util.Map.entry("Laurel.assume", java.util.Map.ofEntries(java.util.Map.entry("cond", "seq"))),
-        java.util.Map.entry("Laurel.return", java.util.Map.ofEntries(java.util.Map.entry("value", "seq"))),
-        java.util.Map.entry("Laurel.block", java.util.Map.ofEntries(java.util.Map.entry("stmts", "semicolonSepList"))),
-        java.util.Map.entry("Laurel.invariantClause", java.util.Map.ofEntries(java.util.Map.entry("cond", "seq"))),
-        java.util.Map.entry("Laurel.while", java.util.Map.ofEntries(java.util.Map.entry("cond", "seq"), java.util.Map.entry("invariants", "seq"), java.util.Map.entry("body", "seq"))),
-        java.util.Map.entry("Laurel.forLoop", java.util.Map.ofEntries(java.util.Map.entry("init", "seq"), java.util.Map.entry("cond", "seq"), java.util.Map.entry("step", "seq"), java.util.Map.entry("invariants", "seq"), java.util.Map.entry("body", "seq"))),
-        java.util.Map.entry("Laurel.parameter", java.util.Map.ofEntries(java.util.Map.entry("name", "seq"), java.util.Map.entry("paramType", "seq"))),
-        java.util.Map.entry("Laurel.mutableField", java.util.Map.ofEntries(java.util.Map.entry("name", "seq"), java.util.Map.entry("fieldType", "seq"))),
-        java.util.Map.entry("Laurel.immutableField", java.util.Map.ofEntries(java.util.Map.entry("name", "seq"), java.util.Map.entry("fieldType", "seq"))),
-        java.util.Map.entry("Laurel.isType", java.util.Map.ofEntries(java.util.Map.entry("target", "seq"), java.util.Map.entry("typeName", "seq"))),
-        java.util.Map.entry("Laurel.asType", java.util.Map.ofEntries(java.util.Map.entry("target", "seq"), java.util.Map.entry("typeName", "seq"))),
-        java.util.Map.entry("Laurel.optionalExtends", java.util.Map.ofEntries(java.util.Map.entry("parents", "commaSepList"))),
-        java.util.Map.entry("Laurel.composite", java.util.Map.ofEntries(java.util.Map.entry("name", "seq"), java.util.Map.entry("extending", "seq"), java.util.Map.entry("fields", "seq"))),
-        java.util.Map.entry("Laurel.datatypeConstructorArg", java.util.Map.ofEntries(java.util.Map.entry("name", "seq"), java.util.Map.entry("argType", "seq"))),
-        java.util.Map.entry("Laurel.datatypeConstructor", java.util.Map.ofEntries(java.util.Map.entry("name", "seq"), java.util.Map.entry("args", "commaSepList"))),
-        java.util.Map.entry("Laurel.datatypeConstructorNoArgs", java.util.Map.ofEntries(java.util.Map.entry("name", "seq"))),
-        java.util.Map.entry("Laurel.datatypeConstructorList", java.util.Map.ofEntries(java.util.Map.entry("constructors", "commaSepList"))),
-        java.util.Map.entry("Laurel.datatype", java.util.Map.ofEntries(java.util.Map.entry("name", "seq"), java.util.Map.entry("constructors", "seq"))),
-        java.util.Map.entry("Laurel.optionalReturnType", java.util.Map.ofEntries(java.util.Map.entry("returnType", "seq"))),
-        java.util.Map.entry("Laurel.requiresClause", java.util.Map.ofEntries(java.util.Map.entry("cond", "seq"), java.util.Map.entry("errorMessage", "seq"))),
-        java.util.Map.entry("Laurel.ensuresClause", java.util.Map.ofEntries(java.util.Map.entry("cond", "seq"), java.util.Map.entry("errorMessage", "seq"))),
-        java.util.Map.entry("Laurel.modifiesClause", java.util.Map.ofEntries(java.util.Map.entry("refs", "commaSepList"))),
-        java.util.Map.entry("Laurel.returnParameters", java.util.Map.ofEntries(java.util.Map.entry("parameters", "commaSepList"))),
-        java.util.Map.entry("Laurel.optionalBody", java.util.Map.ofEntries(java.util.Map.entry("body", "seq"))),
-        java.util.Map.entry("Laurel.procedure", java.util.Map.ofEntries(java.util.Map.entry("name", "seq"), java.util.Map.entry("parameters", "commaSepList"), java.util.Map.entry("returnType", "seq"), java.util.Map.entry("returnParameters", "seq"), java.util.Map.entry("requires", "seq"), java.util.Map.entry("ensures", "seq"), java.util.Map.entry("modifies", "seq"), java.util.Map.entry("body", "seq"))),
-        java.util.Map.entry("Laurel.function", java.util.Map.ofEntries(java.util.Map.entry("name", "seq"), java.util.Map.entry("parameters", "commaSepList"), java.util.Map.entry("returnType", "seq"), java.util.Map.entry("returnParameters", "seq"), java.util.Map.entry("requires", "seq"), java.util.Map.entry("ensures", "seq"), java.util.Map.entry("modifies", "seq"), java.util.Map.entry("body", "seq"))),
-        java.util.Map.entry("Laurel.constrainedType", java.util.Map.ofEntries(java.util.Map.entry("name", "seq"), java.util.Map.entry("valueName", "seq"), java.util.Map.entry("base", "seq"), java.util.Map.entry("constraint", "seq"), java.util.Map.entry("witness", "seq"))),
-        java.util.Map.entry("Laurel.compositeCommand", java.util.Map.ofEntries(java.util.Map.entry("composite", "seq"))),
-        java.util.Map.entry("Laurel.procedureCommand", java.util.Map.ofEntries(java.util.Map.entry("procedure", "seq"))),
-        java.util.Map.entry("Laurel.datatypeCommand", java.util.Map.ofEntries(java.util.Map.entry("datatype", "seq"))),
-        java.util.Map.entry("Laurel.constrainedTypeCommand", java.util.Map.ofEntries(java.util.Map.entry("ct", "seq"))));
-
     public IonSerializer(IonSystem ion) {
         this.ion = ion;
     }
 
     /** Serialize a node as a top-level command (no "op" wrapper). */
     public IonValue serializeCommand(Node node) {
-        return serializeNode(node);
+        return node.toIon(this);
     }
 
     /** Serialize a node as an argument (with "op" wrapper). */
     public IonValue serialize(Node node) {
-        return wrapOp(serializeNode(node));
+        IonSexp sexp = ion.newEmptySexp();
+        sexp.add(ion.newSymbol("op"));
+        sexp.add(node.toIon(this));
+        return sexp;
     }
 
-    private IonSexp serializeNode(Node node) {
+    /** Create an s-expression with operation name and source range. */
+    public IonSexp newOp(java.lang.String opName, SourceRange sr) {
         IonSexp sexp = ion.newEmptySexp();
-        String opName = node.operationName();
         sexp.add(ion.newSymbol(opName));
-        sexp.add(serializeSourceRange(node.sourceRange()));
-
-        var fieldSeps = SEPARATORS.getOrDefault(opName, java.util.Map.of());
-        for (var component : node.getClass().getRecordComponents()) {
-            if (component.getName().equals("sourceRange")) continue;
-            try {
-                java.lang.Object value = component.getAccessor().invoke(node);
-                String sep = fieldSeps.get(component.getName());
-                sexp.add(serializeArg(value, sep, component.getType()));
-            } catch (java.lang.Exception e) {
-                throw new java.lang.RuntimeException("Failed to serialize " + component.getName(), e);
-            }
+        if (sr.start() == 0 && sr.stop() == 0) {
+            sexp.add(ion.newNull());
+        } else {
+            IonSexp range = ion.newEmptySexp();
+            range.add(ion.newInt(sr.start()));
+            range.add(ion.newInt(sr.stop()));
+            sexp.add(range);
         }
         return sexp;
     }
 
-    private IonValue wrapOp(IonValue inner) {
+    private IonSexp newTagged(String symbol, IonValue value) {
+        IonSexp sexp = ion.newEmptySexp();
+        sexp.add(ion.newSymbol(symbol));
+        sexp.add(ion.newNull());
+        sexp.add(value);
+        return sexp;
+    }
+
+    public IonValue serializeIdent(java.lang.String s) { return newTagged("ident", ion.newString(s)); }
+    public IonValue serializeStrlit(java.lang.String s) { return newTagged("strlit", ion.newString(s)); }
+    public IonValue serializeNum(java.math.BigInteger n) { return newTagged("num", ion.newInt(n)); }
+    public IonValue serializeDecimal(java.math.BigDecimal d) { return newTagged("decimal", ion.newDecimal(d)); }
+    public IonValue serializeBytes(byte[] bytes) { return newTagged("bytes", ion.newBlob(bytes)); }
+
+    public IonValue serializeBool(boolean b) {
+        IonSexp inner = ion.newEmptySexp();
+        inner.add(ion.newSymbol(b ? "Init.boolTrue" : "Init.boolFalse"));
+        inner.add(ion.newNull());
         IonSexp sexp = ion.newEmptySexp();
         sexp.add(ion.newSymbol("op"));
         sexp.add(inner);
         return sexp;
     }
 
-    private IonValue serializeSourceRange(SourceRange sr) {
-        if (sr.start() == 0 && sr.stop() == 0) {
-            return ion.newNull();
-        }
-        IonSexp sexp = ion.newEmptySexp();
-        sexp.add(ion.newInt(sr.start()));
-        sexp.add(ion.newInt(sr.stop()));
-        return sexp;
-    }
-
-    private IonValue serializeArg(java.lang.Object value, String sep, java.lang.Class<?> type) {
-        if (value == null) {
-            return serializeOption(java.util.Optional.empty());
-        }
-        if (value instanceof Node n) {
-            return serialize(n);
-        }
-        if (value instanceof java.lang.String s) {
-            return serializeIdent(s);
-        }
-        if (value instanceof java.math.BigInteger bi) {
-            return serializeNum(bi);
-        }
-        if (value instanceof java.math.BigDecimal bd) {
-            return serializeDecimal(bd);
-        }
-        if (value instanceof byte[] bytes) {
-            return serializeBytes(bytes);
-        }
-        if (value instanceof java.lang.Boolean b) {
-            return serializeBool(b);
-        }
-        if (value instanceof java.util.Optional<?> opt) {
-            return serializeOption(opt);
-        }
-        if (value instanceof java.util.List<?> list) {
-            return serializeSeq(list, sep != null ? sep : "seq");
-        }
-        throw new java.lang.IllegalArgumentException("Unsupported type: " + type);
-    }
-
-    private IonValue serializeIdent(java.lang.String s) {
-        IonSexp sexp = ion.newEmptySexp();
-        sexp.add(ion.newSymbol("ident"));
-        sexp.add(ion.newNull());
-        sexp.add(ion.newString(s));
-        return sexp;
-    }
-
-    private IonValue serializeNum(java.math.BigInteger n) {
-        IonSexp sexp = ion.newEmptySexp();
-        sexp.add(ion.newSymbol("num"));
-        sexp.add(ion.newNull());
-        sexp.add(ion.newInt(n));
-        return sexp;
-    }
-
-    private IonValue serializeDecimal(java.math.BigDecimal d) {
-        IonSexp sexp = ion.newEmptySexp();
-        sexp.add(ion.newSymbol("decimal"));
-        sexp.add(ion.newNull());
-        sexp.add(ion.newDecimal(d));
-        return sexp;
-    }
-
-    private IonValue serializeBytes(byte[] bytes) {
-        IonSexp sexp = ion.newEmptySexp();
-        sexp.add(ion.newSymbol("bytes"));
-        sexp.add(ion.newNull());
-        sexp.add(ion.newBlob(bytes));
-        return sexp;
-    }
-
-    private IonValue serializeBool(boolean b) {
-        IonSexp inner = ion.newEmptySexp();
-        inner.add(ion.newSymbol(b ? "Init.boolTrue" : "Init.boolFalse"));
-        inner.add(ion.newNull());
-        return wrapOp(inner);
-    }
-
-    private IonValue serializeOption(java.util.Optional<?> opt) {
+    public <T> IonValue serializeOption(java.util.Optional<T> opt, java.util.function.Function<T, IonValue> f) {
         IonSexp sexp = ion.newEmptySexp();
         sexp.add(ion.newSymbol("option"));
         sexp.add(ion.newNull());
-        if (opt.isPresent()) {
-            sexp.add(serializeArg(opt.get(), null, opt.get().getClass()));
-        }
+        opt.ifPresent(v -> sexp.add(f.apply(v)));
         return sexp;
     }
 
-    private IonValue serializeSeq(java.util.List<?> list, String sepType) {
+    public <T> IonValue serializeSeq(java.util.List<T> list, java.lang.String sepType, java.util.function.Function<T, IonValue> f) {
         IonSexp sexp = ion.newEmptySexp();
         sexp.add(ion.newSymbol(sepType));
         sexp.add(ion.newNull());
-        for (java.lang.Object item : list) {
-            sexp.add(serializeArg(item, null, item.getClass()));
+        for (T item : list) {
+            sexp.add(f.apply(item));
         }
         return sexp;
     }

--- a/verifier/src/main/java/com/aws/jverify/laurel/IsType.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/IsType.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record IsType(
-    SourceRange sourceRange,
-    StmtExpr target, java.lang.String typeName
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.isType"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Laurel.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Laurel.java
@@ -1,249 +1,264 @@
 package com.aws.jverify.laurel;
 
 public class Laurel {
-    public static LaurelType intType(SourceRange sourceRange) { return new IntType(sourceRange); }
-    public static LaurelType intType() { return new IntType(SourceRange.NONE); }
+    public static LaurelType intType(SourceRange sourceRange) { return new LaurelType.IntType(sourceRange); }
+    public static LaurelType intType() { return new LaurelType.IntType(SourceRange.NONE); }
 
-    public static LaurelType boolType(SourceRange sourceRange) { return new BoolType(sourceRange); }
-    public static LaurelType boolType() { return new BoolType(SourceRange.NONE); }
+    public static LaurelType boolType(SourceRange sourceRange) { return new LaurelType.BoolType(sourceRange); }
+    public static LaurelType boolType() { return new LaurelType.BoolType(SourceRange.NONE); }
 
-    public static LaurelType realType(SourceRange sourceRange) { return new RealType(sourceRange); }
-    public static LaurelType realType() { return new RealType(SourceRange.NONE); }
+    public static LaurelType realType(SourceRange sourceRange) { return new LaurelType.RealType(sourceRange); }
+    public static LaurelType realType() { return new LaurelType.RealType(SourceRange.NONE); }
 
-    public static LaurelType float64Type(SourceRange sourceRange) { return new Float64Type(sourceRange); }
-    public static LaurelType float64Type() { return new Float64Type(SourceRange.NONE); }
+    public static LaurelType float64Type(SourceRange sourceRange) { return new LaurelType.Float64Type(sourceRange); }
+    public static LaurelType float64Type() { return new LaurelType.Float64Type(SourceRange.NONE); }
 
-    public static LaurelType stringType(SourceRange sourceRange) { return new StringType(sourceRange); }
-    public static LaurelType stringType() { return new StringType(SourceRange.NONE); }
+    public static LaurelType stringType(SourceRange sourceRange) { return new LaurelType.StringType(sourceRange); }
+    public static LaurelType stringType() { return new LaurelType.StringType(SourceRange.NONE); }
 
-    public static LaurelType mapType(SourceRange sourceRange, LaurelType keyType, LaurelType valueType) { return new MapType(sourceRange, keyType, valueType); }
-    public static LaurelType mapType(LaurelType keyType, LaurelType valueType) { return new MapType(SourceRange.NONE, keyType, valueType); }
+    public static LaurelType bvType(SourceRange sourceRange, long width) { if (width < 0) throw new IllegalArgumentException("width must be non-negative"); return new LaurelType.BvType(sourceRange, java.math.BigInteger.valueOf(width)); }
+    public static LaurelType bvType(long width) { if (width < 0) throw new IllegalArgumentException("width must be non-negative"); return new LaurelType.BvType(SourceRange.NONE, java.math.BigInteger.valueOf(width)); }
 
-    public static LaurelType compositeType(SourceRange sourceRange, java.lang.String name) { return new CompositeType(sourceRange, name); }
-    public static LaurelType compositeType(java.lang.String name) { return new CompositeType(SourceRange.NONE, name); }
+    public static LaurelType coreType(SourceRange sourceRange, java.lang.String name) { return new LaurelType.CoreType(sourceRange, name); }
+    public static LaurelType coreType(java.lang.String name) { return new LaurelType.CoreType(SourceRange.NONE, name); }
 
-    public static StmtExpr literalBool(SourceRange sourceRange, boolean b) { return new LiteralBool(sourceRange, b); }
-    public static StmtExpr literalBool(boolean b) { return new LiteralBool(SourceRange.NONE, b); }
+    public static LaurelType mapType(SourceRange sourceRange, LaurelType keyType, LaurelType valueType) { return new LaurelType.MapType(sourceRange, keyType, valueType); }
+    public static LaurelType mapType(LaurelType keyType, LaurelType valueType) { return new LaurelType.MapType(SourceRange.NONE, keyType, valueType); }
 
-    public static StmtExpr int_(SourceRange sourceRange, long n) { if (n < 0) throw new IllegalArgumentException("n must be non-negative"); return new Int(sourceRange, java.math.BigInteger.valueOf(n)); }
-    public static StmtExpr int_(long n) { if (n < 0) throw new IllegalArgumentException("n must be non-negative"); return new Int(SourceRange.NONE, java.math.BigInteger.valueOf(n)); }
+    public static LaurelType compositeType(SourceRange sourceRange, java.lang.String name) { return new LaurelType.CompositeType(sourceRange, name); }
+    public static LaurelType compositeType(java.lang.String name) { return new LaurelType.CompositeType(SourceRange.NONE, name); }
 
-    public static StmtExpr real(SourceRange sourceRange, double d) { return new Real(sourceRange, java.math.BigDecimal.valueOf(d)); }
-    public static StmtExpr real(double d) { return new Real(SourceRange.NONE, java.math.BigDecimal.valueOf(d)); }
+    public static StmtExpr literalBool(SourceRange sourceRange, boolean b) { return new StmtExpr.LiteralBool(sourceRange, b); }
+    public static StmtExpr literalBool(boolean b) { return new StmtExpr.LiteralBool(SourceRange.NONE, b); }
 
-    public static StmtExpr string(SourceRange sourceRange, java.lang.String s) { return new String_(sourceRange, s); }
-    public static StmtExpr string(java.lang.String s) { return new String_(SourceRange.NONE, s); }
+    public static StmtExpr int_(SourceRange sourceRange, long n) { if (n < 0) throw new IllegalArgumentException("n must be non-negative"); return new StmtExpr.Int(sourceRange, java.math.BigInteger.valueOf(n)); }
+    public static StmtExpr int_(long n) { if (n < 0) throw new IllegalArgumentException("n must be non-negative"); return new StmtExpr.Int(SourceRange.NONE, java.math.BigInteger.valueOf(n)); }
 
-    public static StmtExpr hole(SourceRange sourceRange) { return new Hole(sourceRange); }
-    public static StmtExpr hole() { return new Hole(SourceRange.NONE); }
+    public static StmtExpr real(SourceRange sourceRange, double d) { return new StmtExpr.Real(sourceRange, java.math.BigDecimal.valueOf(d)); }
+    public static StmtExpr real(double d) { return new StmtExpr.Real(SourceRange.NONE, java.math.BigDecimal.valueOf(d)); }
 
-    public static StmtExpr nondetHole(SourceRange sourceRange) { return new NondetHole(sourceRange); }
-    public static StmtExpr nondetHole() { return new NondetHole(SourceRange.NONE); }
+    public static StmtExpr string(SourceRange sourceRange, java.lang.String s) { return new StmtExpr.String_(sourceRange, s); }
+    public static StmtExpr string(java.lang.String s) { return new StmtExpr.String_(SourceRange.NONE, s); }
 
-    public static OptionalType optionalType(SourceRange sourceRange, LaurelType varType) { return new OptionalType_(sourceRange, varType); }
-    public static OptionalType optionalType(LaurelType varType) { return new OptionalType_(SourceRange.NONE, varType); }
+    public static StmtExpr hole(SourceRange sourceRange) { return new StmtExpr.Hole(sourceRange); }
+    public static StmtExpr hole() { return new StmtExpr.Hole(SourceRange.NONE); }
 
-    public static OptionalAssignment optionalAssignment(SourceRange sourceRange, StmtExpr value) { return new OptionalAssignment_(sourceRange, value); }
-    public static OptionalAssignment optionalAssignment(StmtExpr value) { return new OptionalAssignment_(SourceRange.NONE, value); }
+    public static StmtExpr nondetHole(SourceRange sourceRange) { return new StmtExpr.NondetHole(sourceRange); }
+    public static StmtExpr nondetHole() { return new StmtExpr.NondetHole(SourceRange.NONE); }
 
-    public static StmtExpr varDecl(SourceRange sourceRange, java.lang.String name, java.util.Optional<OptionalType> varType, java.util.Optional<OptionalAssignment> assignment) { return new VarDecl(sourceRange, name, varType, assignment); }
-    public static StmtExpr varDecl(java.lang.String name, java.util.Optional<OptionalType> varType, java.util.Optional<OptionalAssignment> assignment) { return new VarDecl(SourceRange.NONE, name, varType, assignment); }
+    public static TypeAnnotation typeAnnotation(SourceRange sourceRange, LaurelType varType) { return new TypeAnnotation.Of(sourceRange, varType); }
+    public static TypeAnnotation typeAnnotation(LaurelType varType) { return new TypeAnnotation.Of(SourceRange.NONE, varType); }
 
-    public static StmtExpr call(SourceRange sourceRange, StmtExpr callee, java.util.List<StmtExpr> args) { return new Call(sourceRange, callee, args); }
-    public static StmtExpr call(StmtExpr callee, java.util.List<StmtExpr> args) { return new Call(SourceRange.NONE, callee, args); }
+    public static Initializer initializer(SourceRange sourceRange, StmtExpr value) { return new Initializer.Of(sourceRange, value); }
+    public static Initializer initializer(StmtExpr value) { return new Initializer.Of(SourceRange.NONE, value); }
 
-    public static StmtExpr new_(SourceRange sourceRange, java.lang.String name) { return new New(sourceRange, name); }
-    public static StmtExpr new_(java.lang.String name) { return new New(SourceRange.NONE, name); }
+    public static StmtExpr varDecl(SourceRange sourceRange, java.lang.String name, java.util.Optional<TypeAnnotation> varType, java.util.Optional<Initializer> assignment) { return new StmtExpr.VarDecl(sourceRange, name, varType, assignment); }
+    public static StmtExpr varDecl(java.lang.String name, java.util.Optional<TypeAnnotation> varType, java.util.Optional<Initializer> assignment) { return new StmtExpr.VarDecl(SourceRange.NONE, name, varType, assignment); }
 
-    public static StmtExpr fieldAccess(SourceRange sourceRange, StmtExpr obj, java.lang.String field) { return new FieldAccess(sourceRange, obj, field); }
-    public static StmtExpr fieldAccess(StmtExpr obj, java.lang.String field) { return new FieldAccess(SourceRange.NONE, obj, field); }
+    public static StmtExpr call(SourceRange sourceRange, StmtExpr callee, java.util.List<StmtExpr> args) { return new StmtExpr.Call(sourceRange, callee, args); }
+    public static StmtExpr call(StmtExpr callee, java.util.List<StmtExpr> args) { return new StmtExpr.Call(SourceRange.NONE, callee, args); }
 
-    public static StmtExpr identifier(SourceRange sourceRange, java.lang.String name) { return new Identifier(sourceRange, name); }
-    public static StmtExpr identifier(java.lang.String name) { return new Identifier(SourceRange.NONE, name); }
+    public static StmtExpr new_(SourceRange sourceRange, java.lang.String name) { return new StmtExpr.New(sourceRange, name); }
+    public static StmtExpr new_(java.lang.String name) { return new StmtExpr.New(SourceRange.NONE, name); }
 
-    public static StmtExpr parenthesis(SourceRange sourceRange, StmtExpr inner) { return new Parenthesis(sourceRange, inner); }
-    public static StmtExpr parenthesis(StmtExpr inner) { return new Parenthesis(SourceRange.NONE, inner); }
+    public static StmtExpr fieldAccess(SourceRange sourceRange, StmtExpr obj, java.lang.String field) { return new StmtExpr.FieldAccess(sourceRange, obj, field); }
+    public static StmtExpr fieldAccess(StmtExpr obj, java.lang.String field) { return new StmtExpr.FieldAccess(SourceRange.NONE, obj, field); }
 
-    public static StmtExpr assign(SourceRange sourceRange, StmtExpr target, StmtExpr value) { return new Assign(sourceRange, target, value); }
-    public static StmtExpr assign(StmtExpr target, StmtExpr value) { return new Assign(SourceRange.NONE, target, value); }
+    public static StmtExpr identifier(SourceRange sourceRange, java.lang.String name) { return new StmtExpr.Identifier(sourceRange, name); }
+    public static StmtExpr identifier(java.lang.String name) { return new StmtExpr.Identifier(SourceRange.NONE, name); }
 
-    public static StmtExpr add(SourceRange sourceRange, StmtExpr lhs, StmtExpr rhs) { return new Add(sourceRange, lhs, rhs); }
-    public static StmtExpr add(StmtExpr lhs, StmtExpr rhs) { return new Add(SourceRange.NONE, lhs, rhs); }
+    public static StmtExpr parenthesis(SourceRange sourceRange, StmtExpr inner) { return new StmtExpr.Parenthesis(sourceRange, inner); }
+    public static StmtExpr parenthesis(StmtExpr inner) { return new StmtExpr.Parenthesis(SourceRange.NONE, inner); }
 
-    public static StmtExpr sub(SourceRange sourceRange, StmtExpr lhs, StmtExpr rhs) { return new Sub(sourceRange, lhs, rhs); }
-    public static StmtExpr sub(StmtExpr lhs, StmtExpr rhs) { return new Sub(SourceRange.NONE, lhs, rhs); }
+    public static StmtExpr assign(SourceRange sourceRange, StmtExpr target, StmtExpr value) { return new StmtExpr.Assign(sourceRange, target, value); }
+    public static StmtExpr assign(StmtExpr target, StmtExpr value) { return new StmtExpr.Assign(SourceRange.NONE, target, value); }
 
-    public static StmtExpr mul(SourceRange sourceRange, StmtExpr lhs, StmtExpr rhs) { return new Mul(sourceRange, lhs, rhs); }
-    public static StmtExpr mul(StmtExpr lhs, StmtExpr rhs) { return new Mul(SourceRange.NONE, lhs, rhs); }
+    public static StmtExpr add(SourceRange sourceRange, StmtExpr lhs, StmtExpr rhs) { return new StmtExpr.Add(sourceRange, lhs, rhs); }
+    public static StmtExpr add(StmtExpr lhs, StmtExpr rhs) { return new StmtExpr.Add(SourceRange.NONE, lhs, rhs); }
 
-    public static StmtExpr div(SourceRange sourceRange, StmtExpr lhs, StmtExpr rhs) { return new Div(sourceRange, lhs, rhs); }
-    public static StmtExpr div(StmtExpr lhs, StmtExpr rhs) { return new Div(SourceRange.NONE, lhs, rhs); }
+    public static StmtExpr sub(SourceRange sourceRange, StmtExpr lhs, StmtExpr rhs) { return new StmtExpr.Sub(sourceRange, lhs, rhs); }
+    public static StmtExpr sub(StmtExpr lhs, StmtExpr rhs) { return new StmtExpr.Sub(SourceRange.NONE, lhs, rhs); }
 
-    public static StmtExpr mod(SourceRange sourceRange, StmtExpr lhs, StmtExpr rhs) { return new Mod(sourceRange, lhs, rhs); }
-    public static StmtExpr mod(StmtExpr lhs, StmtExpr rhs) { return new Mod(SourceRange.NONE, lhs, rhs); }
+    public static StmtExpr mul(SourceRange sourceRange, StmtExpr lhs, StmtExpr rhs) { return new StmtExpr.Mul(sourceRange, lhs, rhs); }
+    public static StmtExpr mul(StmtExpr lhs, StmtExpr rhs) { return new StmtExpr.Mul(SourceRange.NONE, lhs, rhs); }
 
-    public static StmtExpr divT(SourceRange sourceRange, StmtExpr lhs, StmtExpr rhs) { return new DivT(sourceRange, lhs, rhs); }
-    public static StmtExpr divT(StmtExpr lhs, StmtExpr rhs) { return new DivT(SourceRange.NONE, lhs, rhs); }
+    public static StmtExpr div(SourceRange sourceRange, StmtExpr lhs, StmtExpr rhs) { return new StmtExpr.Div(sourceRange, lhs, rhs); }
+    public static StmtExpr div(StmtExpr lhs, StmtExpr rhs) { return new StmtExpr.Div(SourceRange.NONE, lhs, rhs); }
 
-    public static StmtExpr modT(SourceRange sourceRange, StmtExpr lhs, StmtExpr rhs) { return new ModT(sourceRange, lhs, rhs); }
-    public static StmtExpr modT(StmtExpr lhs, StmtExpr rhs) { return new ModT(SourceRange.NONE, lhs, rhs); }
+    public static StmtExpr mod(SourceRange sourceRange, StmtExpr lhs, StmtExpr rhs) { return new StmtExpr.Mod(sourceRange, lhs, rhs); }
+    public static StmtExpr mod(StmtExpr lhs, StmtExpr rhs) { return new StmtExpr.Mod(SourceRange.NONE, lhs, rhs); }
 
-    public static StmtExpr eq(SourceRange sourceRange, StmtExpr lhs, StmtExpr rhs) { return new Eq(sourceRange, lhs, rhs); }
-    public static StmtExpr eq(StmtExpr lhs, StmtExpr rhs) { return new Eq(SourceRange.NONE, lhs, rhs); }
+    public static StmtExpr divT(SourceRange sourceRange, StmtExpr lhs, StmtExpr rhs) { return new StmtExpr.DivT(sourceRange, lhs, rhs); }
+    public static StmtExpr divT(StmtExpr lhs, StmtExpr rhs) { return new StmtExpr.DivT(SourceRange.NONE, lhs, rhs); }
 
-    public static StmtExpr neq(SourceRange sourceRange, StmtExpr lhs, StmtExpr rhs) { return new Neq(sourceRange, lhs, rhs); }
-    public static StmtExpr neq(StmtExpr lhs, StmtExpr rhs) { return new Neq(SourceRange.NONE, lhs, rhs); }
+    public static StmtExpr modT(SourceRange sourceRange, StmtExpr lhs, StmtExpr rhs) { return new StmtExpr.ModT(sourceRange, lhs, rhs); }
+    public static StmtExpr modT(StmtExpr lhs, StmtExpr rhs) { return new StmtExpr.ModT(SourceRange.NONE, lhs, rhs); }
 
-    public static StmtExpr gt(SourceRange sourceRange, StmtExpr lhs, StmtExpr rhs) { return new Gt(sourceRange, lhs, rhs); }
-    public static StmtExpr gt(StmtExpr lhs, StmtExpr rhs) { return new Gt(SourceRange.NONE, lhs, rhs); }
+    public static StmtExpr eq(SourceRange sourceRange, StmtExpr lhs, StmtExpr rhs) { return new StmtExpr.Eq(sourceRange, lhs, rhs); }
+    public static StmtExpr eq(StmtExpr lhs, StmtExpr rhs) { return new StmtExpr.Eq(SourceRange.NONE, lhs, rhs); }
 
-    public static StmtExpr lt(SourceRange sourceRange, StmtExpr lhs, StmtExpr rhs) { return new Lt(sourceRange, lhs, rhs); }
-    public static StmtExpr lt(StmtExpr lhs, StmtExpr rhs) { return new Lt(SourceRange.NONE, lhs, rhs); }
+    public static StmtExpr neq(SourceRange sourceRange, StmtExpr lhs, StmtExpr rhs) { return new StmtExpr.Neq(sourceRange, lhs, rhs); }
+    public static StmtExpr neq(StmtExpr lhs, StmtExpr rhs) { return new StmtExpr.Neq(SourceRange.NONE, lhs, rhs); }
 
-    public static StmtExpr le(SourceRange sourceRange, StmtExpr lhs, StmtExpr rhs) { return new Le(sourceRange, lhs, rhs); }
-    public static StmtExpr le(StmtExpr lhs, StmtExpr rhs) { return new Le(SourceRange.NONE, lhs, rhs); }
+    public static StmtExpr gt(SourceRange sourceRange, StmtExpr lhs, StmtExpr rhs) { return new StmtExpr.Gt(sourceRange, lhs, rhs); }
+    public static StmtExpr gt(StmtExpr lhs, StmtExpr rhs) { return new StmtExpr.Gt(SourceRange.NONE, lhs, rhs); }
 
-    public static StmtExpr ge(SourceRange sourceRange, StmtExpr lhs, StmtExpr rhs) { return new Ge(sourceRange, lhs, rhs); }
-    public static StmtExpr ge(StmtExpr lhs, StmtExpr rhs) { return new Ge(SourceRange.NONE, lhs, rhs); }
+    public static StmtExpr lt(SourceRange sourceRange, StmtExpr lhs, StmtExpr rhs) { return new StmtExpr.Lt(sourceRange, lhs, rhs); }
+    public static StmtExpr lt(StmtExpr lhs, StmtExpr rhs) { return new StmtExpr.Lt(SourceRange.NONE, lhs, rhs); }
 
-    public static StmtExpr and(SourceRange sourceRange, StmtExpr lhs, StmtExpr rhs) { return new And(sourceRange, lhs, rhs); }
-    public static StmtExpr and(StmtExpr lhs, StmtExpr rhs) { return new And(SourceRange.NONE, lhs, rhs); }
+    public static StmtExpr le(SourceRange sourceRange, StmtExpr lhs, StmtExpr rhs) { return new StmtExpr.Le(sourceRange, lhs, rhs); }
+    public static StmtExpr le(StmtExpr lhs, StmtExpr rhs) { return new StmtExpr.Le(SourceRange.NONE, lhs, rhs); }
 
-    public static StmtExpr or(SourceRange sourceRange, StmtExpr lhs, StmtExpr rhs) { return new Or(sourceRange, lhs, rhs); }
-    public static StmtExpr or(StmtExpr lhs, StmtExpr rhs) { return new Or(SourceRange.NONE, lhs, rhs); }
+    public static StmtExpr ge(SourceRange sourceRange, StmtExpr lhs, StmtExpr rhs) { return new StmtExpr.Ge(sourceRange, lhs, rhs); }
+    public static StmtExpr ge(StmtExpr lhs, StmtExpr rhs) { return new StmtExpr.Ge(SourceRange.NONE, lhs, rhs); }
 
-    public static StmtExpr andThen(SourceRange sourceRange, StmtExpr lhs, StmtExpr rhs) { return new AndThen(sourceRange, lhs, rhs); }
-    public static StmtExpr andThen(StmtExpr lhs, StmtExpr rhs) { return new AndThen(SourceRange.NONE, lhs, rhs); }
+    public static StmtExpr and(SourceRange sourceRange, StmtExpr lhs, StmtExpr rhs) { return new StmtExpr.And(sourceRange, lhs, rhs); }
+    public static StmtExpr and(StmtExpr lhs, StmtExpr rhs) { return new StmtExpr.And(SourceRange.NONE, lhs, rhs); }
 
-    public static StmtExpr orElse(SourceRange sourceRange, StmtExpr lhs, StmtExpr rhs) { return new OrElse(sourceRange, lhs, rhs); }
-    public static StmtExpr orElse(StmtExpr lhs, StmtExpr rhs) { return new OrElse(SourceRange.NONE, lhs, rhs); }
+    public static StmtExpr or(SourceRange sourceRange, StmtExpr lhs, StmtExpr rhs) { return new StmtExpr.Or(sourceRange, lhs, rhs); }
+    public static StmtExpr or(StmtExpr lhs, StmtExpr rhs) { return new StmtExpr.Or(SourceRange.NONE, lhs, rhs); }
 
-    public static StmtExpr implies(SourceRange sourceRange, StmtExpr lhs, StmtExpr rhs) { return new Implies(sourceRange, lhs, rhs); }
-    public static StmtExpr implies(StmtExpr lhs, StmtExpr rhs) { return new Implies(SourceRange.NONE, lhs, rhs); }
+    public static StmtExpr andThen(SourceRange sourceRange, StmtExpr lhs, StmtExpr rhs) { return new StmtExpr.AndThen(sourceRange, lhs, rhs); }
+    public static StmtExpr andThen(StmtExpr lhs, StmtExpr rhs) { return new StmtExpr.AndThen(SourceRange.NONE, lhs, rhs); }
 
-    public static StmtExpr strConcat(SourceRange sourceRange, StmtExpr lhs, StmtExpr rhs) { return new StrConcat(sourceRange, lhs, rhs); }
-    public static StmtExpr strConcat(StmtExpr lhs, StmtExpr rhs) { return new StrConcat(SourceRange.NONE, lhs, rhs); }
+    public static StmtExpr orElse(SourceRange sourceRange, StmtExpr lhs, StmtExpr rhs) { return new StmtExpr.OrElse(sourceRange, lhs, rhs); }
+    public static StmtExpr orElse(StmtExpr lhs, StmtExpr rhs) { return new StmtExpr.OrElse(SourceRange.NONE, lhs, rhs); }
 
-    public static StmtExpr not(SourceRange sourceRange, StmtExpr inner) { return new Not(sourceRange, inner); }
-    public static StmtExpr not(StmtExpr inner) { return new Not(SourceRange.NONE, inner); }
+    public static StmtExpr implies(SourceRange sourceRange, StmtExpr lhs, StmtExpr rhs) { return new StmtExpr.Implies(sourceRange, lhs, rhs); }
+    public static StmtExpr implies(StmtExpr lhs, StmtExpr rhs) { return new StmtExpr.Implies(SourceRange.NONE, lhs, rhs); }
 
-    public static StmtExpr neg(SourceRange sourceRange, StmtExpr inner) { return new Neg(sourceRange, inner); }
-    public static StmtExpr neg(StmtExpr inner) { return new Neg(SourceRange.NONE, inner); }
+    public static StmtExpr strConcat(SourceRange sourceRange, StmtExpr lhs, StmtExpr rhs) { return new StmtExpr.StrConcat(sourceRange, lhs, rhs); }
+    public static StmtExpr strConcat(StmtExpr lhs, StmtExpr rhs) { return new StmtExpr.StrConcat(SourceRange.NONE, lhs, rhs); }
 
-    public static OptionalTrigger optionalTrigger(SourceRange sourceRange, StmtExpr trigger) { return new OptionalTrigger_(sourceRange, trigger); }
-    public static OptionalTrigger optionalTrigger(StmtExpr trigger) { return new OptionalTrigger_(SourceRange.NONE, trigger); }
+    public static StmtExpr not(SourceRange sourceRange, StmtExpr inner) { return new StmtExpr.Not(sourceRange, inner); }
+    public static StmtExpr not(StmtExpr inner) { return new StmtExpr.Not(SourceRange.NONE, inner); }
 
-    public static StmtExpr forallExpr(SourceRange sourceRange, java.lang.String name, LaurelType ty, java.util.Optional<OptionalTrigger> trigger, StmtExpr body) { return new ForallExpr(sourceRange, name, ty, trigger, body); }
-    public static StmtExpr forallExpr(java.lang.String name, LaurelType ty, java.util.Optional<OptionalTrigger> trigger, StmtExpr body) { return new ForallExpr(SourceRange.NONE, name, ty, trigger, body); }
+    public static StmtExpr neg(SourceRange sourceRange, StmtExpr inner) { return new StmtExpr.Neg(sourceRange, inner); }
+    public static StmtExpr neg(StmtExpr inner) { return new StmtExpr.Neg(SourceRange.NONE, inner); }
 
-    public static StmtExpr existsExpr(SourceRange sourceRange, java.lang.String name, LaurelType ty, java.util.Optional<OptionalTrigger> trigger, StmtExpr body) { return new ExistsExpr(sourceRange, name, ty, trigger, body); }
-    public static StmtExpr existsExpr(java.lang.String name, LaurelType ty, java.util.Optional<OptionalTrigger> trigger, StmtExpr body) { return new ExistsExpr(SourceRange.NONE, name, ty, trigger, body); }
+    public static Trigger trigger(SourceRange sourceRange, StmtExpr trigger) { return new Trigger.Of(sourceRange, trigger); }
+    public static Trigger trigger(StmtExpr trigger) { return new Trigger.Of(SourceRange.NONE, trigger); }
 
-    public static OptionalErrorMessage errorMessage(SourceRange sourceRange, java.lang.String msg) { return new ErrorMessage(sourceRange, msg); }
-    public static OptionalErrorMessage errorMessage(java.lang.String msg) { return new ErrorMessage(SourceRange.NONE, msg); }
+    public static StmtExpr forallExpr(SourceRange sourceRange, java.lang.String name, LaurelType ty, java.util.Optional<Trigger> trigger, StmtExpr body) { return new StmtExpr.ForallExpr(sourceRange, name, ty, trigger, body); }
+    public static StmtExpr forallExpr(java.lang.String name, LaurelType ty, java.util.Optional<Trigger> trigger, StmtExpr body) { return new StmtExpr.ForallExpr(SourceRange.NONE, name, ty, trigger, body); }
 
-    public static OptionalElse optionalElse(SourceRange sourceRange, StmtExpr stmts) { return new OptionalElse_(sourceRange, stmts); }
-    public static OptionalElse optionalElse(StmtExpr stmts) { return new OptionalElse_(SourceRange.NONE, stmts); }
+    public static StmtExpr existsExpr(SourceRange sourceRange, java.lang.String name, LaurelType ty, java.util.Optional<Trigger> trigger, StmtExpr body) { return new StmtExpr.ExistsExpr(sourceRange, name, ty, trigger, body); }
+    public static StmtExpr existsExpr(java.lang.String name, LaurelType ty, java.util.Optional<Trigger> trigger, StmtExpr body) { return new StmtExpr.ExistsExpr(SourceRange.NONE, name, ty, trigger, body); }
 
-    public static StmtExpr ifThenElse(SourceRange sourceRange, StmtExpr cond, StmtExpr thenBranch, java.util.Optional<OptionalElse> elseBranch) { return new IfThenElse(sourceRange, cond, thenBranch, elseBranch); }
-    public static StmtExpr ifThenElse(StmtExpr cond, StmtExpr thenBranch, java.util.Optional<OptionalElse> elseBranch) { return new IfThenElse(SourceRange.NONE, cond, thenBranch, elseBranch); }
+    public static ErrorSummary errorSummary(SourceRange sourceRange, java.lang.String msg) { return new ErrorSummary.Of(sourceRange, msg); }
+    public static ErrorSummary errorSummary(java.lang.String msg) { return new ErrorSummary.Of(SourceRange.NONE, msg); }
 
-    public static StmtExpr assert_(SourceRange sourceRange, StmtExpr cond, java.util.Optional<OptionalErrorMessage> errorMessage) { return new Assert(sourceRange, cond, errorMessage); }
-    public static StmtExpr assert_(StmtExpr cond, java.util.Optional<OptionalErrorMessage> errorMessage) { return new Assert(SourceRange.NONE, cond, errorMessage); }
+    public static ElseBranch elseBranch(SourceRange sourceRange, StmtExpr stmts) { return new ElseBranch.Of(sourceRange, stmts); }
+    public static ElseBranch elseBranch(StmtExpr stmts) { return new ElseBranch.Of(SourceRange.NONE, stmts); }
 
-    public static StmtExpr assume(SourceRange sourceRange, StmtExpr cond) { return new Assume(sourceRange, cond); }
-    public static StmtExpr assume(StmtExpr cond) { return new Assume(SourceRange.NONE, cond); }
+    public static StmtExpr ifThenElse(SourceRange sourceRange, StmtExpr cond, StmtExpr thenBranch, java.util.Optional<ElseBranch> elseBranch) { return new StmtExpr.IfThenElse(sourceRange, cond, thenBranch, elseBranch); }
+    public static StmtExpr ifThenElse(StmtExpr cond, StmtExpr thenBranch, java.util.Optional<ElseBranch> elseBranch) { return new StmtExpr.IfThenElse(SourceRange.NONE, cond, thenBranch, elseBranch); }
 
-    public static StmtExpr return_(SourceRange sourceRange, StmtExpr value) { return new Return(sourceRange, value); }
-    public static StmtExpr return_(StmtExpr value) { return new Return(SourceRange.NONE, value); }
+    public static StmtExpr assert_(SourceRange sourceRange, StmtExpr cond, java.util.Optional<ErrorSummary> errorMessage) { return new StmtExpr.Assert(sourceRange, cond, errorMessage); }
+    public static StmtExpr assert_(StmtExpr cond, java.util.Optional<ErrorSummary> errorMessage) { return new StmtExpr.Assert(SourceRange.NONE, cond, errorMessage); }
 
-    public static StmtExpr block(SourceRange sourceRange, java.util.List<StmtExpr> stmts) { return new Block(sourceRange, stmts); }
-    public static StmtExpr block(java.util.List<StmtExpr> stmts) { return new Block(SourceRange.NONE, stmts); }
+    public static StmtExpr assume(SourceRange sourceRange, StmtExpr cond) { return new StmtExpr.Assume(sourceRange, cond); }
+    public static StmtExpr assume(StmtExpr cond) { return new StmtExpr.Assume(SourceRange.NONE, cond); }
 
-    public static InvariantClause invariantClause(SourceRange sourceRange, StmtExpr cond) { return new InvariantClause_(sourceRange, cond); }
-    public static InvariantClause invariantClause(StmtExpr cond) { return new InvariantClause_(SourceRange.NONE, cond); }
+    public static StmtExpr return_(SourceRange sourceRange, StmtExpr value) { return new StmtExpr.Return(sourceRange, value); }
+    public static StmtExpr return_(StmtExpr value) { return new StmtExpr.Return(SourceRange.NONE, value); }
 
-    public static StmtExpr while_(SourceRange sourceRange, StmtExpr cond, java.util.List<InvariantClause> invariants, StmtExpr body) { return new While(sourceRange, cond, invariants, body); }
-    public static StmtExpr while_(StmtExpr cond, java.util.List<InvariantClause> invariants, StmtExpr body) { return new While(SourceRange.NONE, cond, invariants, body); }
+    public static StmtExpr block(SourceRange sourceRange, java.util.List<StmtExpr> stmts) { return new StmtExpr.Block(sourceRange, stmts); }
+    public static StmtExpr block(java.util.List<StmtExpr> stmts) { return new StmtExpr.Block(SourceRange.NONE, stmts); }
 
-    public static StmtExpr forLoop(SourceRange sourceRange, StmtExpr init, StmtExpr cond, StmtExpr step, java.util.List<InvariantClause> invariants, StmtExpr body) { return new ForLoop(sourceRange, init, cond, step, invariants, body); }
-    public static StmtExpr forLoop(StmtExpr init, StmtExpr cond, StmtExpr step, java.util.List<InvariantClause> invariants, StmtExpr body) { return new ForLoop(SourceRange.NONE, init, cond, step, invariants, body); }
+    public static StmtExpr labelledBlock(SourceRange sourceRange, java.util.List<StmtExpr> stmts, java.lang.String label) { return new StmtExpr.LabelledBlock(sourceRange, stmts, label); }
+    public static StmtExpr labelledBlock(java.util.List<StmtExpr> stmts, java.lang.String label) { return new StmtExpr.LabelledBlock(SourceRange.NONE, stmts, label); }
 
-    public static Parameter parameter(SourceRange sourceRange, java.lang.String name, LaurelType paramType) { return new Parameter_(sourceRange, name, paramType); }
-    public static Parameter parameter(java.lang.String name, LaurelType paramType) { return new Parameter_(SourceRange.NONE, name, paramType); }
+    public static StmtExpr exit(SourceRange sourceRange, java.lang.String label) { return new StmtExpr.Exit(sourceRange, label); }
+    public static StmtExpr exit(java.lang.String label) { return new StmtExpr.Exit(SourceRange.NONE, label); }
 
-    public static Field mutableField(SourceRange sourceRange, java.lang.String name, LaurelType fieldType) { return new MutableField(sourceRange, name, fieldType); }
-    public static Field mutableField(java.lang.String name, LaurelType fieldType) { return new MutableField(SourceRange.NONE, name, fieldType); }
+    public static InvariantClause invariantClause(SourceRange sourceRange, StmtExpr cond) { return new InvariantClause.Of(sourceRange, cond); }
+    public static InvariantClause invariantClause(StmtExpr cond) { return new InvariantClause.Of(SourceRange.NONE, cond); }
 
-    public static Field immutableField(SourceRange sourceRange, java.lang.String name, LaurelType fieldType) { return new ImmutableField(sourceRange, name, fieldType); }
-    public static Field immutableField(java.lang.String name, LaurelType fieldType) { return new ImmutableField(SourceRange.NONE, name, fieldType); }
+    public static StmtExpr while_(SourceRange sourceRange, StmtExpr cond, java.util.List<InvariantClause> invariants, StmtExpr body) { return new StmtExpr.While(sourceRange, cond, invariants, body); }
+    public static StmtExpr while_(StmtExpr cond, java.util.List<InvariantClause> invariants, StmtExpr body) { return new StmtExpr.While(SourceRange.NONE, cond, invariants, body); }
 
-    public static StmtExpr isType(SourceRange sourceRange, StmtExpr target, java.lang.String typeName) { return new IsType(sourceRange, target, typeName); }
-    public static StmtExpr isType(StmtExpr target, java.lang.String typeName) { return new IsType(SourceRange.NONE, target, typeName); }
+    public static StmtExpr forLoop(SourceRange sourceRange, StmtExpr init, StmtExpr cond, StmtExpr step, java.util.List<InvariantClause> invariants, StmtExpr body) { return new StmtExpr.ForLoop(sourceRange, init, cond, step, invariants, body); }
+    public static StmtExpr forLoop(StmtExpr init, StmtExpr cond, StmtExpr step, java.util.List<InvariantClause> invariants, StmtExpr body) { return new StmtExpr.ForLoop(SourceRange.NONE, init, cond, step, invariants, body); }
 
-    public static StmtExpr asType(SourceRange sourceRange, StmtExpr target, java.lang.String typeName) { return new AsType(sourceRange, target, typeName); }
-    public static StmtExpr asType(StmtExpr target, java.lang.String typeName) { return new AsType(SourceRange.NONE, target, typeName); }
+    public static Parameter parameter(SourceRange sourceRange, java.lang.String name, LaurelType paramType) { return new Parameter.Of(sourceRange, name, paramType); }
+    public static Parameter parameter(java.lang.String name, LaurelType paramType) { return new Parameter.Of(SourceRange.NONE, name, paramType); }
 
-    public static OptionalExtends optionalExtends(SourceRange sourceRange, java.util.List<java.lang.String> parents) { return new OptionalExtends_(sourceRange, parents); }
-    public static OptionalExtends optionalExtends(java.util.List<java.lang.String> parents) { return new OptionalExtends_(SourceRange.NONE, parents); }
+    public static Field mutableField(SourceRange sourceRange, java.lang.String name, LaurelType fieldType) { return new Field.MutableField(sourceRange, name, fieldType); }
+    public static Field mutableField(java.lang.String name, LaurelType fieldType) { return new Field.MutableField(SourceRange.NONE, name, fieldType); }
 
-    public static Composite composite(SourceRange sourceRange, java.lang.String name, java.util.Optional<OptionalExtends> extending, java.util.List<Field> fields) { return new Composite_(sourceRange, name, extending, fields); }
-    public static Composite composite(java.lang.String name, java.util.Optional<OptionalExtends> extending, java.util.List<Field> fields) { return new Composite_(SourceRange.NONE, name, extending, fields); }
+    public static Field immutableField(SourceRange sourceRange, java.lang.String name, LaurelType fieldType) { return new Field.ImmutableField(sourceRange, name, fieldType); }
+    public static Field immutableField(java.lang.String name, LaurelType fieldType) { return new Field.ImmutableField(SourceRange.NONE, name, fieldType); }
 
-    public static DatatypeConstructorArg datatypeConstructorArg(SourceRange sourceRange, java.lang.String name, LaurelType argType) { return new DatatypeConstructorArg_(sourceRange, name, argType); }
-    public static DatatypeConstructorArg datatypeConstructorArg(java.lang.String name, LaurelType argType) { return new DatatypeConstructorArg_(SourceRange.NONE, name, argType); }
+    public static StmtExpr isType(SourceRange sourceRange, StmtExpr target, java.lang.String typeName) { return new StmtExpr.IsType(sourceRange, target, typeName); }
+    public static StmtExpr isType(StmtExpr target, java.lang.String typeName) { return new StmtExpr.IsType(SourceRange.NONE, target, typeName); }
 
-    public static DatatypeConstructor datatypeConstructor(SourceRange sourceRange, java.lang.String name, java.util.List<DatatypeConstructorArg> args) { return new DatatypeConstructor_(sourceRange, name, args); }
-    public static DatatypeConstructor datatypeConstructor(java.lang.String name, java.util.List<DatatypeConstructorArg> args) { return new DatatypeConstructor_(SourceRange.NONE, name, args); }
+    public static StmtExpr asType(SourceRange sourceRange, StmtExpr target, java.lang.String typeName) { return new StmtExpr.AsType(sourceRange, target, typeName); }
+    public static StmtExpr asType(StmtExpr target, java.lang.String typeName) { return new StmtExpr.AsType(SourceRange.NONE, target, typeName); }
 
-    public static DatatypeConstructor datatypeConstructorNoArgs(SourceRange sourceRange, java.lang.String name) { return new DatatypeConstructorNoArgs(sourceRange, name); }
-    public static DatatypeConstructor datatypeConstructorNoArgs(java.lang.String name) { return new DatatypeConstructorNoArgs(SourceRange.NONE, name); }
+    public static Extends extends_(SourceRange sourceRange, java.util.List<java.lang.String> parents) { return new Extends.Of(sourceRange, parents); }
+    public static Extends extends_(java.util.List<java.lang.String> parents) { return new Extends.Of(SourceRange.NONE, parents); }
 
-    public static DatatypeConstructorList datatypeConstructorList(SourceRange sourceRange, java.util.List<DatatypeConstructor> constructors) { return new DatatypeConstructorList_(sourceRange, constructors); }
-    public static DatatypeConstructorList datatypeConstructorList(java.util.List<DatatypeConstructor> constructors) { return new DatatypeConstructorList_(SourceRange.NONE, constructors); }
+    public static DatatypeConstructorArg datatypeConstructorArg(SourceRange sourceRange, java.lang.String name, LaurelType argType) { return new DatatypeConstructorArg.Of(sourceRange, name, argType); }
+    public static DatatypeConstructorArg datatypeConstructorArg(java.lang.String name, LaurelType argType) { return new DatatypeConstructorArg.Of(SourceRange.NONE, name, argType); }
 
-    public static Datatype datatype(SourceRange sourceRange, java.lang.String name, DatatypeConstructorList constructors) { return new Datatype_(sourceRange, name, constructors); }
-    public static Datatype datatype(java.lang.String name, DatatypeConstructorList constructors) { return new Datatype_(SourceRange.NONE, name, constructors); }
+    public static DatatypeConstructor datatypeConstructor(SourceRange sourceRange, java.lang.String name, java.util.List<DatatypeConstructorArg> args) { return new DatatypeConstructor.DatatypeConstructor_(sourceRange, name, args); }
+    public static DatatypeConstructor datatypeConstructor(java.lang.String name, java.util.List<DatatypeConstructorArg> args) { return new DatatypeConstructor.DatatypeConstructor_(SourceRange.NONE, name, args); }
 
-    public static OptionalReturnType optionalReturnType(SourceRange sourceRange, LaurelType returnType) { return new OptionalReturnType_(sourceRange, returnType); }
-    public static OptionalReturnType optionalReturnType(LaurelType returnType) { return new OptionalReturnType_(SourceRange.NONE, returnType); }
+    public static DatatypeConstructor datatypeConstructorNoArgs(SourceRange sourceRange, java.lang.String name) { return new DatatypeConstructor.DatatypeConstructorNoArgs(sourceRange, name); }
+    public static DatatypeConstructor datatypeConstructorNoArgs(java.lang.String name) { return new DatatypeConstructor.DatatypeConstructorNoArgs(SourceRange.NONE, name); }
 
-    public static RequiresClause requiresClause(SourceRange sourceRange, StmtExpr cond, java.util.Optional<OptionalErrorMessage> errorMessage) { return new RequiresClause_(sourceRange, cond, errorMessage); }
-    public static RequiresClause requiresClause(StmtExpr cond, java.util.Optional<OptionalErrorMessage> errorMessage) { return new RequiresClause_(SourceRange.NONE, cond, errorMessage); }
+    public static DatatypeConstructorList datatypeConstructorList(SourceRange sourceRange, java.util.List<DatatypeConstructor> constructors) { return new DatatypeConstructorList.Of(sourceRange, constructors); }
+    public static DatatypeConstructorList datatypeConstructorList(java.util.List<DatatypeConstructor> constructors) { return new DatatypeConstructorList.Of(SourceRange.NONE, constructors); }
 
-    public static EnsuresClause ensuresClause(SourceRange sourceRange, StmtExpr cond, java.util.Optional<OptionalErrorMessage> errorMessage) { return new EnsuresClause_(sourceRange, cond, errorMessage); }
-    public static EnsuresClause ensuresClause(StmtExpr cond, java.util.Optional<OptionalErrorMessage> errorMessage) { return new EnsuresClause_(SourceRange.NONE, cond, errorMessage); }
+    public static Datatype datatype(SourceRange sourceRange, java.lang.String name, DatatypeConstructorList constructors) { return new Datatype.Of(sourceRange, name, constructors); }
+    public static Datatype datatype(java.lang.String name, DatatypeConstructorList constructors) { return new Datatype.Of(SourceRange.NONE, name, constructors); }
 
-    public static ModifiesClause modifiesClause(SourceRange sourceRange, java.util.List<StmtExpr> refs) { return new ModifiesClause_(sourceRange, refs); }
-    public static ModifiesClause modifiesClause(java.util.List<StmtExpr> refs) { return new ModifiesClause_(SourceRange.NONE, refs); }
+    public static ReturnType returnType(SourceRange sourceRange, LaurelType returnType) { return new ReturnType.Of(sourceRange, returnType); }
+    public static ReturnType returnType(LaurelType returnType) { return new ReturnType.Of(SourceRange.NONE, returnType); }
 
-    public static ReturnParameters returnParameters(SourceRange sourceRange, java.util.List<Parameter> parameters) { return new ReturnParameters_(sourceRange, parameters); }
-    public static ReturnParameters returnParameters(java.util.List<Parameter> parameters) { return new ReturnParameters_(SourceRange.NONE, parameters); }
+    public static InvokeOnClause invokeOnClause(SourceRange sourceRange, StmtExpr trigger) { return new InvokeOnClause.Of(sourceRange, trigger); }
+    public static InvokeOnClause invokeOnClause(StmtExpr trigger) { return new InvokeOnClause.Of(SourceRange.NONE, trigger); }
 
-    public static OptionalBody optionalBody(SourceRange sourceRange, StmtExpr body) { return new OptionalBody_(sourceRange, body); }
-    public static OptionalBody optionalBody(StmtExpr body) { return new OptionalBody_(SourceRange.NONE, body); }
+    public static RequiresClause requiresClause(SourceRange sourceRange, StmtExpr cond, java.util.Optional<ErrorSummary> errorMessage) { return new RequiresClause.Of(sourceRange, cond, errorMessage); }
+    public static RequiresClause requiresClause(StmtExpr cond, java.util.Optional<ErrorSummary> errorMessage) { return new RequiresClause.Of(SourceRange.NONE, cond, errorMessage); }
 
-    public static OptionalBody externalBody(SourceRange sourceRange) { return new ExternalBody(sourceRange); }
-    public static OptionalBody externalBody() { return new ExternalBody(SourceRange.NONE); }
+    public static EnsuresClause ensuresClause(SourceRange sourceRange, StmtExpr cond, java.util.Optional<ErrorSummary> errorMessage) { return new EnsuresClause.Of(sourceRange, cond, errorMessage); }
+    public static EnsuresClause ensuresClause(StmtExpr cond, java.util.Optional<ErrorSummary> errorMessage) { return new EnsuresClause.Of(SourceRange.NONE, cond, errorMessage); }
 
-    public static Procedure procedure(SourceRange sourceRange, java.lang.String name, java.util.List<Parameter> parameters, java.util.Optional<OptionalReturnType> returnType, java.util.Optional<ReturnParameters> returnParameters, java.util.List<RequiresClause> requires, java.util.List<EnsuresClause> ensures, java.util.List<ModifiesClause> modifies, java.util.Optional<OptionalBody> body) { return new Procedure_(sourceRange, name, parameters, returnType, returnParameters, requires, ensures, modifies, body); }
-    public static Procedure procedure(java.lang.String name, java.util.List<Parameter> parameters, java.util.Optional<OptionalReturnType> returnType, java.util.Optional<ReturnParameters> returnParameters, java.util.List<RequiresClause> requires, java.util.List<EnsuresClause> ensures, java.util.List<ModifiesClause> modifies, java.util.Optional<OptionalBody> body) { return new Procedure_(SourceRange.NONE, name, parameters, returnType, returnParameters, requires, ensures, modifies, body); }
+    public static ModifiesClause modifiesClause(SourceRange sourceRange, java.util.List<StmtExpr> refs) { return new ModifiesClause.Of(sourceRange, refs); }
+    public static ModifiesClause modifiesClause(java.util.List<StmtExpr> refs) { return new ModifiesClause.Of(SourceRange.NONE, refs); }
 
-    public static Procedure function(SourceRange sourceRange, java.lang.String name, java.util.List<Parameter> parameters, java.util.Optional<OptionalReturnType> returnType, java.util.Optional<ReturnParameters> returnParameters, java.util.List<RequiresClause> requires, java.util.List<EnsuresClause> ensures, java.util.List<ModifiesClause> modifies, java.util.Optional<OptionalBody> body) { return new Function(sourceRange, name, parameters, returnType, returnParameters, requires, ensures, modifies, body); }
-    public static Procedure function(java.lang.String name, java.util.List<Parameter> parameters, java.util.Optional<OptionalReturnType> returnType, java.util.Optional<ReturnParameters> returnParameters, java.util.List<RequiresClause> requires, java.util.List<EnsuresClause> ensures, java.util.List<ModifiesClause> modifies, java.util.Optional<OptionalBody> body) { return new Function(SourceRange.NONE, name, parameters, returnType, returnParameters, requires, ensures, modifies, body); }
+    public static ReturnParameters returnParameters(SourceRange sourceRange, java.util.List<Parameter> parameters) { return new ReturnParameters.Of(sourceRange, parameters); }
+    public static ReturnParameters returnParameters(java.util.List<Parameter> parameters) { return new ReturnParameters.Of(SourceRange.NONE, parameters); }
 
-    public static ConstrainedType constrainedType(SourceRange sourceRange, java.lang.String name, java.lang.String valueName, LaurelType base, StmtExpr constraint, StmtExpr witness) { return new ConstrainedType_(sourceRange, name, valueName, base, constraint, witness); }
-    public static ConstrainedType constrainedType(java.lang.String name, java.lang.String valueName, LaurelType base, StmtExpr constraint, StmtExpr witness) { return new ConstrainedType_(SourceRange.NONE, name, valueName, base, constraint, witness); }
+    public static Body body(SourceRange sourceRange, StmtExpr body) { return new Body.Body_(sourceRange, body); }
+    public static Body body(StmtExpr body) { return new Body.Body_(SourceRange.NONE, body); }
 
-    public static Command compositeCommand(SourceRange sourceRange, Composite composite) { return new CompositeCommand(sourceRange, composite); }
-    public static Command compositeCommand(Composite composite) { return new CompositeCommand(SourceRange.NONE, composite); }
+    public static Body externalBody(SourceRange sourceRange) { return new Body.ExternalBody(sourceRange); }
+    public static Body externalBody() { return new Body.ExternalBody(SourceRange.NONE); }
 
-    public static Command procedureCommand(SourceRange sourceRange, Procedure procedure) { return new ProcedureCommand(sourceRange, procedure); }
-    public static Command procedureCommand(Procedure procedure) { return new ProcedureCommand(SourceRange.NONE, procedure); }
+    public static Procedure procedure(SourceRange sourceRange, java.lang.String name, java.util.List<Parameter> parameters, java.util.Optional<ReturnType> returnType, java.util.Optional<ReturnParameters> returnParameters, java.util.List<RequiresClause> requires, java.util.Optional<InvokeOnClause> invokeOn, java.util.List<EnsuresClause> ensures, java.util.List<ModifiesClause> modifies, java.util.Optional<Body> body) { return new Procedure.Procedure_(sourceRange, name, parameters, returnType, returnParameters, requires, invokeOn, ensures, modifies, body); }
+    public static Procedure procedure(java.lang.String name, java.util.List<Parameter> parameters, java.util.Optional<ReturnType> returnType, java.util.Optional<ReturnParameters> returnParameters, java.util.List<RequiresClause> requires, java.util.Optional<InvokeOnClause> invokeOn, java.util.List<EnsuresClause> ensures, java.util.List<ModifiesClause> modifies, java.util.Optional<Body> body) { return new Procedure.Procedure_(SourceRange.NONE, name, parameters, returnType, returnParameters, requires, invokeOn, ensures, modifies, body); }
 
-    public static Command datatypeCommand(SourceRange sourceRange, Datatype datatype) { return new DatatypeCommand(sourceRange, datatype); }
-    public static Command datatypeCommand(Datatype datatype) { return new DatatypeCommand(SourceRange.NONE, datatype); }
+    public static Procedure function(SourceRange sourceRange, java.lang.String name, java.util.List<Parameter> parameters, java.util.Optional<ReturnType> returnType, java.util.Optional<ReturnParameters> returnParameters, java.util.List<RequiresClause> requires, java.util.Optional<InvokeOnClause> invokeOn, java.util.List<EnsuresClause> ensures, java.util.List<ModifiesClause> modifies, java.util.Optional<Body> body) { return new Procedure.Function(sourceRange, name, parameters, returnType, returnParameters, requires, invokeOn, ensures, modifies, body); }
+    public static Procedure function(java.lang.String name, java.util.List<Parameter> parameters, java.util.Optional<ReturnType> returnType, java.util.Optional<ReturnParameters> returnParameters, java.util.List<RequiresClause> requires, java.util.Optional<InvokeOnClause> invokeOn, java.util.List<EnsuresClause> ensures, java.util.List<ModifiesClause> modifies, java.util.Optional<Body> body) { return new Procedure.Function(SourceRange.NONE, name, parameters, returnType, returnParameters, requires, invokeOn, ensures, modifies, body); }
 
-    public static Command constrainedTypeCommand(SourceRange sourceRange, ConstrainedType ct) { return new ConstrainedTypeCommand(sourceRange, ct); }
-    public static Command constrainedTypeCommand(ConstrainedType ct) { return new ConstrainedTypeCommand(SourceRange.NONE, ct); }
+    public static Composite composite(SourceRange sourceRange, java.lang.String name, java.util.Optional<Extends> extending, java.util.List<Field> fields, java.util.List<Procedure> procedures) { return new Composite.Of(sourceRange, name, extending, fields, procedures); }
+    public static Composite composite(java.lang.String name, java.util.Optional<Extends> extending, java.util.List<Field> fields, java.util.List<Procedure> procedures) { return new Composite.Of(SourceRange.NONE, name, extending, fields, procedures); }
+
+    public static ConstrainedType constrainedType(SourceRange sourceRange, java.lang.String name, java.lang.String valueName, LaurelType base, StmtExpr constraint, StmtExpr witness) { return new ConstrainedType.Of(sourceRange, name, valueName, base, constraint, witness); }
+    public static ConstrainedType constrainedType(java.lang.String name, java.lang.String valueName, LaurelType base, StmtExpr constraint, StmtExpr witness) { return new ConstrainedType.Of(SourceRange.NONE, name, valueName, base, constraint, witness); }
+
+    public static Command compositeCommand(SourceRange sourceRange, Composite composite) { return new Command.CompositeCommand(sourceRange, composite); }
+    public static Command compositeCommand(Composite composite) { return new Command.CompositeCommand(SourceRange.NONE, composite); }
+
+    public static Command procedureCommand(SourceRange sourceRange, Procedure procedure) { return new Command.ProcedureCommand(sourceRange, procedure); }
+    public static Command procedureCommand(Procedure procedure) { return new Command.ProcedureCommand(SourceRange.NONE, procedure); }
+
+    public static Command datatypeCommand(SourceRange sourceRange, Datatype datatype) { return new Command.DatatypeCommand(sourceRange, datatype); }
+    public static Command datatypeCommand(Datatype datatype) { return new Command.DatatypeCommand(SourceRange.NONE, datatype); }
+
+    public static Command constrainedTypeCommand(SourceRange sourceRange, ConstrainedType ct) { return new Command.ConstrainedTypeCommand(sourceRange, ct); }
+    public static Command constrainedTypeCommand(ConstrainedType ct) { return new Command.ConstrainedTypeCommand(SourceRange.NONE, ct); }
 }

--- a/verifier/src/main/java/com/aws/jverify/laurel/LaurelType.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/LaurelType.java
@@ -1,3 +1,129 @@
 package com.aws.jverify.laurel;
 
-public sealed interface LaurelType extends Node permits IntType, BoolType, RealType, Float64Type, StringType, MapType, CompositeType {}
+public sealed interface LaurelType extends Node permits LaurelType.IntType, LaurelType.BoolType, LaurelType.RealType, LaurelType.Float64Type, LaurelType.StringType, LaurelType.BvType, LaurelType.CoreType, LaurelType.MapType, LaurelType.CompositeType {
+    public record IntType(
+        SourceRange sourceRange
+    ) implements LaurelType {
+        @Override
+        public java.lang.String operationName() { return "Laurel.intType"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.intType", sourceRange());
+            return sexp;
+        }
+    }
+
+    public record BoolType(
+        SourceRange sourceRange
+    ) implements LaurelType {
+        @Override
+        public java.lang.String operationName() { return "Laurel.boolType"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.boolType", sourceRange());
+            return sexp;
+        }
+    }
+
+    public record RealType(
+        SourceRange sourceRange
+    ) implements LaurelType {
+        @Override
+        public java.lang.String operationName() { return "Laurel.realType"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.realType", sourceRange());
+            return sexp;
+        }
+    }
+
+    public record Float64Type(
+        SourceRange sourceRange
+    ) implements LaurelType {
+        @Override
+        public java.lang.String operationName() { return "Laurel.float64Type"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.float64Type", sourceRange());
+            return sexp;
+        }
+    }
+
+    public record StringType(
+        SourceRange sourceRange
+    ) implements LaurelType {
+        @Override
+        public java.lang.String operationName() { return "Laurel.stringType"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.stringType", sourceRange());
+            return sexp;
+        }
+    }
+
+    public record BvType(
+        SourceRange sourceRange,
+        java.math.BigInteger width
+    ) implements LaurelType {
+        @Override
+        public java.lang.String operationName() { return "Laurel.bvType"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.bvType", sourceRange());
+            sexp.add($s.serializeNum(width()));
+            return sexp;
+        }
+    }
+
+    public record CoreType(
+        SourceRange sourceRange,
+        java.lang.String name
+    ) implements LaurelType {
+        @Override
+        public java.lang.String operationName() { return "Laurel.coreType"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.coreType", sourceRange());
+            sexp.add($s.serializeIdent(name()));
+            return sexp;
+        }
+    }
+
+    public record MapType(
+        SourceRange sourceRange,
+        LaurelType keyType, LaurelType valueType
+    ) implements LaurelType {
+        @Override
+        public java.lang.String operationName() { return "Laurel.mapType"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.mapType", sourceRange());
+            sexp.add($s.serialize(keyType()));
+            sexp.add($s.serialize(valueType()));
+            return sexp;
+        }
+    }
+
+    public record CompositeType(
+        SourceRange sourceRange,
+        java.lang.String name
+    ) implements LaurelType {
+        @Override
+        public java.lang.String operationName() { return "Laurel.compositeType"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.compositeType", sourceRange());
+            sexp.add($s.serializeIdent(name()));
+            return sexp;
+        }
+    }
+}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Le.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Le.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record Le(
-    SourceRange sourceRange,
-    StmtExpr lhs, StmtExpr rhs
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.le"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/LiteralBool.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/LiteralBool.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record LiteralBool(
-    SourceRange sourceRange,
-    boolean b
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.literalBool"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Lt.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Lt.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record Lt(
-    SourceRange sourceRange,
-    StmtExpr lhs, StmtExpr rhs
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.lt"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/MapType.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/MapType.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record MapType(
-    SourceRange sourceRange,
-    LaurelType keyType, LaurelType valueType
-) implements LaurelType {
-    @Override
-    public java.lang.String operationName() { return "Laurel.mapType"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Mod.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Mod.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record Mod(
-    SourceRange sourceRange,
-    StmtExpr lhs, StmtExpr rhs
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.mod"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/ModT.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/ModT.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record ModT(
-    SourceRange sourceRange,
-    StmtExpr lhs, StmtExpr rhs
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.modT"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/ModifiesClause.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/ModifiesClause.java
@@ -1,3 +1,18 @@
 package com.aws.jverify.laurel;
 
-public sealed interface ModifiesClause extends Node permits ModifiesClause_ {}
+public sealed interface ModifiesClause extends Node permits ModifiesClause.Of {
+    public record Of(
+        SourceRange sourceRange,
+        java.util.List<StmtExpr> refs
+    ) implements ModifiesClause {
+        @Override
+        public java.lang.String operationName() { return "Laurel.modifiesClause"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.modifiesClause", sourceRange());
+            sexp.add($s.serializeSeq(refs(), "commaSepList", $s::serialize));
+            return sexp;
+        }
+    }
+}

--- a/verifier/src/main/java/com/aws/jverify/laurel/ModifiesClause_.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/ModifiesClause_.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record ModifiesClause_(
-    SourceRange sourceRange,
-    java.util.List<StmtExpr> refs
-) implements ModifiesClause {
-    @Override
-    public java.lang.String operationName() { return "Laurel.modifiesClause"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Mul.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Mul.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record Mul(
-    SourceRange sourceRange,
-    StmtExpr lhs, StmtExpr rhs
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.mul"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/MutableField.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/MutableField.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record MutableField(
-    SourceRange sourceRange,
-    java.lang.String name, LaurelType fieldType
-) implements Field {
-    @Override
-    public java.lang.String operationName() { return "Laurel.mutableField"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Neg.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Neg.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record Neg(
-    SourceRange sourceRange,
-    StmtExpr inner
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.neg"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Neq.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Neq.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record Neq(
-    SourceRange sourceRange,
-    StmtExpr lhs, StmtExpr rhs
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.neq"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/New.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/New.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record New(
-    SourceRange sourceRange,
-    java.lang.String name
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.new"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Node.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Node.java
@@ -1,6 +1,9 @@
 package com.aws.jverify.laurel;
 
-public sealed interface Node permits OptionalExtends, Parameter, ConstrainedType, Composite, Procedure, Datatype, DatatypeConstructorList, DatatypeConstructorArg, OptionalTrigger, InvariantClause, OptionalElse, OptionalErrorMessage, OptionalBody, Field, StmtExpr, LaurelType, Command, OptionalType, DatatypeConstructor, RequiresClause, OptionalReturnType, ReturnParameters, OptionalAssignment, ModifiesClause, EnsuresClause {
+import com.amazon.ion.IonSexp;
+
+public sealed interface Node permits Parameter, ReturnType, ConstrainedType, Procedure, Composite, Datatype, DatatypeConstructorList, DatatypeConstructorArg, ElseBranch, Body, Extends, InvariantClause, Trigger, Initializer, Field, StmtExpr, Command, LaurelType, ErrorSummary, DatatypeConstructor, InvokeOnClause, RequiresClause, ReturnParameters, TypeAnnotation, ModifiesClause, EnsuresClause {
     SourceRange sourceRange();
     java.lang.String operationName();
+    IonSexp toIon(IonSerializer $s);
 }

--- a/verifier/src/main/java/com/aws/jverify/laurel/NondetHole.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/NondetHole.java
@@ -1,8 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record NondetHole(
-    SourceRange sourceRange
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.nondetHole"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Not.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Not.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record Not(
-    SourceRange sourceRange,
-    StmtExpr inner
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.not"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/OptionalAssignment.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/OptionalAssignment.java
@@ -1,3 +1,0 @@
-package com.aws.jverify.laurel;
-
-public sealed interface OptionalAssignment extends Node permits OptionalAssignment_ {}

--- a/verifier/src/main/java/com/aws/jverify/laurel/OptionalAssignment_.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/OptionalAssignment_.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record OptionalAssignment_(
-    SourceRange sourceRange,
-    StmtExpr value
-) implements OptionalAssignment {
-    @Override
-    public java.lang.String operationName() { return "Laurel.optionalAssignment"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/OptionalBody.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/OptionalBody.java
@@ -1,3 +1,0 @@
-package com.aws.jverify.laurel;
-
-public sealed interface OptionalBody extends Node permits OptionalBody_, ExternalBody {}

--- a/verifier/src/main/java/com/aws/jverify/laurel/OptionalBody_.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/OptionalBody_.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record OptionalBody_(
-    SourceRange sourceRange,
-    StmtExpr body
-) implements OptionalBody {
-    @Override
-    public java.lang.String operationName() { return "Laurel.optionalBody"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/OptionalElse.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/OptionalElse.java
@@ -1,3 +1,0 @@
-package com.aws.jverify.laurel;
-
-public sealed interface OptionalElse extends Node permits OptionalElse_ {}

--- a/verifier/src/main/java/com/aws/jverify/laurel/OptionalElse_.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/OptionalElse_.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record OptionalElse_(
-    SourceRange sourceRange,
-    StmtExpr stmts
-) implements OptionalElse {
-    @Override
-    public java.lang.String operationName() { return "Laurel.optionalElse"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/OptionalErrorMessage.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/OptionalErrorMessage.java
@@ -1,3 +1,0 @@
-package com.aws.jverify.laurel;
-
-public sealed interface OptionalErrorMessage extends Node permits ErrorMessage {}

--- a/verifier/src/main/java/com/aws/jverify/laurel/OptionalExtends.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/OptionalExtends.java
@@ -1,3 +1,0 @@
-package com.aws.jverify.laurel;
-
-public sealed interface OptionalExtends extends Node permits OptionalExtends_ {}

--- a/verifier/src/main/java/com/aws/jverify/laurel/OptionalExtends_.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/OptionalExtends_.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record OptionalExtends_(
-    SourceRange sourceRange,
-    java.util.List<java.lang.String> parents
-) implements OptionalExtends {
-    @Override
-    public java.lang.String operationName() { return "Laurel.optionalExtends"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/OptionalReturnType.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/OptionalReturnType.java
@@ -1,3 +1,0 @@
-package com.aws.jverify.laurel;
-
-public sealed interface OptionalReturnType extends Node permits OptionalReturnType_ {}

--- a/verifier/src/main/java/com/aws/jverify/laurel/OptionalReturnType_.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/OptionalReturnType_.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record OptionalReturnType_(
-    SourceRange sourceRange,
-    LaurelType returnType
-) implements OptionalReturnType {
-    @Override
-    public java.lang.String operationName() { return "Laurel.optionalReturnType"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/OptionalTrigger.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/OptionalTrigger.java
@@ -1,3 +1,0 @@
-package com.aws.jverify.laurel;
-
-public sealed interface OptionalTrigger extends Node permits OptionalTrigger_ {}

--- a/verifier/src/main/java/com/aws/jverify/laurel/OptionalTrigger_.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/OptionalTrigger_.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record OptionalTrigger_(
-    SourceRange sourceRange,
-    StmtExpr trigger
-) implements OptionalTrigger {
-    @Override
-    public java.lang.String operationName() { return "Laurel.optionalTrigger"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/OptionalType.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/OptionalType.java
@@ -1,3 +1,0 @@
-package com.aws.jverify.laurel;
-
-public sealed interface OptionalType extends Node permits OptionalType_ {}

--- a/verifier/src/main/java/com/aws/jverify/laurel/OptionalType_.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/OptionalType_.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record OptionalType_(
-    SourceRange sourceRange,
-    LaurelType varType
-) implements OptionalType {
-    @Override
-    public java.lang.String operationName() { return "Laurel.optionalType"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Or.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Or.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record Or(
-    SourceRange sourceRange,
-    StmtExpr lhs, StmtExpr rhs
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.or"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/OrElse.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/OrElse.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record OrElse(
-    SourceRange sourceRange,
-    StmtExpr lhs, StmtExpr rhs
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.orElse"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Parameter.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Parameter.java
@@ -1,3 +1,19 @@
 package com.aws.jverify.laurel;
 
-public sealed interface Parameter extends Node permits Parameter_ {}
+public sealed interface Parameter extends Node permits Parameter.Of {
+    public record Of(
+        SourceRange sourceRange,
+        java.lang.String name, LaurelType paramType
+    ) implements Parameter {
+        @Override
+        public java.lang.String operationName() { return "Laurel.parameter"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.parameter", sourceRange());
+            sexp.add($s.serializeIdent(name()));
+            sexp.add($s.serialize(paramType()));
+            return sexp;
+        }
+    }
+}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Parameter_.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Parameter_.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record Parameter_(
-    SourceRange sourceRange,
-    java.lang.String name, LaurelType paramType
-) implements Parameter {
-    @Override
-    public java.lang.String operationName() { return "Laurel.parameter"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Parenthesis.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Parenthesis.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record Parenthesis(
-    SourceRange sourceRange,
-    StmtExpr inner
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.parenthesis"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Procedure.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Procedure.java
@@ -1,3 +1,49 @@
 package com.aws.jverify.laurel;
 
-public sealed interface Procedure extends Node permits Procedure_, Function {}
+public sealed interface Procedure extends Node permits Procedure.Procedure_, Procedure.Function {
+    public record Procedure_(
+        SourceRange sourceRange,
+        java.lang.String name, java.util.List<Parameter> parameters, java.util.Optional<ReturnType> returnType, java.util.Optional<ReturnParameters> returnParameters, java.util.List<RequiresClause> requires, java.util.Optional<InvokeOnClause> invokeOn, java.util.List<EnsuresClause> ensures, java.util.List<ModifiesClause> modifies, java.util.Optional<Body> body
+    ) implements Procedure {
+        @Override
+        public java.lang.String operationName() { return "Laurel.procedure"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.procedure", sourceRange());
+            sexp.add($s.serializeIdent(name()));
+            sexp.add($s.serializeSeq(parameters(), "commaSepList", $s::serialize));
+            sexp.add($s.serializeOption(returnType(), $s::serialize));
+            sexp.add($s.serializeOption(returnParameters(), $s::serialize));
+            sexp.add($s.serializeSeq(requires(), "seq", $s::serialize));
+            sexp.add($s.serializeOption(invokeOn(), $s::serialize));
+            sexp.add($s.serializeSeq(ensures(), "seq", $s::serialize));
+            sexp.add($s.serializeSeq(modifies(), "seq", $s::serialize));
+            sexp.add($s.serializeOption(body(), $s::serialize));
+            return sexp;
+        }
+    }
+
+    public record Function(
+        SourceRange sourceRange,
+        java.lang.String name, java.util.List<Parameter> parameters, java.util.Optional<ReturnType> returnType, java.util.Optional<ReturnParameters> returnParameters, java.util.List<RequiresClause> requires, java.util.Optional<InvokeOnClause> invokeOn, java.util.List<EnsuresClause> ensures, java.util.List<ModifiesClause> modifies, java.util.Optional<Body> body
+    ) implements Procedure {
+        @Override
+        public java.lang.String operationName() { return "Laurel.function"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.function", sourceRange());
+            sexp.add($s.serializeIdent(name()));
+            sexp.add($s.serializeSeq(parameters(), "commaSepList", $s::serialize));
+            sexp.add($s.serializeOption(returnType(), $s::serialize));
+            sexp.add($s.serializeOption(returnParameters(), $s::serialize));
+            sexp.add($s.serializeSeq(requires(), "seq", $s::serialize));
+            sexp.add($s.serializeOption(invokeOn(), $s::serialize));
+            sexp.add($s.serializeSeq(ensures(), "seq", $s::serialize));
+            sexp.add($s.serializeSeq(modifies(), "seq", $s::serialize));
+            sexp.add($s.serializeOption(body(), $s::serialize));
+            return sexp;
+        }
+    }
+}

--- a/verifier/src/main/java/com/aws/jverify/laurel/ProcedureCommand.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/ProcedureCommand.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record ProcedureCommand(
-    SourceRange sourceRange,
-    Procedure procedure
-) implements Command {
-    @Override
-    public java.lang.String operationName() { return "Laurel.procedureCommand"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Procedure_.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Procedure_.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record Procedure_(
-    SourceRange sourceRange,
-    java.lang.String name, java.util.List<Parameter> parameters, java.util.Optional<OptionalReturnType> returnType, java.util.Optional<ReturnParameters> returnParameters, java.util.List<RequiresClause> requires, java.util.List<EnsuresClause> ensures, java.util.List<ModifiesClause> modifies, java.util.Optional<OptionalBody> body
-) implements Procedure {
-    @Override
-    public java.lang.String operationName() { return "Laurel.procedure"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Real.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Real.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record Real(
-    SourceRange sourceRange,
-    java.math.BigDecimal d
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.real"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/RealType.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/RealType.java
@@ -1,8 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record RealType(
-    SourceRange sourceRange
-) implements LaurelType {
-    @Override
-    public java.lang.String operationName() { return "Laurel.realType"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/RequiresClause.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/RequiresClause.java
@@ -1,3 +1,19 @@
 package com.aws.jverify.laurel;
 
-public sealed interface RequiresClause extends Node permits RequiresClause_ {}
+public sealed interface RequiresClause extends Node permits RequiresClause.Of {
+    public record Of(
+        SourceRange sourceRange,
+        StmtExpr cond, java.util.Optional<ErrorSummary> errorMessage
+    ) implements RequiresClause {
+        @Override
+        public java.lang.String operationName() { return "Laurel.requiresClause"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.requiresClause", sourceRange());
+            sexp.add($s.serialize(cond()));
+            sexp.add($s.serializeOption(errorMessage(), $s::serialize));
+            return sexp;
+        }
+    }
+}

--- a/verifier/src/main/java/com/aws/jverify/laurel/RequiresClause_.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/RequiresClause_.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record RequiresClause_(
-    SourceRange sourceRange,
-    StmtExpr cond, java.util.Optional<OptionalErrorMessage> errorMessage
-) implements RequiresClause {
-    @Override
-    public java.lang.String operationName() { return "Laurel.requiresClause"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Return.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Return.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record Return(
-    SourceRange sourceRange,
-    StmtExpr value
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.return"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/ReturnParameters.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/ReturnParameters.java
@@ -1,3 +1,18 @@
 package com.aws.jverify.laurel;
 
-public sealed interface ReturnParameters extends Node permits ReturnParameters_ {}
+public sealed interface ReturnParameters extends Node permits ReturnParameters.Of {
+    public record Of(
+        SourceRange sourceRange,
+        java.util.List<Parameter> parameters
+    ) implements ReturnParameters {
+        @Override
+        public java.lang.String operationName() { return "Laurel.returnParameters"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.returnParameters", sourceRange());
+            sexp.add($s.serializeSeq(parameters(), "commaSepList", $s::serialize));
+            return sexp;
+        }
+    }
+}

--- a/verifier/src/main/java/com/aws/jverify/laurel/ReturnParameters_.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/ReturnParameters_.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record ReturnParameters_(
-    SourceRange sourceRange,
-    java.util.List<Parameter> parameters
-) implements ReturnParameters {
-    @Override
-    public java.lang.String operationName() { return "Laurel.returnParameters"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/ReturnType.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/ReturnType.java
@@ -1,0 +1,18 @@
+package com.aws.jverify.laurel;
+
+public sealed interface ReturnType extends Node permits ReturnType.Of {
+    public record Of(
+        SourceRange sourceRange,
+        LaurelType returnType
+    ) implements ReturnType {
+        @Override
+        public java.lang.String operationName() { return "Laurel.returnType"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.returnType", sourceRange());
+            sexp.add($s.serialize(returnType()));
+            return sexp;
+        }
+    }
+}

--- a/verifier/src/main/java/com/aws/jverify/laurel/StmtExpr.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/StmtExpr.java
@@ -1,3 +1,746 @@
 package com.aws.jverify.laurel;
 
-public sealed interface StmtExpr extends Node permits LiteralBool, Int, Real, String_, Hole, NondetHole, VarDecl, Call, New, FieldAccess, Identifier, Parenthesis, Assign, Add, Sub, Mul, Div, Mod, DivT, ModT, Eq, Neq, Gt, Lt, Le, Ge, And, Or, AndThen, OrElse, Implies, StrConcat, Not, Neg, ForallExpr, ExistsExpr, IfThenElse, Assert, Assume, Return, Block, While, ForLoop, IsType, AsType {}
+public sealed interface StmtExpr extends Node permits StmtExpr.LiteralBool, StmtExpr.Int, StmtExpr.Real, StmtExpr.String_, StmtExpr.Hole, StmtExpr.NondetHole, StmtExpr.VarDecl, StmtExpr.Call, StmtExpr.New, StmtExpr.FieldAccess, StmtExpr.Identifier, StmtExpr.Parenthesis, StmtExpr.Assign, StmtExpr.Add, StmtExpr.Sub, StmtExpr.Mul, StmtExpr.Div, StmtExpr.Mod, StmtExpr.DivT, StmtExpr.ModT, StmtExpr.Eq, StmtExpr.Neq, StmtExpr.Gt, StmtExpr.Lt, StmtExpr.Le, StmtExpr.Ge, StmtExpr.And, StmtExpr.Or, StmtExpr.AndThen, StmtExpr.OrElse, StmtExpr.Implies, StmtExpr.StrConcat, StmtExpr.Not, StmtExpr.Neg, StmtExpr.ForallExpr, StmtExpr.ExistsExpr, StmtExpr.IfThenElse, StmtExpr.Assert, StmtExpr.Assume, StmtExpr.Return, StmtExpr.Block, StmtExpr.LabelledBlock, StmtExpr.Exit, StmtExpr.While, StmtExpr.ForLoop, StmtExpr.IsType, StmtExpr.AsType {
+    public record LiteralBool(
+        SourceRange sourceRange,
+        boolean b
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.literalBool"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.literalBool", sourceRange());
+            sexp.add($s.serializeBool(b()));
+            return sexp;
+        }
+    }
+
+    public record Int(
+        SourceRange sourceRange,
+        java.math.BigInteger n
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.int"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.int", sourceRange());
+            sexp.add($s.serializeNum(n()));
+            return sexp;
+        }
+    }
+
+    public record Real(
+        SourceRange sourceRange,
+        java.math.BigDecimal d
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.real"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.real", sourceRange());
+            sexp.add($s.serializeDecimal(d()));
+            return sexp;
+        }
+    }
+
+    public record String_(
+        SourceRange sourceRange,
+        java.lang.String s
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.string"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.string", sourceRange());
+            sexp.add($s.serializeStrlit(s()));
+            return sexp;
+        }
+    }
+
+    public record Hole(
+        SourceRange sourceRange
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.hole"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.hole", sourceRange());
+            return sexp;
+        }
+    }
+
+    public record NondetHole(
+        SourceRange sourceRange
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.nondetHole"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.nondetHole", sourceRange());
+            return sexp;
+        }
+    }
+
+    public record VarDecl(
+        SourceRange sourceRange,
+        java.lang.String name, java.util.Optional<TypeAnnotation> varType, java.util.Optional<Initializer> assignment
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.varDecl"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.varDecl", sourceRange());
+            sexp.add($s.serializeIdent(name()));
+            sexp.add($s.serializeOption(varType(), $s::serialize));
+            sexp.add($s.serializeOption(assignment(), $s::serialize));
+            return sexp;
+        }
+    }
+
+    public record Call(
+        SourceRange sourceRange,
+        StmtExpr callee, java.util.List<StmtExpr> args
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.call"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.call", sourceRange());
+            sexp.add($s.serialize(callee()));
+            sexp.add($s.serializeSeq(args(), "commaSepList", $s::serialize));
+            return sexp;
+        }
+    }
+
+    public record New(
+        SourceRange sourceRange,
+        java.lang.String name
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.new"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.new", sourceRange());
+            sexp.add($s.serializeIdent(name()));
+            return sexp;
+        }
+    }
+
+    public record FieldAccess(
+        SourceRange sourceRange,
+        StmtExpr obj, java.lang.String field
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.fieldAccess"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.fieldAccess", sourceRange());
+            sexp.add($s.serialize(obj()));
+            sexp.add($s.serializeIdent(field()));
+            return sexp;
+        }
+    }
+
+    public record Identifier(
+        SourceRange sourceRange,
+        java.lang.String name
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.identifier"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.identifier", sourceRange());
+            sexp.add($s.serializeIdent(name()));
+            return sexp;
+        }
+    }
+
+    public record Parenthesis(
+        SourceRange sourceRange,
+        StmtExpr inner
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.parenthesis"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.parenthesis", sourceRange());
+            sexp.add($s.serialize(inner()));
+            return sexp;
+        }
+    }
+
+    public record Assign(
+        SourceRange sourceRange,
+        StmtExpr target, StmtExpr value
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.assign"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.assign", sourceRange());
+            sexp.add($s.serialize(target()));
+            sexp.add($s.serialize(value()));
+            return sexp;
+        }
+    }
+
+    public record Add(
+        SourceRange sourceRange,
+        StmtExpr lhs, StmtExpr rhs
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.add"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.add", sourceRange());
+            sexp.add($s.serialize(lhs()));
+            sexp.add($s.serialize(rhs()));
+            return sexp;
+        }
+    }
+
+    public record Sub(
+        SourceRange sourceRange,
+        StmtExpr lhs, StmtExpr rhs
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.sub"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.sub", sourceRange());
+            sexp.add($s.serialize(lhs()));
+            sexp.add($s.serialize(rhs()));
+            return sexp;
+        }
+    }
+
+    public record Mul(
+        SourceRange sourceRange,
+        StmtExpr lhs, StmtExpr rhs
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.mul"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.mul", sourceRange());
+            sexp.add($s.serialize(lhs()));
+            sexp.add($s.serialize(rhs()));
+            return sexp;
+        }
+    }
+
+    public record Div(
+        SourceRange sourceRange,
+        StmtExpr lhs, StmtExpr rhs
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.div"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.div", sourceRange());
+            sexp.add($s.serialize(lhs()));
+            sexp.add($s.serialize(rhs()));
+            return sexp;
+        }
+    }
+
+    public record Mod(
+        SourceRange sourceRange,
+        StmtExpr lhs, StmtExpr rhs
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.mod"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.mod", sourceRange());
+            sexp.add($s.serialize(lhs()));
+            sexp.add($s.serialize(rhs()));
+            return sexp;
+        }
+    }
+
+    public record DivT(
+        SourceRange sourceRange,
+        StmtExpr lhs, StmtExpr rhs
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.divT"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.divT", sourceRange());
+            sexp.add($s.serialize(lhs()));
+            sexp.add($s.serialize(rhs()));
+            return sexp;
+        }
+    }
+
+    public record ModT(
+        SourceRange sourceRange,
+        StmtExpr lhs, StmtExpr rhs
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.modT"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.modT", sourceRange());
+            sexp.add($s.serialize(lhs()));
+            sexp.add($s.serialize(rhs()));
+            return sexp;
+        }
+    }
+
+    public record Eq(
+        SourceRange sourceRange,
+        StmtExpr lhs, StmtExpr rhs
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.eq"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.eq", sourceRange());
+            sexp.add($s.serialize(lhs()));
+            sexp.add($s.serialize(rhs()));
+            return sexp;
+        }
+    }
+
+    public record Neq(
+        SourceRange sourceRange,
+        StmtExpr lhs, StmtExpr rhs
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.neq"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.neq", sourceRange());
+            sexp.add($s.serialize(lhs()));
+            sexp.add($s.serialize(rhs()));
+            return sexp;
+        }
+    }
+
+    public record Gt(
+        SourceRange sourceRange,
+        StmtExpr lhs, StmtExpr rhs
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.gt"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.gt", sourceRange());
+            sexp.add($s.serialize(lhs()));
+            sexp.add($s.serialize(rhs()));
+            return sexp;
+        }
+    }
+
+    public record Lt(
+        SourceRange sourceRange,
+        StmtExpr lhs, StmtExpr rhs
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.lt"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.lt", sourceRange());
+            sexp.add($s.serialize(lhs()));
+            sexp.add($s.serialize(rhs()));
+            return sexp;
+        }
+    }
+
+    public record Le(
+        SourceRange sourceRange,
+        StmtExpr lhs, StmtExpr rhs
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.le"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.le", sourceRange());
+            sexp.add($s.serialize(lhs()));
+            sexp.add($s.serialize(rhs()));
+            return sexp;
+        }
+    }
+
+    public record Ge(
+        SourceRange sourceRange,
+        StmtExpr lhs, StmtExpr rhs
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.ge"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.ge", sourceRange());
+            sexp.add($s.serialize(lhs()));
+            sexp.add($s.serialize(rhs()));
+            return sexp;
+        }
+    }
+
+    public record And(
+        SourceRange sourceRange,
+        StmtExpr lhs, StmtExpr rhs
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.and"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.and", sourceRange());
+            sexp.add($s.serialize(lhs()));
+            sexp.add($s.serialize(rhs()));
+            return sexp;
+        }
+    }
+
+    public record Or(
+        SourceRange sourceRange,
+        StmtExpr lhs, StmtExpr rhs
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.or"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.or", sourceRange());
+            sexp.add($s.serialize(lhs()));
+            sexp.add($s.serialize(rhs()));
+            return sexp;
+        }
+    }
+
+    public record AndThen(
+        SourceRange sourceRange,
+        StmtExpr lhs, StmtExpr rhs
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.andThen"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.andThen", sourceRange());
+            sexp.add($s.serialize(lhs()));
+            sexp.add($s.serialize(rhs()));
+            return sexp;
+        }
+    }
+
+    public record OrElse(
+        SourceRange sourceRange,
+        StmtExpr lhs, StmtExpr rhs
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.orElse"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.orElse", sourceRange());
+            sexp.add($s.serialize(lhs()));
+            sexp.add($s.serialize(rhs()));
+            return sexp;
+        }
+    }
+
+    public record Implies(
+        SourceRange sourceRange,
+        StmtExpr lhs, StmtExpr rhs
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.implies"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.implies", sourceRange());
+            sexp.add($s.serialize(lhs()));
+            sexp.add($s.serialize(rhs()));
+            return sexp;
+        }
+    }
+
+    public record StrConcat(
+        SourceRange sourceRange,
+        StmtExpr lhs, StmtExpr rhs
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.strConcat"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.strConcat", sourceRange());
+            sexp.add($s.serialize(lhs()));
+            sexp.add($s.serialize(rhs()));
+            return sexp;
+        }
+    }
+
+    public record Not(
+        SourceRange sourceRange,
+        StmtExpr inner
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.not"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.not", sourceRange());
+            sexp.add($s.serialize(inner()));
+            return sexp;
+        }
+    }
+
+    public record Neg(
+        SourceRange sourceRange,
+        StmtExpr inner
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.neg"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.neg", sourceRange());
+            sexp.add($s.serialize(inner()));
+            return sexp;
+        }
+    }
+
+    public record ForallExpr(
+        SourceRange sourceRange,
+        java.lang.String name, LaurelType ty, java.util.Optional<Trigger> trigger, StmtExpr body
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.forallExpr"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.forallExpr", sourceRange());
+            sexp.add($s.serializeIdent(name()));
+            sexp.add($s.serialize(ty()));
+            sexp.add($s.serializeOption(trigger(), $s::serialize));
+            sexp.add($s.serialize(body()));
+            return sexp;
+        }
+    }
+
+    public record ExistsExpr(
+        SourceRange sourceRange,
+        java.lang.String name, LaurelType ty, java.util.Optional<Trigger> trigger, StmtExpr body
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.existsExpr"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.existsExpr", sourceRange());
+            sexp.add($s.serializeIdent(name()));
+            sexp.add($s.serialize(ty()));
+            sexp.add($s.serializeOption(trigger(), $s::serialize));
+            sexp.add($s.serialize(body()));
+            return sexp;
+        }
+    }
+
+    public record IfThenElse(
+        SourceRange sourceRange,
+        StmtExpr cond, StmtExpr thenBranch, java.util.Optional<ElseBranch> elseBranch
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.ifThenElse"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.ifThenElse", sourceRange());
+            sexp.add($s.serialize(cond()));
+            sexp.add($s.serialize(thenBranch()));
+            sexp.add($s.serializeOption(elseBranch(), $s::serialize));
+            return sexp;
+        }
+    }
+
+    public record Assert(
+        SourceRange sourceRange,
+        StmtExpr cond, java.util.Optional<ErrorSummary> errorMessage
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.assert"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.assert", sourceRange());
+            sexp.add($s.serialize(cond()));
+            sexp.add($s.serializeOption(errorMessage(), $s::serialize));
+            return sexp;
+        }
+    }
+
+    public record Assume(
+        SourceRange sourceRange,
+        StmtExpr cond
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.assume"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.assume", sourceRange());
+            sexp.add($s.serialize(cond()));
+            return sexp;
+        }
+    }
+
+    public record Return(
+        SourceRange sourceRange,
+        StmtExpr value
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.return"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.return", sourceRange());
+            sexp.add($s.serialize(value()));
+            return sexp;
+        }
+    }
+
+    public record Block(
+        SourceRange sourceRange,
+        java.util.List<StmtExpr> stmts
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.block"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.block", sourceRange());
+            sexp.add($s.serializeSeq(stmts(), "semicolonSepList", $s::serialize));
+            return sexp;
+        }
+    }
+
+    public record LabelledBlock(
+        SourceRange sourceRange,
+        java.util.List<StmtExpr> stmts, java.lang.String label
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.labelledBlock"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.labelledBlock", sourceRange());
+            sexp.add($s.serializeSeq(stmts(), "semicolonSepList", $s::serialize));
+            sexp.add($s.serializeIdent(label()));
+            return sexp;
+        }
+    }
+
+    public record Exit(
+        SourceRange sourceRange,
+        java.lang.String label
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.exit"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.exit", sourceRange());
+            sexp.add($s.serializeIdent(label()));
+            return sexp;
+        }
+    }
+
+    public record While(
+        SourceRange sourceRange,
+        StmtExpr cond, java.util.List<InvariantClause> invariants, StmtExpr body
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.while"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.while", sourceRange());
+            sexp.add($s.serialize(cond()));
+            sexp.add($s.serializeSeq(invariants(), "seq", $s::serialize));
+            sexp.add($s.serialize(body()));
+            return sexp;
+        }
+    }
+
+    public record ForLoop(
+        SourceRange sourceRange,
+        StmtExpr init, StmtExpr cond, StmtExpr step, java.util.List<InvariantClause> invariants, StmtExpr body
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.forLoop"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.forLoop", sourceRange());
+            sexp.add($s.serialize(init()));
+            sexp.add($s.serialize(cond()));
+            sexp.add($s.serialize(step()));
+            sexp.add($s.serializeSeq(invariants(), "seq", $s::serialize));
+            sexp.add($s.serialize(body()));
+            return sexp;
+        }
+    }
+
+    public record IsType(
+        SourceRange sourceRange,
+        StmtExpr target, java.lang.String typeName
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.isType"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.isType", sourceRange());
+            sexp.add($s.serialize(target()));
+            sexp.add($s.serializeIdent(typeName()));
+            return sexp;
+        }
+    }
+
+    public record AsType(
+        SourceRange sourceRange,
+        StmtExpr target, java.lang.String typeName
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.asType"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.asType", sourceRange());
+            sexp.add($s.serialize(target()));
+            sexp.add($s.serializeIdent(typeName()));
+            return sexp;
+        }
+    }
+}

--- a/verifier/src/main/java/com/aws/jverify/laurel/StrConcat.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/StrConcat.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record StrConcat(
-    SourceRange sourceRange,
-    StmtExpr lhs, StmtExpr rhs
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.strConcat"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/StringType.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/StringType.java
@@ -1,8 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record StringType(
-    SourceRange sourceRange
-) implements LaurelType {
-    @Override
-    public java.lang.String operationName() { return "Laurel.stringType"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/String_.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/String_.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record String_(
-    SourceRange sourceRange,
-    java.lang.String s
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.string"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Sub.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Sub.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record Sub(
-    SourceRange sourceRange,
-    StmtExpr lhs, StmtExpr rhs
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.sub"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/Trigger.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/Trigger.java
@@ -1,0 +1,18 @@
+package com.aws.jverify.laurel;
+
+public sealed interface Trigger extends Node permits Trigger.Of {
+    public record Of(
+        SourceRange sourceRange,
+        StmtExpr trigger
+    ) implements Trigger {
+        @Override
+        public java.lang.String operationName() { return "Laurel.trigger"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.trigger", sourceRange());
+            sexp.add($s.serialize(trigger()));
+            return sexp;
+        }
+    }
+}

--- a/verifier/src/main/java/com/aws/jverify/laurel/TypeAnnotation.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/TypeAnnotation.java
@@ -1,0 +1,18 @@
+package com.aws.jverify.laurel;
+
+public sealed interface TypeAnnotation extends Node permits TypeAnnotation.Of {
+    public record Of(
+        SourceRange sourceRange,
+        LaurelType varType
+    ) implements TypeAnnotation {
+        @Override
+        public java.lang.String operationName() { return "Laurel.typeAnnotation"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.typeAnnotation", sourceRange());
+            sexp.add($s.serialize(varType()));
+            return sexp;
+        }
+    }
+}

--- a/verifier/src/main/java/com/aws/jverify/laurel/VarDecl.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/VarDecl.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record VarDecl(
-    SourceRange sourceRange,
-    java.lang.String name, java.util.Optional<OptionalType> varType, java.util.Optional<OptionalAssignment> assignment
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.varDecl"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/laurel/While.java
+++ b/verifier/src/main/java/com/aws/jverify/laurel/While.java
@@ -1,9 +1,0 @@
-package com.aws.jverify.laurel;
-
-public record While(
-    SourceRange sourceRange,
-    StmtExpr cond, java.util.List<InvariantClause> invariants, StmtExpr body
-) implements StmtExpr {
-    @Override
-    public java.lang.String operationName() { return "Laurel.while"; }
-}

--- a/verifier/src/main/java/com/aws/jverify/verifier/compiler/generator/laurel/JavaToLaurelCompiler.java
+++ b/verifier/src/main/java/com/aws/jverify/verifier/compiler/generator/laurel/JavaToLaurelCompiler.java
@@ -21,6 +21,8 @@ import javax.tools.JavaFileObject;
 import java.net.URI;
 import java.util.*;
 
+import static com.aws.jverify.laurel.Laurel.*;
+
 public class JavaToLaurelCompiler {
     private final JavaLowerer lowerer;
     private final MethodOrLoopContractCompiler contractCompiler;
@@ -54,7 +56,7 @@ public class JavaToLaurelCompiler {
                 first = false;
             }
             for (var proc : visitor.procedures) {
-                commands.add(new ProcedureCommand(SourceRange.NONE, proc));
+                commands.add(procedureCommand(proc));
             }
             result.add(new LaurelFile(compilationUnit.sourcefile.toUri(), commands));
             lineMaps.put(compilationUnit.sourcefile.toUri(), compilationUnit.getLineMap());
@@ -85,35 +87,36 @@ public class JavaToLaurelCompiler {
 
     private List<Command> getPredefinedTypes() {
         return List.of(
-            constrainedTypeCommand("int8", -128L, 127L),
-            constrainedTypeCommand("int16", -32768L, 32767L),
-            constrainedTypeCommand("int32", -2147483648L, 2147483647L),
-            constrainedTypeCommand("int64", -9223372036854775808L, 9223372036854775807L)
+            makeConstrainedType("int8", -128L, 127L),
+            makeConstrainedType("int16", -32768L, 32767L),
+            makeConstrainedType("int32", -2147483648L, 2147483647L),
+            makeConstrainedType("int64", -9223372036854775808L, 9223372036854775807L)
         );
     }
 
-    private Command constrainedTypeCommand(String name, long min, long max) {
+    private Command makeConstrainedType(String name, long min, long max) {
         var sr = toSourceRange(currentCompilationUnit);
-        var x = new Identifier(sr, "x");
-        var minExpr = min >= 0
-                ? new Int(sr, java.math.BigInteger.valueOf(min))
-                : new Neg(sr, new Int(sr, java.math.BigInteger.valueOf(min).negate()));
-        var maxExpr = new Int(sr, java.math.BigInteger.valueOf(max));
-        var constraint = new And(sr,
-                new Ge(sr, x, minExpr),
-                new Le(sr, x, maxExpr));
-        var witness = new Int(sr, java.math.BigInteger.ZERO);
-        return new ConstrainedTypeCommand(sr,
-                new ConstrainedType_(sr, name, "x", new IntType(sr), constraint, witness));
+        var x = identifier(sr, "x");
+        var minExpr = longLiteral(sr, min);
+        var maxExpr = longLiteral(sr, max);
+        var constraint = and(sr, ge(sr, x, minExpr), le(sr, x, maxExpr));
+        var witness = int_(sr, 0);
+        return constrainedTypeCommand(sr, constrainedType(sr, name, "x", intType(sr), constraint, witness));
+    }
+
+    /** Create a Laurel integer literal for any long value, wrapping negatives in Neg. */
+    private static StmtExpr longLiteral(SourceRange sr, long val) {
+        if (val >= 0) return int_(sr, val);
+        return neg(sr, new StmtExpr.Int(sr, java.math.BigInteger.valueOf(val).negate()));
     }
 
     private LaurelType translateType(com.sun.tools.javac.code.Type type) {
         return switch (type.getTag()) {
-            case INT -> new CompositeType(SourceRange.NONE, "int32");
-            case SHORT -> new CompositeType(SourceRange.NONE, "int16");
-            case BYTE -> new CompositeType(SourceRange.NONE, "int8");
-            case LONG -> new CompositeType(SourceRange.NONE, "int64");
-            case BOOLEAN -> new BoolType(SourceRange.NONE);
+            case INT -> compositeType("int32");
+            case SHORT -> compositeType("int16");
+            case BYTE -> compositeType("int8");
+            case LONG -> compositeType("int64");
+            case BOOLEAN -> boolType();
             default -> throw new JavaViolationException("Unsupported type: " + type);
         };
     }
@@ -123,43 +126,37 @@ public class JavaToLaurelCompiler {
 
         @Override
         public void visitMethodDef(JCTree.JCMethodDecl method) {
-            // TODO: Use NameCompiler for unique method names to avoid collisions across classes
-            // TODO: Filter synthetic methods (JVerifyUtils.isSynthetic) and constructors (JVerifyUtils.isConstructor)
-            // TODO: Respect @Verify(false) annotation
             if ((method.mods.flags & Flags.STATIC) != 0) {
                 String methodName = method.name.toString();
 
-                // Parameters
                 List<Parameter> params = new ArrayList<>();
                 for (var param : method.params) {
-                    params.add(new Parameter_(SourceRange.NONE, param.name.toString(), translateType(param.type)));
+                    params.add(parameter(param.name.toString(), translateType(param.type)));
                 }
 
-                // Return type
-                Optional<OptionalReturnType> returnType = Optional.empty();
+                Optional<ReturnType> retType = Optional.empty();
                 if (method.restype != null && method.restype.type != null
                         && method.restype.type.getTag() != TypeTag.VOID) {
-                    returnType = Optional.of(new OptionalReturnType_(SourceRange.NONE, translateType(method.restype.type)));
+                    retType = Optional.of(returnType(translateType(method.restype.type)));
                 }
 
-                // Extract contracts from the method body
                 List<RequiresClause> requires = new ArrayList<>();
                 List<EnsuresClause> ensures = new ArrayList<>();
-                StmtExpr body = null;
+                StmtExpr methodBody = null;
 
                 if (method.body != null) {
                     MethodOrLoopContract contract = contractCompiler.getContract(method.body);
                     for (var pre : contract.preconditions()) {
-                        requires.add(new RequiresClause_(SourceRange.NONE, convertExpression(pre.get()), Optional.empty()));
+                        requires.add(requiresClause(convertExpression(pre.get()), Optional.empty()));
                     }
                     for (var post : contract.postconditions()) {
                         var postExpr = post.get();
                         if (postExpr instanceof JCTree.JCLambda lambda && lambda.params.size() == 1) {
                             var paramName = lambda.params.getFirst().name.toString();
                             var renames = Map.of(paramName, "result");
-                            ensures.add(new EnsuresClause_(SourceRange.NONE, convertLambdaBody(lambda, renames), Optional.empty()));
+                            ensures.add(ensuresClause(convertLambdaBody(lambda, renames), Optional.empty()));
                         } else {
-                            ensures.add(new EnsuresClause_(SourceRange.NONE, convertExpression(postExpr), Optional.empty()));
+                            ensures.add(ensuresClause(convertExpression(postExpr), Optional.empty()));
                         }
                     }
 
@@ -172,97 +169,96 @@ public class JavaToLaurelCompiler {
                                 stmts.add(converted);
                             }
                         }
-                        body = new Block(toSourceRange(method.body), stmts);
+                        methodBody = block(toSourceRange(method.body), stmts);
                     }
                 }
 
-                Optional<OptionalBody> optBody = body != null
-                        ? Optional.of(new OptionalBody_(SourceRange.NONE, body))
+                Optional<Body> optBody = methodBody != null
+                        ? Optional.of(body(methodBody))
                         : Optional.empty();
 
                 boolean isPure = jverifyUtils.isPure(method.sym);
                 Procedure proc = isPure
-                        ? new Function(toSourceRange(method), methodName, params,
-                                returnType, Optional.empty(), requires, ensures, List.of(), optBody)
-                        : new Procedure_(toSourceRange(method), methodName, params,
-                                returnType, Optional.empty(), requires, ensures, List.of(), optBody);
+                        ? function(toSourceRange(method), methodName, params,
+                                retType, Optional.empty(), requires, Optional.empty(), ensures, List.of(), optBody)
+                        : procedure(toSourceRange(method), methodName, params,
+                                retType, Optional.empty(), requires, Optional.empty(), ensures, List.of(), optBody);
                 procedures.add(proc);
             }
             super.visitMethodDef(method);
         }
 
-        private StmtExpr convertBlock(JCTree.JCBlock block) {
+        private StmtExpr convertBlock(JCTree.JCBlock blk) {
             List<StmtExpr> statements = new ArrayList<>();
-            for (var statement : block.stats) {
+            for (var statement : blk.stats) {
                 StmtExpr converted = convertStatement(statement);
                 if (converted != null) {
                     statements.add(converted);
                 }
             }
-            return new Block(toSourceRange(block), statements);
+            return block(toSourceRange(blk), statements);
         }
 
         private StmtExpr convertStatement(JCTree.JCStatement statement) {
             return switch (statement) {
                 case JCTree.JCAssert assertStmt ->
-                        new Assert(toSourceRange(assertStmt), convertExpression(assertStmt.cond), Optional.empty());
+                        assert_(toSourceRange(assertStmt), convertExpression(assertStmt.cond), Optional.empty());
                 case JCTree.JCExpressionStatement exprStmt -> convertExpression(exprStmt.expr);
-                case JCTree.JCBlock block -> convertBlock(block);
+                case JCTree.JCBlock blk -> convertBlock(blk);
                 case JCTree.JCVariableDecl varDecl -> {
                     LaurelType type = translateType(varDecl.type);
-                    Optional<OptionalAssignment> optAssign = varDecl.init != null
-                            ? Optional.of(new OptionalAssignment_(SourceRange.NONE, convertExpression(varDecl.init)))
+                    Optional<Initializer> optAssign = varDecl.init != null
+                            ? Optional.of(initializer(convertExpression(varDecl.init)))
                             : Optional.empty();
-                    yield new VarDecl(toSourceRange(varDecl), varDecl.name.toString(),
-                            Optional.of(new OptionalType_(SourceRange.NONE, type)), optAssign);
+                    yield varDecl(toSourceRange(varDecl), varDecl.name.toString(),
+                            Optional.of(typeAnnotation(type)), optAssign);
                 }
                 case JCTree.JCIf ifStmt -> {
                     StmtExpr cond = convertExpression(ifStmt.cond);
                     StmtExpr thenBranch = convertStatement(ifStmt.thenpart);
-                    Optional<OptionalElse> elseBranch = Optional.empty();
+                    Optional<ElseBranch> elseB = Optional.empty();
                     if (ifStmt.elsepart != null) {
                         StmtExpr elseStmt = convertStatement(ifStmt.elsepart);
                         if (elseStmt != null) {
-                            elseBranch = Optional.of(new OptionalElse_(SourceRange.NONE, elseStmt));
+                            elseB = Optional.of(elseBranch(elseStmt));
                         }
                     }
-                    yield new IfThenElse(toSourceRange(ifStmt), cond, thenBranch, elseBranch);
+                    yield ifThenElse(toSourceRange(ifStmt), cond, thenBranch, elseB);
                 }
                 case JCTree.JCReturn retStmt -> {
                     if (retStmt.expr != null) {
-                        yield new Return(toSourceRange(retStmt), convertExpression(retStmt.expr));
+                        yield return_(toSourceRange(retStmt), convertExpression(retStmt.expr));
                     }
-                    // void return — skip
                     yield null;
                 }
                 case JCTree.JCWhileLoop whileStmt -> {
                     StmtExpr cond = convertExpression(whileStmt.cond);
                     if (whileStmt.body instanceof JCTree.JCBlock loopBlock) {
                         var parts = extractLoopParts(loopBlock);
-                        yield new While(toSourceRange(whileStmt), cond, parts.invariants, parts.body);
+                        yield while_(toSourceRange(whileStmt), cond, parts.invariants, parts.body);
                     }
-                    yield new While(toSourceRange(whileStmt), cond, List.of(), convertStatement(whileStmt.body));
+                    yield while_(toSourceRange(whileStmt), cond, List.of(), convertStatement(whileStmt.body));
                 }
                 case JCTree.JCForLoop forLoop -> {
                     if (forLoop.init.size() > 1 || forLoop.step.size() > 1)
                         throw new JavaViolationException("Multi-init or multi-step for loops are not supported");
-                    StmtExpr init = forLoop.init.isEmpty() ? new Block(toSourceRange(forLoop), List.of())
+                    StmtExpr init = forLoop.init.isEmpty() ? block(toSourceRange(forLoop), List.of())
                             : convertStatement(forLoop.init.getFirst());
                     StmtExpr cond = forLoop.cond != null
                             ? convertExpression(forLoop.cond)
-                            : new LiteralBool(toSourceRange(forLoop), true);
-                    StmtExpr step = forLoop.step.isEmpty() ? new Block(toSourceRange(forLoop), List.of())
+                            : literalBool(toSourceRange(forLoop), true);
+                    StmtExpr step = forLoop.step.isEmpty() ? block(toSourceRange(forLoop), List.of())
                             : convertStatement(forLoop.step.getFirst());
                     List<InvariantClause> invariants = List.of();
-                    StmtExpr body;
+                    StmtExpr loopBody;
                     if (forLoop.body instanceof JCTree.JCBlock loopBlock) {
                         var parts = extractLoopParts(loopBlock);
                         invariants = parts.invariants;
-                        body = parts.body;
+                        loopBody = parts.body;
                     } else {
-                        body = convertStatement(forLoop.body);
+                        loopBody = convertStatement(forLoop.body);
                     }
-                    yield new ForLoop(toSourceRange(forLoop), init, cond, step, invariants, body);
+                    yield forLoop(toSourceRange(forLoop), init, cond, step, invariants, loopBody);
                 }
                 default -> throw new JavaViolationException("Unsupported statement: " + statement.getClass().getSimpleName());
             };
@@ -277,8 +273,8 @@ public class JavaToLaurelCompiler {
                 return convertExpression(exprBody, renames);
             } else if (lambda.body instanceof JCTree.JCReturn ret && ret.expr != null) {
                 return convertExpression(ret.expr, renames);
-            } else if (lambda.body instanceof JCTree.JCBlock block && block.stats.size() == 1
-                    && block.stats.getFirst() instanceof JCTree.JCReturn ret && ret.expr != null) {
+            } else if (lambda.body instanceof JCTree.JCBlock blk && blk.stats.size() == 1
+                    && blk.stats.getFirst() instanceof JCTree.JCReturn ret && ret.expr != null) {
                 return convertExpression(ret.expr, renames);
             }
             throw new JavaViolationException("Unsupported lambda body");
@@ -290,7 +286,7 @@ public class JavaToLaurelCompiler {
             MethodOrLoopContract loopContract = contractCompiler.getContract(loopBlock);
             List<InvariantClause> invariants = new ArrayList<>();
             for (var inv : loopContract.loopInvariants()) {
-                invariants.add(new InvariantClause_(SourceRange.NONE, convertExpression(inv.get())));
+                invariants.add(invariantClause(convertExpression(inv.get())));
             }
             var implStatements = MethodOrLoopContractCompiler.getImplementationStatements(loopBlock);
             List<StmtExpr> stmts = new ArrayList<>();
@@ -298,7 +294,7 @@ public class JavaToLaurelCompiler {
                 StmtExpr converted = convertStatement(s);
                 if (converted != null) stmts.add(converted);
             }
-            return new LoopParts(invariants, new Block(toSourceRange(loopBlock), stmts));
+            return new LoopParts(invariants, block(toSourceRange(loopBlock), stmts));
         }
 
         private StmtExpr convertExpression(JCTree.JCExpression expr, Map<String, String> renames) {
@@ -306,32 +302,31 @@ public class JavaToLaurelCompiler {
                 case JCTree.JCLiteral literal -> convertLiteral(literal);
                 case JCTree.JCIdent ident -> {
                     String name = ident.name.toString();
-                    yield new Identifier(toSourceRange(ident), renames.getOrDefault(name, name));
+                    yield identifier(toSourceRange(ident), renames.getOrDefault(name, name));
                 }
                 case JCTree.JCParens parens ->
                         convertExpression(parens.expr, renames);
                 case JCTree.JCBinary binary -> convertBinary(binary, renames);
                 case JCTree.JCUnary unary -> convertUnary(unary, renames);
-                case JCTree.JCAssign assign ->
-                        new Assign(toSourceRange(assign), convertExpression(assign.lhs, renames), convertExpression(assign.rhs, renames));
+                case JCTree.JCAssign asgn ->
+                        assign(toSourceRange(asgn), convertExpression(asgn.lhs, renames), convertExpression(asgn.rhs, renames));
                 case JCTree.JCConditional cond ->
-                        new IfThenElse(toSourceRange(cond), convertExpression(cond.cond, renames),
+                        ifThenElse(toSourceRange(cond), convertExpression(cond.cond, renames),
                                 convertExpression(cond.truepart, renames),
-                                Optional.of(new OptionalElse_(toSourceRange(cond.falsepart), convertExpression(cond.falsepart, renames))));
+                                Optional.of(elseBranch(toSourceRange(cond.falsepart), convertExpression(cond.falsepart, renames))));
                 case JCTree.JCMethodInvocation invocation -> {
                     var jverifyMethod = JVerifyUtils.getJVerifyMethod(invocation);
                     if (jverifyMethod != null) {
                         yield convertJVerifyCall(invocation, jverifyMethod, renames);
                     }
-                    // Regular static method call
                     var methodSym = (Symbol.MethodSymbol) TreeInfo.symbol(invocation.getMethodSelect());
                     String calleeName = methodSym.getSimpleName().toString();
                     List<StmtExpr> args = new ArrayList<>();
                     for (var arg : invocation.args) {
                         args.add(convertExpression(arg, renames));
                     }
-                    yield new Call(toSourceRange(invocation),
-                            new Identifier(toSourceRange(invocation), calleeName), args);
+                    yield call(toSourceRange(invocation),
+                            identifier(toSourceRange(invocation), calleeName), args);
                 }
                 default -> throw new JavaViolationException("Unsupported expression: " + expr.getClass().getSimpleName());
             };
@@ -340,12 +335,10 @@ public class JavaToLaurelCompiler {
         private StmtExpr convertLiteral(JCTree.JCLiteral literal) {
             var sr = toSourceRange(literal);
             return switch (literal.typetag) {
-                case BOOLEAN -> new LiteralBool(sr, (int) literal.value != 0);
+                case BOOLEAN -> literalBool(sr, (int) literal.value != 0);
                 case INT, LONG, SHORT, BYTE -> {
                     long val = ((Number) literal.value).longValue();
-                    yield val >= 0
-                            ? new Int(sr, java.math.BigInteger.valueOf(val))
-                            : new Neg(sr, new Int(sr, java.math.BigInteger.valueOf(val).negate()));
+                    yield longLiteral(sr, val);
                 }
                 default -> throw new JavaViolationException("Unsupported literal type: " + literal.typetag);
             };
@@ -356,19 +349,19 @@ public class JavaToLaurelCompiler {
             StmtExpr rhs = convertExpression(binary.rhs, renames);
             SourceRange sr = toSourceRange(binary);
             return switch (binary.getTag()) {
-                case PLUS -> new Add(sr, lhs, rhs);
-                case MINUS -> new Sub(sr, lhs, rhs);
-                case MUL -> new Mul(sr, lhs, rhs);
-                case DIV -> new DivT(sr, lhs, rhs);
-                case MOD -> new ModT(sr, lhs, rhs);
-                case EQ -> new Eq(sr, lhs, rhs);
-                case NE -> new Neq(sr, lhs, rhs);
-                case GT -> new Gt(sr, lhs, rhs);
-                case LT -> new Lt(sr, lhs, rhs);
-                case GE -> new Ge(sr, lhs, rhs);
-                case LE -> new Le(sr, lhs, rhs);
-                case AND -> new AndThen(sr, lhs, rhs);
-                case OR -> new OrElse(sr, lhs, rhs);
+                case PLUS -> add(sr, lhs, rhs);
+                case MINUS -> sub(sr, lhs, rhs);
+                case MUL -> mul(sr, lhs, rhs);
+                case DIV -> divT(sr, lhs, rhs);
+                case MOD -> modT(sr, lhs, rhs);
+                case EQ -> eq(sr, lhs, rhs);
+                case NE -> neq(sr, lhs, rhs);
+                case GT -> gt(sr, lhs, rhs);
+                case LT -> lt(sr, lhs, rhs);
+                case GE -> ge(sr, lhs, rhs);
+                case LE -> le(sr, lhs, rhs);
+                case AND -> andThen(sr, lhs, rhs);
+                case OR -> orElse(sr, lhs, rhs);
                 default -> throw new JavaViolationException("Unsupported binary op: " + binary.getTag());
             };
         }
@@ -377,8 +370,8 @@ public class JavaToLaurelCompiler {
             StmtExpr inner = convertExpression(unary.arg, renames);
             SourceRange sr = toSourceRange(unary);
             return switch (unary.getTag()) {
-                case NOT -> new Not(sr, inner);
-                case NEG -> new Neg(sr, inner);
+                case NOT -> not(sr, inner);
+                case NEG -> neg(sr, inner);
                 default -> throw new JavaViolationException("Unsupported unary op: " + unary.getTag());
             };
         }
@@ -392,35 +385,32 @@ public class JavaToLaurelCompiler {
                 case "check" -> {
                     if (invocation.args.size() != 1)
                         throw new JavaViolationException("check should have a single argument");
-                    yield new Assert(sr, convertExpression(invocation.args.getFirst(), renames), Optional.empty());
+                    yield assert_(sr, convertExpression(invocation.args.getFirst(), renames), Optional.empty());
                 }
                 case "assume" -> {
                     if (invocation.args.size() != 1)
                         throw new JavaViolationException("assume should have a single argument");
-                    yield new Assume(sr, convertExpression(invocation.args.getFirst(), renames));
+                    yield assume(sr, convertExpression(invocation.args.getFirst(), renames));
                 }
                 case "implies" -> {
                     if (invocation.args.size() != 2)
                         throw new JavaViolationException("implies should have two arguments");
-                    // implies(a, b) = !a | b (eager, both sides always evaluated)
-                    yield new Or(sr, new Not(sr, convertExpression(invocation.args.get(0), renames)),
+                    yield or(sr, not(sr, convertExpression(invocation.args.get(0), renames)),
                             convertExpression(invocation.args.get(1), renames));
                 }
                 case "forall", "exists" -> {
                     if (invocation.args.size() != 1 || !(invocation.args.getFirst() instanceof JCTree.JCLambda lambda))
                         throw new JavaViolationException(name + " requires a single lambda argument");
-                    StmtExpr body = convertLambdaBody(lambda, renames);
+                    StmtExpr qBody = convertLambdaBody(lambda, renames);
                     for (int i = lambda.params.size() - 1; i >= 0; i--) {
                         var p = lambda.params.get(i);
                         var ty = translateType(p.type);
-                        body = name.equals("forall")
-                                ? new ForallExpr(sr, p.name.toString(), ty, Optional.empty(), body)
-                                : new ExistsExpr(sr, p.name.toString(), ty, Optional.empty(), body);
+                        qBody = name.equals("forall")
+                                ? forallExpr(sr, p.name.toString(), ty, Optional.empty(), qBody)
+                                : existsExpr(sr, p.name.toString(), ty, Optional.empty(), qBody);
                     }
-                    yield body;
+                    yield qBody;
                 }
-                // TODO: Support old() in postconditions
-                // TODO: Support break/continue (blocked on Strata grammar — needs Exit node)
                 default -> throw new JavaViolationException("Unsupported JVerify method: " + name);
             };
         }

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/examples/StrataProcedureCalls.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/examples/StrataProcedureCalls.java
@@ -9,7 +9,6 @@ import static com.aws.jverify.verifier.Backend.Strata;
 class StrataProcedureCalls {
     static int addOne(int x) {
         precondition(x > 0);
-//                   ^^^^^ Error: assertion does not hold
         // Overflow guard: x + 1 must fit in int32
         precondition(x < 2147483647);
         return x + 1;
@@ -20,8 +19,7 @@ class StrataProcedureCalls {
     }
 
     static void invalidCall() {
-        // Triggers precondition violation, but Strata reports the error
-        // at the precondition definition, not at this call site.
         int r = addOne(0);
+//      ^^^^^^^^^^^^^^^^^^ Error: precondition does not hold
     }
 }


### PR DESCRIPTION
Bump the Strata submodule from f6c306c3 to 71977b32 (latest main) and regenerate Laurel Java classes.

Notable Strata changes included:
- strata-org/Strata#764 — sanitize SMT-LIB filenames (replaces problematic chars like `?`, parens, spaces with underscores)
- Refactored CLI verify options into shared `verifyOptionsFlags`/`parseVerifyOptions`
- Various other improvements (see 120 files changed in regenerated classes)