### PR TITLE
Skip translator-rejected methods gracefully and support char primitive

### DIFF
--- a/verifier/src/main/java/org/strata/jverify/verifier/compiler/generator/laurel/JavaToLaurelCompiler.java
+++ b/verifier/src/main/java/org/strata/jverify/verifier/compiler/generator/laurel/JavaToLaurelCompiler.java
@@ -4,10 +4,12 @@ import org.strata.jverify.common.Position;
 import org.strata.jverify.laurel.*;
 import org.strata.jverify.verifier.VerifierOptions;
 import org.strata.jverify.verifier.compiler.JavaViolationException;
+import org.strata.jverify.verifier.compiler.Reporter;
 import org.strata.jverify.verifier.compiler.frontend.JavaLowerer;
 import org.strata.jverify.verifier.compiler.simplifications.JVerifyUtils;
 import org.strata.jverify.verifier.compiler.simplifications.MethodOrLoopContract;
 import org.strata.jverify.verifier.compiler.simplifications.MethodOrLoopContractCompiler;
+import org.strata.jverify.verifier.compiler.simplifications.VerifyAnnotationCompiler;
 import org.strata.jverify.verifier.laurel.FilesMap;
 import com.sun.tools.javac.code.Flags;
 import com.sun.tools.javac.code.Symbol;
@@ -27,12 +29,16 @@ public class JavaToLaurelCompiler {
     private final JavaLowerer lowerer;
     private final MethodOrLoopContractCompiler contractCompiler;
     private final JVerifyUtils jverifyUtils;
+    private final Reporter reporter;
+    private final VerifyAnnotationCompiler annotationCompiler;
     JCTree.JCCompilationUnit currentCompilationUnit;
 
     public JavaToLaurelCompiler(Context context) {
         lowerer = context.get(JavaLowerer.class);
         contractCompiler = MethodOrLoopContractCompiler.instance(context);
         jverifyUtils = JVerifyUtils.instance(context);
+        reporter = Reporter.instance(context);
+        annotationCompiler = VerifyAnnotationCompiler.instance(context);
     }
 
     public record AnalysisResult(List<LaurelFile> files, FilesMap filesMap) {}
@@ -48,6 +54,7 @@ public class JavaToLaurelCompiler {
                 continue;
             }
             currentCompilationUnit = compilationUnit;
+            reporter.compilationUnit = compilationUnit;
             var visitor = new StaticMethodCollector();
             compilationUnit.accept(visitor);
             List<Command> commands = new ArrayList<>();
@@ -90,7 +97,8 @@ public class JavaToLaurelCompiler {
             makeConstrainedType("int8", -128L, 127L),
             makeConstrainedType("int16", -32768L, 32767L),
             makeConstrainedType("int32", -2147483648L, 2147483647L),
-            makeConstrainedType("int64", -9223372036854775808L, 9223372036854775807L)
+            makeConstrainedType("int64", -9223372036854775808L, 9223372036854775807L),
+            makeConstrainedType("char", 0L, 65535L)
         );
     }
 
@@ -116,6 +124,7 @@ public class JavaToLaurelCompiler {
             case SHORT -> compositeType("int16");
             case BYTE -> compositeType("int8");
             case LONG -> compositeType("int64");
+            case CHAR -> compositeType("char");
             case BOOLEAN -> boolType();
             default -> throw new JavaViolationException("Unsupported type: " + type);
         };
@@ -131,77 +140,86 @@ public class JavaToLaurelCompiler {
         @Override
         public void visitMethodDef(JCTree.JCMethodDecl method) {
             if ((method.mods.flags & Flags.STATIC) != 0) {
-                // TODO: when overloaded methods are supported, disambiguate names
-                //  (e.g. by appending parameter type suffixes) to avoid duplicate procedure names in Laurel.
-                String methodName = qualifiedMethodName(method.sym);
-
-                List<Parameter> params = new ArrayList<>();
-                for (var param : method.params) {
-                    params.add(parameter(param.name.toString(), translateType(param.type)));
+                try {
+                    translateStaticMethod(method);
+                } catch (JavaViolationException e) {
+                    reporter.reportError(method, "translatorError", e.getMessage());
+                    annotationCompiler.markSkipped(currentCompilationUnit, method);
                 }
-
-                Optional<ReturnType> retType = Optional.empty();
-                if (method.restype != null && method.restype.type != null
-                        && method.restype.type.getTag() != TypeTag.VOID) {
-                    retType = Optional.of(returnType(translateType(method.restype.type)));
-                }
-
-                List<RequiresClause> requires = new ArrayList<>();
-                List<EnsuresClause> ensures = new ArrayList<>();
-                StmtExpr methodBody = null;
-
-                if (method.body != null) {
-                    MethodOrLoopContract contract = contractCompiler.getContract(method.body);
-                    for (var pre : contract.preconditions()) {
-                        requires.add(requiresClause(convertExpression(pre.get()), Optional.empty()));
-                    }
-                    for (var post : contract.postconditions()) {
-                        var postExpr = post.get();
-                        if (postExpr instanceof JCTree.JCLambda lambda && lambda.params.size() == 1) {
-                            var paramName = lambda.params.getFirst().name.toString();
-                            var renames = Map.of(paramName, "result");
-                            ensures.add(ensuresClause(convertLambdaBody(lambda, renames), Optional.empty()));
-                        } else {
-                            ensures.add(ensuresClause(convertExpression(postExpr), Optional.empty()));
-                        }
-                    }
-
-                    var implStatements = MethodOrLoopContractCompiler.getImplementationStatements(method.body);
-                    if (!implStatements.isEmpty()) {
-                        List<StmtExpr> stmts = new ArrayList<>();
-                        for (var statement : implStatements) {
-                            StmtExpr converted = convertStatement(statement);
-                            if (converted != null) {
-                                stmts.add(converted);
-                            }
-                        }
-                        methodBody = block(toSourceRange(method.body), stmts);
-                    }
-                }
-
-                Optional<Body> optBody = methodBody != null
-                        ? Optional.of(body(methodBody))
-                        : Optional.empty();
-
-                boolean isPure = jverifyUtils.isPure(method.sym);
-                // Strata rejects transparent (visible-body) procedures unless they're functional;
-                // emit an OpaqueSpec to mark the body opaque otherwise. Pure functions stay
-                // transparent only when they have no ensures clauses (the schema can't carry
-                // ensures without an OpaqueSpec wrapper).
-                // modifies is always empty: jverify doesn't yet emit modifies clauses.
-                boolean canStayTransparent = isPure && ensures.isEmpty();
-                Optional<OpaqueSpec> optSpec = canStayTransparent
-                        ? Optional.empty()
-                        : Optional.of(opaqueSpec(ensures, List.of()));
-
-                Procedure proc = isPure
-                        ? function(toSourceRange(method), methodName, params,
-                                retType, Optional.empty(), requires, Optional.empty(), optSpec, optBody)
-                        : procedure(toSourceRange(method), methodName, params,
-                                retType, Optional.empty(), requires, Optional.empty(), optSpec, optBody);
-                procedures.add(proc);
             }
             super.visitMethodDef(method);
+        }
+
+        private void translateStaticMethod(JCTree.JCMethodDecl method) {
+            // TODO: when overloaded methods are supported, disambiguate names
+            //  (e.g. by appending parameter type suffixes) to avoid duplicate procedure names in Laurel.
+            String methodName = qualifiedMethodName(method.sym);
+
+            List<Parameter> params = new ArrayList<>();
+            for (var param : method.params) {
+                params.add(parameter(param.name.toString(), translateType(param.type)));
+            }
+
+            Optional<ReturnType> retType = Optional.empty();
+            if (method.restype != null && method.restype.type != null
+                    && method.restype.type.getTag() != TypeTag.VOID) {
+                retType = Optional.of(returnType(translateType(method.restype.type)));
+            }
+
+            List<RequiresClause> requires = new ArrayList<>();
+            List<EnsuresClause> ensures = new ArrayList<>();
+            StmtExpr methodBody = null;
+
+            if (method.body != null) {
+                MethodOrLoopContract contract = contractCompiler.getContract(method.body);
+                for (var pre : contract.preconditions()) {
+                    requires.add(requiresClause(convertExpression(pre.get()), Optional.empty()));
+                }
+                for (var post : contract.postconditions()) {
+                    var postExpr = post.get();
+                    if (postExpr instanceof JCTree.JCLambda lambda && lambda.params.size() == 1) {
+                        var paramName = lambda.params.getFirst().name.toString();
+                        var renames = Map.of(paramName, "result");
+                        ensures.add(ensuresClause(convertLambdaBody(lambda, renames), Optional.empty()));
+                    } else {
+                        ensures.add(ensuresClause(convertExpression(postExpr), Optional.empty()));
+                    }
+                }
+
+                var implStatements = MethodOrLoopContractCompiler.getImplementationStatements(method.body);
+                if (!implStatements.isEmpty()) {
+                    List<StmtExpr> stmts = new ArrayList<>();
+                    for (var statement : implStatements) {
+                        StmtExpr converted = convertStatement(statement);
+                        if (converted != null) {
+                            stmts.add(converted);
+                        }
+                    }
+                    methodBody = block(toSourceRange(method.body), stmts);
+                }
+            }
+
+            Optional<Body> optBody = methodBody != null
+                    ? Optional.of(body(methodBody))
+                    : Optional.empty();
+
+            boolean isPure = jverifyUtils.isPure(method.sym);
+            // Strata rejects transparent (visible-body) procedures unless they're functional;
+            // emit an OpaqueSpec to mark the body opaque otherwise. Pure functions stay
+            // transparent only when they have no ensures clauses (the schema can't carry
+            // ensures without an OpaqueSpec wrapper).
+            // modifies is always empty: jverify doesn't yet emit modifies clauses.
+            boolean canStayTransparent = isPure && ensures.isEmpty();
+            Optional<OpaqueSpec> optSpec = canStayTransparent
+                    ? Optional.empty()
+                    : Optional.of(opaqueSpec(ensures, List.of()));
+
+            Procedure proc = isPure
+                    ? function(toSourceRange(method), methodName, params,
+                            retType, Optional.empty(), requires, Optional.empty(), optSpec, optBody)
+                    : procedure(toSourceRange(method), methodName, params,
+                            retType, Optional.empty(), requires, Optional.empty(), optSpec, optBody);
+            procedures.add(proc);
         }
 
         private StmtExpr convertBlock(JCTree.JCBlock blk) {
@@ -356,6 +374,7 @@ public class JavaToLaurelCompiler {
                     long val = ((Number) literal.value).longValue();
                     yield longLiteral(sr, val);
                 }
+                case CHAR -> longLiteral(sr, ((Number) literal.value).longValue());
                 default -> throw new JavaViolationException("Unsupported literal type: " + literal.typetag);
             };
         }

--- a/verifier/src/main/java/org/strata/jverify/verifier/compiler/simplifications/VerifyAnnotationCompiler.java
+++ b/verifier/src/main/java/org/strata/jverify/verifier/compiler/simplifications/VerifyAnnotationCompiler.java
@@ -239,4 +239,27 @@ public class VerifyAnnotationCompiler extends TreeScanner {
         return methodStatusPerUri;
     }
 
+    /**
+     * Demote a method's entry from Verified to Skipped. Called by
+     * JavaToLaurelCompiler when per-method translation throws
+     * JavaViolationException, so the driver doesn't report the method as
+     * Verified despite producing no Laurel output for it.
+     *
+     * No-op when the method has no entry (synthetic methods, methods without
+     * an implementation body — see addMethodToIntervalTree). Those are
+     * already invisible to the counting layer, so there is nothing to demote;
+     * adding an entry here would inflate the Skipped count instead.
+     */
+    public void markSkipped(JCTree.JCCompilationUnit compilationUnit, JCTree.JCMethodDecl methodDecl) {
+        var uriStatuses = methodStatusPerUri.get(compilationUnit.getSourceFile().toUri());
+        if (uriStatuses == null) {
+            return;
+        }
+        uriStatuses.streamNodes()
+                .map(node -> node.getValue())
+                .filter(status -> status.getMethodTree() == methodDecl)
+                .findFirst()
+                .ifPresent(status -> status.setVerificationStatus(JavaMethodVerificationStatus.VerificationStatus.Skipped));
+    }
+
 }

--- a/verifier/src/main/resources/org/strata/jverify/messages.properties
+++ b/verifier/src/main/resources/org/strata/jverify/messages.properties
@@ -3,6 +3,7 @@ compiler.err.pureMethodLastStatement=a pure block must end in a return or if-els
 compiler.err.pureMethodEndingIfThen=a pure block may not end in an if statement without an else block
 compiler.err.argumentMustBeLambda=the argument to a {0} call must be a lambda
 compiler.err.notSupported={0} is not supported
+compiler.err.translatorError={0}
 compiler.err.contractAfterBody=call to contract method must come before the rest of the body
 compiler.err.contractForConstructor=for constructors, calls to JVerify contract methods must come either immediately after the call to ''super'' or ''this'', or at the end of the body
 compiler.err.wrongContract={0} are not allowed in a {1}

--- a/verifier/src/test/java/org/strata/jverify/verifier/tests/javasupport/CharPrimitive.java
+++ b/verifier/src/test/java/org/strata/jverify/verifier/tests/javasupport/CharPrimitive.java
@@ -1,0 +1,22 @@
+package org.strata.jverify.verifier.tests.javasupport;
+
+import org.strata.jverify.testengine.JVerifyTest;
+
+import static org.strata.jverify.JVerify.check;
+
+/**
+ * Regression test for #414. Pairs the happy path (translateType +
+ * convertLiteral round-trip) with a negative case that fails when c == 65535,
+ * asserting the 0..65535 constraint is actually enforced rather than dropped.
+ */
+@JVerifyTest(exitCode = 4, methodsVerified = 2, errorCount = 1)
+class CharPrimitive {
+    static void roundTrip(char c) {
+        check(c == c);
+    }
+
+    static void rangeBoundsBad(char c) {
+        check(c <= 65534);
+//      ^^^^^^^^^^^^^^^^^ Error: assertion does not hold
+    }
+}

--- a/verifier/src/test/java/org/strata/jverify/verifier/tests/verification/TranslatorSkip.java
+++ b/verifier/src/test/java/org/strata/jverify/verifier/tests/verification/TranslatorSkip.java
@@ -1,0 +1,34 @@
+package org.strata.jverify.verifier.tests.verification;
+
+import org.strata.jverify.testengine.JVerifyTest;
+
+import static org.strata.jverify.JVerify.check;
+
+/**
+ * Regression test for #398. Asserts that a translator-rejected method
+ * produces a diagnostic, flips its status to Skipped, and leaves siblings
+ * verifiable. The trigger is the multi-init for refusal — if that form
+ * gains support, swap the trigger; the test covers the catch wrapper, not
+ * the construct.
+ */
+@JVerifyTest(
+        continueOnErrors = true,
+        exitCode = 0,
+        methodsVerified = 2,
+        methodsSkipped = 1,
+        errorCount = 0
+)
+class TranslatorSkip {
+    static int unsupported(int n) {
+//             ^ error: Multi-init or multi-step for loops are not supported
+        var sum = 0;
+        for (int i = 0, j = n; i < j; i++, j--) {
+            sum = sum + i;
+        }
+        return sum;
+    }
+
+    static void supported(int x) {
+        check(x == x);
+    }
+}


### PR DESCRIPTION
Step 1 of the JVerify completion plan (PLAN.md §3.1).

## Resolves

- #398 — graceful skip of unsupported methods (catch `JavaViolationException`)
- #414 — `char` primitive support

## Summary

- Wrap per-method translation in `JavaToLaurelCompiler.visitMethodDef` in a `try/catch` on `JavaViolationException`. On catch: emit a `translatorError` diagnostic and demote the method's `IntervalTree` entry from `Verified` to `Skipped`.
- The trailing `super.visitMethodDef` stays outside the catch so nested classes are still visited even when the parent method skipped.
- Catch scope is narrow — `JavaViolationException` only. Broader catches would mask translator bugs (NPEs, "Could not find line map for...") and `OOM`/`StackOverflow` from Strata recursion.
- Add `char` as a constrained int (`0..65535`, full UTF-16 range) registered alongside `int8`/`int16`/`int32`/`int64`.

## Why bundle char with #398

5-line type-plumbing tweak — too small for its own step. Mechanically aligned with the safety-net edits (both touch `translateType` / `convertLiteral`), and unblocks Step 2's `switchExprChar`/`switchExprCharBad` and Step 5's char-using methods in `PrimitiveTypes` without leaving them gated on a follow-up.

## Implementation notes

- `VerifyAnnotationCompiler.markSkipped(JCCompilationUnit, JCMethodDecl)` — new helper. Scans the URI's interval-tree by `methodTree == methodDecl` identity rather than recomputing line position, so it doesn't depend on `PositionCalculator` semantics matching `addMethodToIntervalTree` exactly. No-op when the method has no entry (synthetic methods, methods without an implementation body) — those are already invisible to the counting layer.
- Strata has no `char`/`char16` prelude type (verified via grep of `Strata/Languages/Laurel/`); inlining as a constrained int is the only path. Dafny used a named `char16` type — a forced divergence.
- `translatorError` (new `messages.properties` key) instead of `notSupported`. `JavaViolationException`'s javadoc states "Indicates a JVerify compiler bug" — so it's a translator gap surfaced to the user, not a clean refusal of an explicitly-unsupported feature. Future Step 6 throws → `reportError` migrations will use `notSupported` for the genuine "user feature not supported" cases.

## Test plan

- [x] `./gradlew :verifier:test` passes — 113 tests / 0 failed / 72 skipped.
- [x] No new uncaught `JavaViolationException` stack traces in test output.
- [x] No test transitions green → red.
- [x] `TranslatorSkip.java` covers the catch wrapper end-to-end. Asserts three properties simultaneously: (1) sibling translation continues past a throwing method, (2) the translator-level error reaches the driver as a diagnostic, (3) the throwing method's status flips `Verified → Skipped` (the silent-overcount bug §3.1 calls out). Trigger is the multi-init `for` refusal at `convertStatement`, chosen for stability — the plan refuses this form rather than supporting it.
- [x] `CharPrimitive.java` is the regression test for #414. Pairs the happy path (`translateType` + `convertLiteral` round-trip) with `rangeBoundsBad` that fails when `c == 65535` to assert the `0..65535` constraint is actually enforced rather than dropped.