### PR TITLE
Bump Strata submodule to latest main

### DIFF
--- a/verifier/src/main/java/org/strata/jverify/laurel/AssignTarget.java
+++ b/verifier/src/main/java/org/strata/jverify/laurel/AssignTarget.java
@@ -1,0 +1,50 @@
+package org.strata.jverify.laurel;
+
+public sealed interface AssignTarget extends Node permits AssignTarget.AssignTargetDecl, AssignTarget.AssignTargetVar, AssignTarget.AssignTargetField {
+    public record AssignTargetDecl(
+        SourceRange sourceRange,
+        java.lang.String name, LaurelType targetType
+    ) implements AssignTarget {
+        @Override
+        public java.lang.String operationName() { return "Laurel.assignTargetDecl"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.assignTargetDecl", sourceRange());
+            sexp.add($s.serializeIdent(name()));
+            sexp.add($s.serialize(targetType()));
+            return sexp;
+        }
+    }
+
+    public record AssignTargetVar(
+        SourceRange sourceRange,
+        java.lang.String name
+    ) implements AssignTarget {
+        @Override
+        public java.lang.String operationName() { return "Laurel.assignTargetVar"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.assignTargetVar", sourceRange());
+            sexp.add($s.serializeIdent(name()));
+            return sexp;
+        }
+    }
+
+    public record AssignTargetField(
+        SourceRange sourceRange,
+        java.lang.String obj, java.lang.String field
+    ) implements AssignTarget {
+        @Override
+        public java.lang.String operationName() { return "Laurel.assignTargetField"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.assignTargetField", sourceRange());
+            sexp.add($s.serializeIdent(obj()));
+            sexp.add($s.serializeIdent(field()));
+            return sexp;
+        }
+    }
+}

--- a/verifier/src/main/java/org/strata/jverify/laurel/Laurel.java
+++ b/verifier/src/main/java/org/strata/jverify/laurel/Laurel.java
@@ -73,6 +73,18 @@ public class Laurel {
     public static StmtExpr assign(SourceRange sourceRange, StmtExpr target, StmtExpr value) { return new StmtExpr.Assign(sourceRange, target, value); }
     public static StmtExpr assign(StmtExpr target, StmtExpr value) { return new StmtExpr.Assign(SourceRange.NONE, target, value); }
 
+    public static AssignTarget assignTargetDecl(SourceRange sourceRange, java.lang.String name, LaurelType targetType) { return new AssignTarget.AssignTargetDecl(sourceRange, name, targetType); }
+    public static AssignTarget assignTargetDecl(java.lang.String name, LaurelType targetType) { return new AssignTarget.AssignTargetDecl(SourceRange.NONE, name, targetType); }
+
+    public static AssignTarget assignTargetVar(SourceRange sourceRange, java.lang.String name) { return new AssignTarget.AssignTargetVar(sourceRange, name); }
+    public static AssignTarget assignTargetVar(java.lang.String name) { return new AssignTarget.AssignTargetVar(SourceRange.NONE, name); }
+
+    public static AssignTarget assignTargetField(SourceRange sourceRange, java.lang.String obj, java.lang.String field) { return new AssignTarget.AssignTargetField(sourceRange, obj, field); }
+    public static AssignTarget assignTargetField(java.lang.String obj, java.lang.String field) { return new AssignTarget.AssignTargetField(SourceRange.NONE, obj, field); }
+
+    public static StmtExpr multiAssign(SourceRange sourceRange, java.util.List<AssignTarget> targets, StmtExpr value) { return new StmtExpr.MultiAssign(sourceRange, targets, value); }
+    public static StmtExpr multiAssign(java.util.List<AssignTarget> targets, StmtExpr value) { return new StmtExpr.MultiAssign(SourceRange.NONE, targets, value); }
+
     public static StmtExpr add(SourceRange sourceRange, StmtExpr lhs, StmtExpr rhs) { return new StmtExpr.Add(sourceRange, lhs, rhs); }
     public static StmtExpr add(StmtExpr lhs, StmtExpr rhs) { return new StmtExpr.Add(SourceRange.NONE, lhs, rhs); }
 
@@ -226,11 +238,17 @@ public class Laurel {
     public static EnsuresClause ensuresClause(SourceRange sourceRange, StmtExpr cond, java.util.Optional<ErrorSummary> errorMessage) { return new EnsuresClause.Of(sourceRange, cond, errorMessage); }
     public static EnsuresClause ensuresClause(StmtExpr cond, java.util.Optional<ErrorSummary> errorMessage) { return new EnsuresClause.Of(SourceRange.NONE, cond, errorMessage); }
 
-    public static ModifiesClause modifiesClause(SourceRange sourceRange, java.util.List<StmtExpr> refs) { return new ModifiesClause.Of(sourceRange, refs); }
-    public static ModifiesClause modifiesClause(java.util.List<StmtExpr> refs) { return new ModifiesClause.Of(SourceRange.NONE, refs); }
+    public static ModifiesClause modifiesClause(SourceRange sourceRange, java.util.List<StmtExpr> refs) { return new ModifiesClause.ModifiesClause_(sourceRange, refs); }
+    public static ModifiesClause modifiesClause(java.util.List<StmtExpr> refs) { return new ModifiesClause.ModifiesClause_(SourceRange.NONE, refs); }
+
+    public static ModifiesClause modifiesWildcard(SourceRange sourceRange) { return new ModifiesClause.ModifiesWildcard(sourceRange); }
+    public static ModifiesClause modifiesWildcard() { return new ModifiesClause.ModifiesWildcard(SourceRange.NONE); }
 
     public static ReturnParameters returnParameters(SourceRange sourceRange, java.util.List<Parameter> parameters) { return new ReturnParameters.Of(sourceRange, parameters); }
     public static ReturnParameters returnParameters(java.util.List<Parameter> parameters) { return new ReturnParameters.Of(SourceRange.NONE, parameters); }
+
+    public static OpaqueSpec opaqueSpec(SourceRange sourceRange, java.util.List<EnsuresClause> ensures, java.util.List<ModifiesClause> modifies) { return new OpaqueSpec.Of(sourceRange, ensures, modifies); }
+    public static OpaqueSpec opaqueSpec(java.util.List<EnsuresClause> ensures, java.util.List<ModifiesClause> modifies) { return new OpaqueSpec.Of(SourceRange.NONE, ensures, modifies); }
 
     public static Body body(SourceRange sourceRange, StmtExpr body) { return new Body.Body_(sourceRange, body); }
     public static Body body(StmtExpr body) { return new Body.Body_(SourceRange.NONE, body); }
@@ -238,11 +256,11 @@ public class Laurel {
     public static Body externalBody(SourceRange sourceRange) { return new Body.ExternalBody(sourceRange); }
     public static Body externalBody() { return new Body.ExternalBody(SourceRange.NONE); }
 
-    public static Procedure procedure(SourceRange sourceRange, java.lang.String name, java.util.List<Parameter> parameters, java.util.Optional<ReturnType> returnType, java.util.Optional<ReturnParameters> returnParameters, java.util.List<RequiresClause> requires, java.util.Optional<InvokeOnClause> invokeOn, java.util.List<EnsuresClause> ensures, java.util.List<ModifiesClause> modifies, java.util.Optional<Body> body) { return new Procedure.Procedure_(sourceRange, name, parameters, returnType, returnParameters, requires, invokeOn, ensures, modifies, body); }
-    public static Procedure procedure(java.lang.String name, java.util.List<Parameter> parameters, java.util.Optional<ReturnType> returnType, java.util.Optional<ReturnParameters> returnParameters, java.util.List<RequiresClause> requires, java.util.Optional<InvokeOnClause> invokeOn, java.util.List<EnsuresClause> ensures, java.util.List<ModifiesClause> modifies, java.util.Optional<Body> body) { return new Procedure.Procedure_(SourceRange.NONE, name, parameters, returnType, returnParameters, requires, invokeOn, ensures, modifies, body); }
+    public static Procedure procedure(SourceRange sourceRange, java.lang.String name, java.util.List<Parameter> parameters, java.util.Optional<ReturnType> returnType, java.util.Optional<ReturnParameters> returnParameters, java.util.List<RequiresClause> requires, java.util.Optional<InvokeOnClause> invokeOn, java.util.Optional<OpaqueSpec> opaqueSpec, java.util.Optional<Body> body) { return new Procedure.Procedure_(sourceRange, name, parameters, returnType, returnParameters, requires, invokeOn, opaqueSpec, body); }
+    public static Procedure procedure(java.lang.String name, java.util.List<Parameter> parameters, java.util.Optional<ReturnType> returnType, java.util.Optional<ReturnParameters> returnParameters, java.util.List<RequiresClause> requires, java.util.Optional<InvokeOnClause> invokeOn, java.util.Optional<OpaqueSpec> opaqueSpec, java.util.Optional<Body> body) { return new Procedure.Procedure_(SourceRange.NONE, name, parameters, returnType, returnParameters, requires, invokeOn, opaqueSpec, body); }
 
-    public static Procedure function(SourceRange sourceRange, java.lang.String name, java.util.List<Parameter> parameters, java.util.Optional<ReturnType> returnType, java.util.Optional<ReturnParameters> returnParameters, java.util.List<RequiresClause> requires, java.util.Optional<InvokeOnClause> invokeOn, java.util.List<EnsuresClause> ensures, java.util.List<ModifiesClause> modifies, java.util.Optional<Body> body) { return new Procedure.Function(sourceRange, name, parameters, returnType, returnParameters, requires, invokeOn, ensures, modifies, body); }
-    public static Procedure function(java.lang.String name, java.util.List<Parameter> parameters, java.util.Optional<ReturnType> returnType, java.util.Optional<ReturnParameters> returnParameters, java.util.List<RequiresClause> requires, java.util.Optional<InvokeOnClause> invokeOn, java.util.List<EnsuresClause> ensures, java.util.List<ModifiesClause> modifies, java.util.Optional<Body> body) { return new Procedure.Function(SourceRange.NONE, name, parameters, returnType, returnParameters, requires, invokeOn, ensures, modifies, body); }
+    public static Procedure function(SourceRange sourceRange, java.lang.String name, java.util.List<Parameter> parameters, java.util.Optional<ReturnType> returnType, java.util.Optional<ReturnParameters> returnParameters, java.util.List<RequiresClause> requires, java.util.Optional<InvokeOnClause> invokeOn, java.util.Optional<OpaqueSpec> opaqueSpec, java.util.Optional<Body> body) { return new Procedure.Function(sourceRange, name, parameters, returnType, returnParameters, requires, invokeOn, opaqueSpec, body); }
+    public static Procedure function(java.lang.String name, java.util.List<Parameter> parameters, java.util.Optional<ReturnType> returnType, java.util.Optional<ReturnParameters> returnParameters, java.util.List<RequiresClause> requires, java.util.Optional<InvokeOnClause> invokeOn, java.util.Optional<OpaqueSpec> opaqueSpec, java.util.Optional<Body> body) { return new Procedure.Function(SourceRange.NONE, name, parameters, returnType, returnParameters, requires, invokeOn, opaqueSpec, body); }
 
     public static Composite composite(SourceRange sourceRange, java.lang.String name, java.util.Optional<Extends> extending, java.util.List<Field> fields, java.util.List<Procedure> procedures) { return new Composite.Of(sourceRange, name, extending, fields, procedures); }
     public static Composite composite(java.lang.String name, java.util.Optional<Extends> extending, java.util.List<Field> fields, java.util.List<Procedure> procedures) { return new Composite.Of(SourceRange.NONE, name, extending, fields, procedures); }

--- a/verifier/src/main/java/org/strata/jverify/laurel/ModifiesClause.java
+++ b/verifier/src/main/java/org/strata/jverify/laurel/ModifiesClause.java
@@ -1,7 +1,7 @@
 package org.strata.jverify.laurel;
 
-public sealed interface ModifiesClause extends Node permits ModifiesClause.Of {
-    public record Of(
+public sealed interface ModifiesClause extends Node permits ModifiesClause.ModifiesClause_, ModifiesClause.ModifiesWildcard {
+    public record ModifiesClause_(
         SourceRange sourceRange,
         java.util.List<StmtExpr> refs
     ) implements ModifiesClause {
@@ -12,6 +12,19 @@ public sealed interface ModifiesClause extends Node permits ModifiesClause.Of {
         public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
             var sexp = $s.newOp("Laurel.modifiesClause", sourceRange());
             sexp.add($s.serializeSeq(refs(), "commaSepList", $s::serialize));
+            return sexp;
+        }
+    }
+
+    public record ModifiesWildcard(
+        SourceRange sourceRange
+    ) implements ModifiesClause {
+        @Override
+        public java.lang.String operationName() { return "Laurel.modifiesWildcard"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.modifiesWildcard", sourceRange());
             return sexp;
         }
     }

--- a/verifier/src/main/java/org/strata/jverify/laurel/Node.java
+++ b/verifier/src/main/java/org/strata/jverify/laurel/Node.java
@@ -2,7 +2,7 @@ package org.strata.jverify.laurel;
 
 import com.amazon.ion.IonSexp;
 
-public sealed interface Node permits Parameter, ReturnType, ConstrainedType, Procedure, Composite, Datatype, DatatypeConstructorList, DatatypeConstructorArg, ElseBranch, Body, Extends, InvariantClause, Trigger, Initializer, Field, StmtExpr, Command, LaurelType, ErrorSummary, DatatypeConstructor, InvokeOnClause, RequiresClause, ReturnParameters, TypeAnnotation, ModifiesClause, EnsuresClause {
+public sealed interface Node permits Parameter, AssignTarget, ReturnType, ConstrainedType, Composite, Procedure, Datatype, DatatypeConstructorList, DatatypeConstructorArg, ElseBranch, OpaqueSpec, Body, Extends, InvariantClause, Trigger, Initializer, Field, StmtExpr, Command, LaurelType, ErrorSummary, DatatypeConstructor, InvokeOnClause, RequiresClause, ReturnParameters, TypeAnnotation, ModifiesClause, EnsuresClause {
     SourceRange sourceRange();
     java.lang.String operationName();
     IonSexp toIon(IonSerializer $s);

--- a/verifier/src/main/java/org/strata/jverify/laurel/OpaqueSpec.java
+++ b/verifier/src/main/java/org/strata/jverify/laurel/OpaqueSpec.java
@@ -1,0 +1,19 @@
+package org.strata.jverify.laurel;
+
+public sealed interface OpaqueSpec extends Node permits OpaqueSpec.Of {
+    public record Of(
+        SourceRange sourceRange,
+        java.util.List<EnsuresClause> ensures, java.util.List<ModifiesClause> modifies
+    ) implements OpaqueSpec {
+        @Override
+        public java.lang.String operationName() { return "Laurel.opaqueSpec"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.opaqueSpec", sourceRange());
+            sexp.add($s.serializeSeq(ensures(), "seq", $s::serialize));
+            sexp.add($s.serializeSeq(modifies(), "seq", $s::serialize));
+            return sexp;
+        }
+    }
+}

--- a/verifier/src/main/java/org/strata/jverify/laurel/Procedure.java
+++ b/verifier/src/main/java/org/strata/jverify/laurel/Procedure.java
@@ -3,7 +3,7 @@ package org.strata.jverify.laurel;
 public sealed interface Procedure extends Node permits Procedure.Procedure_, Procedure.Function {
     public record Procedure_(
         SourceRange sourceRange,
-        java.lang.String name, java.util.List<Parameter> parameters, java.util.Optional<ReturnType> returnType, java.util.Optional<ReturnParameters> returnParameters, java.util.List<RequiresClause> requires, java.util.Optional<InvokeOnClause> invokeOn, java.util.List<EnsuresClause> ensures, java.util.List<ModifiesClause> modifies, java.util.Optional<Body> body
+        java.lang.String name, java.util.List<Parameter> parameters, java.util.Optional<ReturnType> returnType, java.util.Optional<ReturnParameters> returnParameters, java.util.List<RequiresClause> requires, java.util.Optional<InvokeOnClause> invokeOn, java.util.Optional<OpaqueSpec> opaqueSpec, java.util.Optional<Body> body
     ) implements Procedure {
         @Override
         public java.lang.String operationName() { return "Laurel.procedure"; }
@@ -17,8 +17,7 @@ public sealed interface Procedure extends Node permits Procedure.Procedure_, Pro
             sexp.add($s.serializeOption(returnParameters(), $s::serialize));
             sexp.add($s.serializeSeq(requires(), "seq", $s::serialize));
             sexp.add($s.serializeOption(invokeOn(), $s::serialize));
-            sexp.add($s.serializeSeq(ensures(), "seq", $s::serialize));
-            sexp.add($s.serializeSeq(modifies(), "seq", $s::serialize));
+            sexp.add($s.serializeOption(opaqueSpec(), $s::serialize));
             sexp.add($s.serializeOption(body(), $s::serialize));
             return sexp;
         }
@@ -26,7 +25,7 @@ public sealed interface Procedure extends Node permits Procedure.Procedure_, Pro
 
     public record Function(
         SourceRange sourceRange,
-        java.lang.String name, java.util.List<Parameter> parameters, java.util.Optional<ReturnType> returnType, java.util.Optional<ReturnParameters> returnParameters, java.util.List<RequiresClause> requires, java.util.Optional<InvokeOnClause> invokeOn, java.util.List<EnsuresClause> ensures, java.util.List<ModifiesClause> modifies, java.util.Optional<Body> body
+        java.lang.String name, java.util.List<Parameter> parameters, java.util.Optional<ReturnType> returnType, java.util.Optional<ReturnParameters> returnParameters, java.util.List<RequiresClause> requires, java.util.Optional<InvokeOnClause> invokeOn, java.util.Optional<OpaqueSpec> opaqueSpec, java.util.Optional<Body> body
     ) implements Procedure {
         @Override
         public java.lang.String operationName() { return "Laurel.function"; }
@@ -40,8 +39,7 @@ public sealed interface Procedure extends Node permits Procedure.Procedure_, Pro
             sexp.add($s.serializeOption(returnParameters(), $s::serialize));
             sexp.add($s.serializeSeq(requires(), "seq", $s::serialize));
             sexp.add($s.serializeOption(invokeOn(), $s::serialize));
-            sexp.add($s.serializeSeq(ensures(), "seq", $s::serialize));
-            sexp.add($s.serializeSeq(modifies(), "seq", $s::serialize));
+            sexp.add($s.serializeOption(opaqueSpec(), $s::serialize));
             sexp.add($s.serializeOption(body(), $s::serialize));
             return sexp;
         }

--- a/verifier/src/main/java/org/strata/jverify/laurel/StmtExpr.java
+++ b/verifier/src/main/java/org/strata/jverify/laurel/StmtExpr.java
@@ -1,6 +1,6 @@
 package org.strata.jverify.laurel;
 
-public sealed interface StmtExpr extends Node permits StmtExpr.LiteralBool, StmtExpr.Int, StmtExpr.Real, StmtExpr.String_, StmtExpr.Hole, StmtExpr.NondetHole, StmtExpr.VarDecl, StmtExpr.Call, StmtExpr.New, StmtExpr.FieldAccess, StmtExpr.Identifier, StmtExpr.Parenthesis, StmtExpr.Assign, StmtExpr.Add, StmtExpr.Sub, StmtExpr.Mul, StmtExpr.Div, StmtExpr.Mod, StmtExpr.DivT, StmtExpr.ModT, StmtExpr.Eq, StmtExpr.Neq, StmtExpr.Gt, StmtExpr.Lt, StmtExpr.Le, StmtExpr.Ge, StmtExpr.And, StmtExpr.Or, StmtExpr.AndThen, StmtExpr.OrElse, StmtExpr.Implies, StmtExpr.StrConcat, StmtExpr.Not, StmtExpr.Neg, StmtExpr.ForallExpr, StmtExpr.ExistsExpr, StmtExpr.IfThenElse, StmtExpr.Assert, StmtExpr.Assume, StmtExpr.Return, StmtExpr.Block, StmtExpr.LabelledBlock, StmtExpr.Exit, StmtExpr.While, StmtExpr.ForLoop, StmtExpr.IsType, StmtExpr.AsType {
+public sealed interface StmtExpr extends Node permits StmtExpr.LiteralBool, StmtExpr.Int, StmtExpr.Real, StmtExpr.String_, StmtExpr.Hole, StmtExpr.NondetHole, StmtExpr.VarDecl, StmtExpr.Call, StmtExpr.New, StmtExpr.FieldAccess, StmtExpr.Identifier, StmtExpr.Parenthesis, StmtExpr.Assign, StmtExpr.MultiAssign, StmtExpr.Add, StmtExpr.Sub, StmtExpr.Mul, StmtExpr.Div, StmtExpr.Mod, StmtExpr.DivT, StmtExpr.ModT, StmtExpr.Eq, StmtExpr.Neq, StmtExpr.Gt, StmtExpr.Lt, StmtExpr.Le, StmtExpr.Ge, StmtExpr.And, StmtExpr.Or, StmtExpr.AndThen, StmtExpr.OrElse, StmtExpr.Implies, StmtExpr.StrConcat, StmtExpr.Not, StmtExpr.Neg, StmtExpr.ForallExpr, StmtExpr.ExistsExpr, StmtExpr.IfThenElse, StmtExpr.Assert, StmtExpr.Assume, StmtExpr.Return, StmtExpr.Block, StmtExpr.LabelledBlock, StmtExpr.Exit, StmtExpr.While, StmtExpr.ForLoop, StmtExpr.IsType, StmtExpr.AsType {
     public record LiteralBool(
         SourceRange sourceRange,
         boolean b
@@ -192,6 +192,22 @@ public sealed interface StmtExpr extends Node permits StmtExpr.LiteralBool, Stmt
         public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
             var sexp = $s.newOp("Laurel.assign", sourceRange());
             sexp.add($s.serialize(target()));
+            sexp.add($s.serialize(value()));
+            return sexp;
+        }
+    }
+
+    public record MultiAssign(
+        SourceRange sourceRange,
+        java.util.List<AssignTarget> targets, StmtExpr value
+    ) implements StmtExpr {
+        @Override
+        public java.lang.String operationName() { return "Laurel.multiAssign"; }
+
+        @Override
+        public com.amazon.ion.IonSexp toIon(IonSerializer $s) {
+            var sexp = $s.newOp("Laurel.multiAssign", sourceRange());
+            sexp.add($s.serializeSeq(targets(), "commaSepList", $s::serialize));
             sexp.add($s.serialize(value()));
             return sexp;
         }

--- a/verifier/src/main/java/org/strata/jverify/verifier/compiler/generator/laurel/JavaToLaurelCompiler.java
+++ b/verifier/src/main/java/org/strata/jverify/verifier/compiler/generator/laurel/JavaToLaurelCompiler.java
@@ -180,11 +180,21 @@ public class JavaToLaurelCompiler {
                         : Optional.empty();
 
                 boolean isPure = jverifyUtils.isPure(method.sym);
+                // Strata rejects transparent (visible-body) procedures unless they're functional;
+                // emit an OpaqueSpec to mark the body opaque otherwise. Pure functions stay
+                // transparent only when they have no ensures clauses (the schema can't carry
+                // ensures without an OpaqueSpec wrapper).
+                // modifies is always empty: jverify doesn't yet emit modifies clauses.
+                boolean canStayTransparent = isPure && ensures.isEmpty();
+                Optional<OpaqueSpec> optSpec = canStayTransparent
+                        ? Optional.empty()
+                        : Optional.of(opaqueSpec(ensures, List.of()));
+
                 Procedure proc = isPure
                         ? function(toSourceRange(method), methodName, params,
-                                retType, Optional.empty(), requires, Optional.empty(), ensures, List.of(), optBody)
+                                retType, Optional.empty(), requires, Optional.empty(), optSpec, optBody)
                         : procedure(toSourceRange(method), methodName, params,
-                                retType, Optional.empty(), requires, Optional.empty(), ensures, List.of(), optBody);
+                                retType, Optional.empty(), requires, Optional.empty(), optSpec, optBody);
                 procedures.add(proc);
             }
             super.visitMethodDef(method);

--- a/verifier/src/main/java/org/strata/jverify/verifier/laurel/LaurelDriver.java
+++ b/verifier/src/main/java/org/strata/jverify/verifier/laurel/LaurelDriver.java
@@ -108,7 +108,7 @@ public class LaurelDriver implements Driver {
 
     public JVerifyResults runVerifier(FilesMap filesMap, IonValue serializedProgram) {
         var processBuilder = new ProcessBuilder(
-                "lake", "exe", "-q", "strata", "laurelAnalyzeBinary"
+                "lake", "exe", "-q", "strata", "laurelAnalyzeBinary", "--solver", "z3"
         );
         processBuilder.directory(verifierOptions.backendPath().toFile());
         return verifierOptions.time("Running Strata", () -> {


### PR DESCRIPTION
Bump the Strata submodule from `8593f7cf` to `53a3df53` (latest main) and regenerate Laurel Java classes. [Compare](https://github.com/strata-org/Strata/compare/8593f7cf...53a3df53) (101 commits).

## Schema-affecting Strata commits

These are the commits that touched the Laurel AST or grammar definitions and account for the regenerated-file diff:

- strata-org/Strata#1076 — disallow transparent procedures (procedures with visible bodies must now be `opaque`)
- strata-org/Strata#969 — add `opaque` keyword to Laurel grammar; `ensures` and `modifies` are now wrapped in an optional `OpaqueSpec`
- strata-org/Strata#1031 — add `modifies *` wildcard (new `ModifiesClause.ModifiesWildcard` variant; unused by this PR)
- strata-org/Strata#1077 — generalized multi-target assign (new `MultiAssign` + `AssignTarget` AST nodes; unused by this PR)
- strata-org/Strata#1140 — Provenance type / metadata migration

## Hand-written changes

- **`JavaToLaurelCompiler`**: emit an `OpaqueSpec` for impure procedures (always) and for pure functions with non-empty `ensures`. Pure functions with no ensures clauses stay transparent (resolver permits it; preserves definitional unfolding for callers).
- **`LaurelDriver`**: pass `--solver z3` explicitly when invoking Strata. The previous Strata hardcoded `solver := "z3"` for the Laurel verify path; the bumped Strata removed that override and now defaults to `cvc5`, which our CI doesn't install.

All other diffs in `verifier/src/main/java/org/strata/jverify/laurel/` are generated by `make generate-laurel-ast`.

## Behavioral note

Pure functions that declare `@Ensures` used to translate to a Laurel `Transparent` body and now translate to `Opaque` (forced by the schema — the wrapper carrying postconditions also flips the body kind).

Practical consequence: callers reason about such a function via its postcondition rather than by inlining its definition. This is sound but potentially less complete.

A grep of the test suite for files combining `@Pure` and `@Ensures` returned zero results, so this shift doesn't affect any existing test.

## Test plan
- [x] `make generate-laurel-ast` regenerates cleanly
- [x] `./gradlew build` passes
- [x] `./gradlew test` passes (full suite, locally with cvc5 absent)