### PR TITLE
Drop Strata prefix from example test class names

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
       "label": "verify",
       "type": "shell",
       "command": "${workspaceFolder}/verifier/build/install/verifier/bin/verifier",
-      "args": ["--print-dafny=${workspaceFolder}/build/temp.dfy", "--show-ranges", "--paths", "${file}", "--verifier", "${workspaceFolder}/dafny/Scripts/dafny"],
+      "args": ["--show-ranges", "--paths", "${file}"],
       "problemMatcher": {
         "owner": "jverify",
         "fileLocation": ["relative", "${workspaceFolder}"],

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/examples/Basic.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/examples/Basic.java
@@ -5,7 +5,7 @@ import com.aws.jverify.testengine.JVerifyTest;
 import static com.aws.jverify.JVerify.*;
 
 @JVerifyTest(exitCode = 4, errorCount = 2)
-class StrataBasic {
+class Basic {
     static void arithmetic() {
         int x = 5;
         int y = x * 2 - 3;

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/examples/BoundedInts.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/examples/BoundedInts.java
@@ -5,7 +5,7 @@ import com.aws.jverify.testengine.JVerifyTest;
 import static com.aws.jverify.JVerify.*;
 
 @JVerifyTest(exitCode = 0)
-class StrataBoundedInts {
+class BoundedInts {
     static int addBounded(int x, int y) {
         precondition(0 <= x && x <= 2000000000);
         precondition(0 <= y && y <= 147483647);

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/examples/DivMod.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/examples/DivMod.java
@@ -5,7 +5,7 @@ import com.aws.jverify.testengine.JVerifyTest;
 import static com.aws.jverify.JVerify.*;
 
 @JVerifyTest(exitCode = 0)
-class StrataDivMod {
+class DivMod {
     static void truncationDivision() {
         check(-7 / 2 == -3);
         check(-7 % 2 == -1);

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/examples/ForLoop.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/examples/ForLoop.java
@@ -5,7 +5,7 @@ import com.aws.jverify.testengine.JVerifyTest;
 import static com.aws.jverify.JVerify.*;
 
 @JVerifyTest(exitCode = 0)
-class StrataForLoop {
+class ForLoop {
     static void simpleFor() {
         int sum = 0;
         for (int i = 0; i < 3; i = i + 1) {

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/examples/PostconditionFailure.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/examples/PostconditionFailure.java
@@ -5,7 +5,7 @@ import com.aws.jverify.testengine.JVerifyTest;
 import static com.aws.jverify.JVerify.*;
 
 @JVerifyTest(exitCode = 4, errorCount = 1)
-class StrataPostconditionFailure {
+class PostconditionFailure {
     static int alwaysZero(int x) {
         postcondition((int res) -> res > 0);
 //                                 ^^^^^^^ Error: assertion does not hold

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/examples/Postconditions.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/examples/Postconditions.java
@@ -5,7 +5,7 @@ import com.aws.jverify.testengine.JVerifyTest;
 import static com.aws.jverify.JVerify.*;
 
 @JVerifyTest(exitCode = 0)
-class StrataPostconditions {
+class Postconditions {
     static int addOne(int x) {
         precondition(0 <= x && x < 2147483647);
         postcondition((int res) -> res == x + 1);

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/examples/ProcedureCalls.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/examples/ProcedureCalls.java
@@ -5,7 +5,7 @@ import com.aws.jverify.testengine.JVerifyTest;
 import static com.aws.jverify.JVerify.*;
 
 @JVerifyTest(exitCode = 4, errorCount = 1)
-class StrataProcedureCalls {
+class ProcedureCalls {
     static int addOne(int x) {
         precondition(x > 0);
         // Overflow guard: x + 1 must fit in int32

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/examples/PureFunction.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/examples/PureFunction.java
@@ -8,7 +8,7 @@ import static com.aws.jverify.JVerify.*;
 // @Pure with int return type is not yet supported in Strata (constrained return types on functions).
 // Testing with boolean return type only.
 @JVerifyTest(exitCode = 0)
-class StrataPureFunction {
+class PureFunction {
     @Pure
     static boolean isPositive(boolean x) {
         return x;

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/examples/Quantifiers.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/examples/Quantifiers.java
@@ -5,7 +5,7 @@ import com.aws.jverify.testengine.JVerifyTest;
 import static com.aws.jverify.JVerify.*;
 
 @JVerifyTest(exitCode = 0)
-class StrataQuantifiers {
+class Quantifiers {
     static void universalQuantifier() {
         check(forall((int x) -> implies(x > 0, x >= 1)));
     }

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/examples/ShortCircuit.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/examples/ShortCircuit.java
@@ -5,7 +5,7 @@ import com.aws.jverify.testengine.JVerifyTest;
 import static com.aws.jverify.JVerify.*;
 
 @JVerifyTest(exitCode = 0)
-class StrataShortCircuit {
+class ShortCircuit {
     // Short-circuit ||: y == 0 prevents evaluation of x / y
     static void orElseGuardsDivision(int x, int y) {
         check(y == 0 || x / y == x / y);

--- a/verifier/src/test/java/com/aws/jverify/verifier/tests/examples/WhileLoop.java
+++ b/verifier/src/test/java/com/aws/jverify/verifier/tests/examples/WhileLoop.java
@@ -5,7 +5,7 @@ import com.aws.jverify.testengine.JVerifyTest;
 import static com.aws.jverify.JVerify.*;
 
 @JVerifyTest(exitCode = 0)
-class StrataWhileLoop {
+class WhileLoop {
     static void countDown() {
         int i = 3;
         while (i > 0) {


### PR DESCRIPTION
Now that Strata is the only backend, the `Strata` prefix on these test files is redundant.

## Changes
- Renamed 11 test files in `verifier/src/test/.../tests/examples/` (`StrataBasic` → `Basic`, etc.)
- Updated class names to match
- Fixed `.vscode/tasks.json` — removed `--print-dafny` and `--verifier ./dafny/Scripts/dafny` (both reference the deleted Dafny backend)

## Testing
- `./gradlew test` passes locally