### PR TITLE
Lower switches to if/conditional chains in a new SwitchDesugarer phase

### DIFF
--- a/verifier/src/main/java/org/strata/jverify/verifier/compiler/frontend/JavaLowerer.java
+++ b/verifier/src/main/java/org/strata/jverify/verifier/compiler/frontend/JavaLowerer.java
@@ -240,6 +240,7 @@ public class JavaLowerer {
                     phases.add(new MissingContractCompiler(context)::transform);
                     phases.add(new IsAbstractCompiler(context)::transform);
                     phases.add(new PreconditionOfCompiler(context)::transform);
+                    phases.add(new SwitchDesugarer(context)::transform);
                     phases.add(us -> unsuspend(lower(suspend(us))));
                     phases.add(new ArrayCompiler(context)::transform);
                     phases.add(new MoveStaticMethodsToStaticType(context)::translate);

--- a/verifier/src/main/java/org/strata/jverify/verifier/compiler/frontend/Suspenders.java
+++ b/verifier/src/main/java/org/strata/jverify/verifier/compiler/frontend/Suspenders.java
@@ -1,40 +1,36 @@
 package org.strata.jverify.verifier.compiler.frontend;
 
-import com.sun.source.tree.CaseTree;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symtab;
-import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.TreeMaker;
 import com.sun.tools.javac.tree.TreeTranslator;
 import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.List;
-import com.sun.tools.javac.util.Log;
 import com.sun.tools.javac.util.Name;
 import com.sun.tools.javac.util.Names;
 
 import java.util.HashSet;
-import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import static com.sun.tools.javac.code.Flags.RECORD;
 
 
 ///
-/// A reversible rewriting phase that prevents features like
-/// records and switch statements/expressions from being lowered by the LOWER phase.
-/// (get it? :)
+/// A reversible rewriting phase that prevents features from being lowered
+/// by the LOWER phase. (get it? :)
 ///
-/// Currently, it applies two different transformations to avoid undesirable lowerings:
+/// Currently, it applies two symmetric transformations to defend tree
+/// shapes LOWER would otherwise mutate:
 ///
-///   - Records are translated into normal classes with extra synthetic declarations.
-///     To avoid this we remove the RECORD flag on records and then restore it afterwards.
-///   - Switches with case rules (which we do support) are rewritten into case statements (which we don't).
-///     To avoid this we rewrite switches into equivalent chained if statements or ?: conditionals,
-///     and then reverse it afterwards.
-///     This ensures all the content of the switches is still in scope for lowering.
-///     See `switchToIf` and `switchExpressionToConditional` for details on the encoding.
+///   - Records: RECORD flag is removed before LOWER and restored after.
+///     Without this LOWER would translate records into ordinary classes
+///     with synthetic accessors etc., losing record-ness for downstream phases.
+///   - Asserts: rewritten as `if ($assertMarker) { cond; }` before LOWER and
+///     restored after. Without this LOWER would convert `assert` to `throw`.
+///
+/// One-way pre-LOWER transformations (e.g. switch desugaring) live in
+/// their own classes; see SwitchDesugarer.
 ///
 public class Suspenders extends TreeTranslator {
 
@@ -42,12 +38,9 @@ public class Suspenders extends TreeTranslator {
 
     private final Set<Symbol> records = new HashSet<>();
 
-    private final Log log;
     private final TreeMaker maker;
     private final Names names;
-    private JCTree.JCVariableDecl placeholderField;
     private final Symtab symtab;
-    private final Name caseMatchName;
 
     public static Suspenders instance(Context context) {
         Suspenders instance = context.get(key);
@@ -59,11 +52,9 @@ public class Suspenders extends TreeTranslator {
     public Suspenders(Context context) {
         context.put(key, this);
 
-        this.log = Log.instance(context);
         this.maker = TreeMaker.instance(context);
         this.names = Names.instance(context);
         this.symtab = Symtab.instance(context);
-        this.caseMatchName = names.fromString("$caseMatch");
         this.assertMarkerName = names.fromString("$assertMarker");
     }
 
@@ -72,7 +63,7 @@ public class Suspenders extends TreeTranslator {
         UNSUSPEND
     }
     private Direction direction;
-    
+
     // Name used to mark suspended assert statements
     private final Name assertMarkerName;
 
@@ -116,10 +107,10 @@ public class Suspenders extends TreeTranslator {
     @Override
     public void visitAssert(JCTree.JCAssert tree) {
         if (direction == Direction.SUSPEND) {
-            // Transform: assert condition; 
+            // Transform: assert condition;
             // Into: if ($assertMarker) { condition; }
             // The marker condition prevents LOWER from recognizing this as an assert
-            
+
             // Create a synthetic variable symbol for the marker
             var markerSymbol = new Symbol.VarSymbol(
                 0, // flags
@@ -127,13 +118,13 @@ public class Suspenders extends TreeTranslator {
                 symtab.booleanType,
                 symtab.noSymbol // owner
             );
-            
+
             var markerCondition = maker.Ident(markerSymbol);
             markerCondition.type = symtab.booleanType;
-            
+
             var conditionStatement = maker.Exec(tree.cond);
             var thenBlock = maker.Block(0, List.of(conditionStatement));
-            
+
             var ifStmt = maker.If(markerCondition, thenBlock, null);
             result = ifStmt;
             result.accept(this);
@@ -146,329 +137,21 @@ public class Suspenders extends TreeTranslator {
     public void visitIf(JCTree.JCIf tree) {
         if (direction == Direction.UNSUSPEND) {
             // Check if this is a suspended assert statement
-            if (tree.cond instanceof JCTree.JCIdent ident && 
+            if (tree.cond instanceof JCTree.JCIdent ident &&
                 ident.name.equals(assertMarkerName) &&
                 tree.elsepart == null &&
                 tree.thenpart instanceof JCTree.JCBlock block &&
                 block.stats.size() == 1 &&
                 block.stats.head instanceof JCTree.JCExpressionStatement exprStmt) {
-                
+
                 // Transform back: if ($assertMarker) { condition; } -> assert condition;
                 var assertStmt = maker.Assert(exprStmt.expr, null);
                 result = assertStmt;
                 result.accept(this);
                 return;
             }
-            
-            // Check if this is a switch-encoded if statement
-            var maybeSwitch = switchFromIf(tree);
-            if (maybeSwitch.isPresent()) {
-                result = maybeSwitch.get();
-                result.accept(this);
-                return;
-            }
         }
 
         super.visitIf(tree);
-    }
-
-    @Override
-    public void visitSwitch(JCTree.JCSwitch tree) {
-        if (direction == Direction.SUSPEND) {
-            var exhaustive = tree.isExhaustive &&
-                    tree.cases.stream().noneMatch(cas ->
-                            cas.labels.stream().anyMatch(label -> label instanceof JCTree.JCDefaultCaseLabel));
-            var maybeIf = switchToIf(tree.selector, tree.cases, exhaustive);
-            if (maybeIf.isPresent()) {
-                result = maybeIf.get();
-                result.accept(this);
-                return;
-            }
-        }
-
-        super.visitSwitch(tree);
-    }
-
-    @Override
-    public void visitConditional(JCTree.JCConditional tree) {
-        if (direction == Direction.UNSUSPEND) {
-            var maybeSwitch = switchExpressionFromConditional(tree);
-            if (maybeSwitch.isPresent()) {
-                result = maybeSwitch.get();
-                result.accept(this);
-                return;
-            }
-        }
-
-        super.visitConditional(tree);
-    }
-
-    ///
-    /// Translates a switch statement into an equivalent chained if statement.
-    /// See also switchFromIf for the reverse transformation used
-    /// in the UNSUSPECT direction.
-    ///
-    /// For example:
-    /// {@snippet :
-    ///       var num = -1;
-    ///       switch (i) {
-    ///            case 0 -> num = 10;
-    ///            case 1, 2 -> num = 20;
-    ///            case 3 -> num = 30;
-    ///            default -> num = 40;
-    ///       }
-    ///  }
-    /// Becomes:
-    /// {@snippet :
-    ///       var num = -1;
-    ///       if (i == 0) {
-    ///            num = 10;
-    ///       } else if (i == 1 || i == 2) {
-    ///            num = 20;
-    ///       } else if (i == 3) {
-    ///            num = 30;
-    ///       } else {
-    ///            num = 40;
-    ///       }
-    ///  }
-    /// If the switch was determined to be exhaustive and there is no default case label,
-    /// then an extra `else { assert false; } branch is added at the end to encode that bit.
-    ///
-    /// The "==" operators are tagged with a separate Name to identify them
-    /// as encoding implicit switch case patterns,
-    /// so there is no ambiguity with existing source code.
-    ///
-    /// Returns an Optional<JCStatement> because not all switch statements are possible
-    /// to encode in this way. This mapping covers all statements we currently support,
-    /// however, so if the encoding fails we can just skip suspending the switch.
-    /// The translation will cause errors anyway,
-    /// and the only consequence of the LOWER rewriting is that
-    /// some errors may be relocated or duplicated.
-    ///
-    private Optional<JCTree.JCStatement> switchToIf(JCTree.JCExpression selector, List<JCTree.JCCase> cases, boolean exhaustive) {
-        final JCTree.JCStatement rest;
-        if (cases.tail.nonEmpty()) {
-            var maybeRest = switchToIf(selector, cases.tail, exhaustive);
-            if (maybeRest.isEmpty()) {
-                return maybeRest;
-            }
-            rest = maybeRest.get();
-        } else if (exhaustive) {
-            maker.pos = selector.pos;
-            rest = maker.Assert(maker.Literal(false), null);
-        } else {
-            rest = null;
-        }
-        return caseToExpression(selector, cases.head, cases.head.labels).map(head -> {
-            maker.pos = head.pos;
-            return maker.If(head, maker.Block(0, cases.head.stats), rest);
-        });
-    }
-
-    private Optional<JCTree.JCSwitch> switchFromIf(JCTree.JCIf ifStmt) {
-        var maybeSelector = selectorFromIf(ifStmt);
-        return maybeSelector.map(selector -> {
-            var cases = casesFromIf(ifStmt);
-            var result = maker.Switch(selector, cases);
-            result.isExhaustive = exhaustiveFromIf(ifStmt);
-            return result;
-        });
-    }
-
-    private List<JCTree.JCCase> casesFromIf(JCTree.JCIf ifStmt) {
-        var labels = caseLabelsFromExpression(ifStmt.cond);
-        var cas = maker.Case(CaseTree.CaseKind.RULE, labels, null, ((JCTree.JCBlock)ifStmt.thenpart).stats, ifStmt.thenpart);
-        var ifCase = List.of(cas);
-        if (ifStmt.elsepart instanceof JCTree.JCIf elseIf) {
-            return ifCase.appendList(casesFromIf(elseIf));
-        } else if (ifStmt.elsepart != null) {
-            return ifCase.append(defaultCase(ifStmt.elsepart));
-        } else {
-            return ifCase;
-        }
-    }
-
-    private JCTree.JCCase defaultCase(JCTree.JCStatement statement) {
-        return maker.Case(CaseTree.CaseKind.RULE, List.of(maker.DefaultCaseLabel()), null, ((JCTree.JCBlock)statement).stats, statement);
-    }
-
-    private boolean exhaustiveFromIf(JCTree.JCIf ifStmt) {
-        if (ifStmt.elsepart instanceof JCTree.JCIf elseIf) {
-            return exhaustiveFromIf(elseIf);
-        } else {
-            return ifStmt.elsepart != null;
-        }
-    }
-
-    private Optional<JCTree.JCExpression> selectorFromIf(JCTree.JCIf ifStmt) {
-        var selector = ifStmt.elsepart instanceof JCTree.JCIf elseIf
-            ? Stream.concat(selectorsFromExpression(ifStmt.cond), selectorsFromExpression(elseIf.cond))
-            : selectorsFromExpression(ifStmt.cond);
-        return selector.findFirst();
-    }
-
-    private Stream<JCTree.JCExpression> selectorsFromExpression(JCTree.JCExpression expr) {
-        return switch (expr) {
-            case JCTree.JCBinary binary -> {
-                if (binary.operator.name.equals(caseMatchName)) {
-                    yield Stream.of(binary.lhs);
-                } else if (binary.hasTag(JCTree.Tag.OR)) {
-                    yield Stream.concat(selectorsFromExpression(binary.lhs), selectorsFromExpression(binary.rhs));
-                } else {
-                    yield Stream.empty();
-                }
-            }
-            default -> Stream.empty();
-        };
-    }
-
-    private List<JCTree.JCCaseLabel> caseLabelsFromExpression(JCTree.JCExpression expr) {
-        return switch (expr) {
-            case JCTree.JCBinary binary -> {
-                if (binary.operator.name.equals(caseMatchName)) {
-                    yield List.of(maker.ConstantCaseLabel(binary.rhs));
-                } else if (binary.hasTag(JCTree.Tag.OR)) {
-                    yield caseLabelsFromExpression(binary.lhs).appendList(caseLabelsFromExpression(binary.rhs));
-                } else {
-                    throw new IllegalStateException();
-                }
-            }
-            case JCTree.JCLiteral literal when literal.value == Boolean.TRUE ->
-                List.of(maker.DefaultCaseLabel());
-            default -> throw new IllegalStateException();
-        };
-    }
-
-    private Optional<JCTree.JCExpression> caseLabelToExpression(JCTree.JCExpression selector, JCTree.JCCaseLabel label) {
-        return switch (label) {
-            case JCTree.JCConstantCaseLabel constantCaseLabel -> {
-                var methodType = new Type.MethodType(List.of(selector.type, constantCaseLabel.expr.type), symtab.booleanType, null, null);
-                var result = makeResolvedBinary(JCTree.Tag.EQ, selector, constantCaseLabel.expr, methodType);
-                result.operator = new Symbol.OperatorSymbol(caseMatchName, methodType, -1, symtab.noSymbol);;
-                yield Optional.of(result);
-            }
-            case JCTree.JCDefaultCaseLabel _ -> Optional.of(maker.Literal(true));
-            default -> Optional.empty();
-        };
-    }
-
-    private Optional<JCTree.JCExpression> caseToExpression(JCTree.JCExpression selector, JCTree.JCCase cas, List<JCTree.JCCaseLabel> labels) {
-        if (cas.caseKind == CaseTree.CaseKind.STATEMENT) {
-            return Optional.empty();
-        } else if (labels.tail.isEmpty()) {
-            return caseLabelToExpression(selector, labels.head);
-        } else {
-            return caseToExpression(selector, cas, labels.tail).flatMap(rest ->
-                caseLabelToExpression(selector, labels.head).map(head ->
-                    makeResolvedBinary(JCTree.Tag.OR, head, rest,
-                            new Type.MethodType(List.of(symtab.booleanType, symtab.booleanType), symtab.booleanType, null, null))));
-        }
-    }
-
-    private JCTree.JCBinary makeResolvedBinary(JCTree.Tag opcode, JCTree.JCExpression lhs, JCTree.JCExpression rhs, Type.MethodType resultType) {
-        var result = maker.Binary(opcode, lhs, rhs);
-        result.operator = new Symbol.OperatorSymbol(names.equals, resultType, -1, symtab.noSymbol);
-        result.type = resultType.restype;
-        return result;
-    }
-
-    @Override
-    public void visitSwitchExpression(JCTree.JCSwitchExpression tree) {
-        if (direction == Direction.SUSPEND) {
-            var maybeSwitch = switchExpressionToConditional(tree.selector, tree.cases, tree.type);
-            if (maybeSwitch.isPresent()) {
-                result = maybeSwitch.get();
-                result.accept(this);
-                return;
-            }
-        }
-
-        super.visitSwitchExpression(tree);
-    }
-
-    ///
-    /// Translates a switch expression into an equivalent chained conditional expression.
-    /// See also switchExpressionFromConditional for the reverse transformation used
-    /// in the UNSUSPEND direction.
-    ///
-    /// For example:
-    /// {@snippet :
-    ///       var num = switch (i) {
-    ///            case 0 -> 10;
-    ///            case 1, 2 -> 20;
-    ///            case 3 -> 30;
-    ///            default -> 40;
-    ///       };
-    ///  }
-    /// Becomes:
-    /// {@snippet :
-    ///       var num = (i == 10) ? 10 :
-    ///            (i == 1 || i == 2) ? 20 :
-    ///                 (i == 3) ? 30 :
-    ///                      (true) ? 40 : <hole>
-    ///  }
-    /// The "==" operators are tagged with a separate Name to identify them
-    /// as encoding implicit switch case patterns,
-    /// so there is no ambiguity with existing source code.
-    ///
-    /// Returns an Optional<JCExpression> because not all switch expressions are possible
-    /// to encode in this way. This mapping covers all statements we currently support,
-    /// however, so if the encoding fails we can just skip suspending the switch.
-    /// The translation will cause errors anyway,
-    /// and the only consequence of the LOWER rewriting is that
-    /// some errors may be relocated or duplicated.
-    ///
-    private Optional<JCTree.JCExpression> switchExpressionToConditional(JCTree.JCExpression selector, List<JCTree.JCCase> cases, Type typ) {
-        if (cases.isEmpty()) {
-            // TODO: Should be a "hole" instead, or we should ensure the default case comes last in the list
-            return Optional.of(maker.Literal(false));
-        } else {
-            var rest = switchExpressionToConditional(selector, cases.tail, typ);
-            if (rest.isEmpty()) {
-                return rest;
-            }
-
-            if (cases.head.body instanceof JCTree.JCExpression headExpr) {
-                return caseToExpression(selector, cases.head, cases.head.labels).map(head -> {
-                    var conditional = maker.Conditional(head, headExpr, rest.get());
-                    conditional.type = typ;
-                    return conditional;
-                });
-            } else {
-                return Optional.empty();
-            }
-
-        }
-    }
-
-    private Optional<JCTree.JCSwitchExpression> switchExpressionFromConditional(JCTree.JCConditional conditional) {
-        var maybeSelector = selectorsFromConditional(conditional).findFirst();
-        return maybeSelector.map(selector -> {
-            var cases = casesFromConditional(conditional);
-            return maker.SwitchExpression(selector, cases);
-        });
-    }
-
-    private Stream<JCTree.JCExpression> selectorsFromConditional(JCTree.JCConditional conditional) {
-        return conditional.falsepart instanceof JCTree.JCConditional falseCond
-                ? Stream.concat(selectorsFromExpression(conditional.cond), selectorsFromConditional(falseCond))
-                : selectorsFromExpression(conditional.cond);
-    }
-
-    private List<JCTree.JCCase> casesFromConditional(JCTree.JCConditional conditional) {
-        var labels = caseLabelsFromExpression(conditional.cond);
-        var stats = List.<JCTree.JCStatement>of(maker.Yield(conditional.truepart));
-        var cas = maker.Case(CaseTree.CaseKind.RULE, labels, null, stats, conditional.truepart);
-        var truepartCase = List.of(cas);
-        if (conditional.falsepart instanceof JCTree.JCConditional falseCond) {
-            return truepartCase.appendList(casesFromConditional(falseCond));
-        } else {
-            return truepartCase.append(defaultCaseFromExpr(conditional.falsepart));
-        }
-    }
-
-    private JCTree.JCCase defaultCaseFromExpr(JCTree.JCExpression expr) {
-        var stats = List.<JCTree.JCStatement>of(maker.Yield(expr));
-        return maker.Case(CaseTree.CaseKind.RULE, List.of(maker.DefaultCaseLabel()), null, stats, expr);
     }
 }

--- a/verifier/src/main/java/org/strata/jverify/verifier/compiler/frontend/SwitchDesugarer.java
+++ b/verifier/src/main/java/org/strata/jverify/verifier/compiler/frontend/SwitchDesugarer.java
@@ -1,0 +1,279 @@
+package org.strata.jverify.verifier.compiler.frontend;
+
+import com.sun.source.tree.CaseTree;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Symtab;
+import com.sun.tools.javac.code.Type;
+import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.tree.TreeMaker;
+import com.sun.tools.javac.tree.TreeTranslator;
+import com.sun.tools.javac.util.Context;
+import com.sun.tools.javac.util.List;
+import com.sun.tools.javac.util.ListBuffer;
+import com.sun.tools.javac.util.Names;
+
+import java.util.Optional;
+
+/// Lowers Java switch statements and switch expressions into chained
+/// if-statements and ?: conditionals respectively. Runs as its own phase in
+/// JavaLowerer's pipeline before LOWER, because LOWER would otherwise mangle
+/// switches into bytecode-flavored fall-through shapes JavaToLaurelCompiler
+/// doesn't accept.
+///
+/// JavaToLaurelCompiler consumes the if/conditional shape directly, so the
+/// rewrite is one-way (no UNSUSPEND-style reversal). Forms that can't be
+/// encoded (case-statement groups, non-literal labels, pattern guards,
+/// block/throw bodies in switch expressions, `case null`) fall through to
+/// LOWER and surface as method-level skips via JavaToLaurelCompiler's
+/// per-method catch. Step 2b of PLAN.md §3 will replace those skips with
+/// per-construct refusal diagnostics emitted at this phase.
+public class SwitchDesugarer extends TreeTranslator {
+
+    private final TreeMaker maker;
+    private final Names names;
+    private final Symtab symtab;
+    private int nextSelectorIndex = 0;
+
+    public SwitchDesugarer(Context context) {
+        this.maker = TreeMaker.instance(context);
+        this.names = Names.instance(context);
+        this.symtab = Symtab.instance(context);
+    }
+
+    public java.util.List<JCTree.JCCompilationUnit> transform(java.util.List<JCTree.JCCompilationUnit> envs) {
+        for (var env : envs) {
+            translate(env);
+        }
+        return envs;
+    }
+
+    @Override
+    public void visitSwitch(JCTree.JCSwitch tree) {
+        var maybeIf = switchToIf(tree.selector, tree.cases, tree.isExhaustive);
+        if (maybeIf.isPresent()) {
+            result = maybeIf.get();
+            result.accept(this);
+            return;
+        }
+        super.visitSwitch(tree);
+    }
+
+    @Override
+    public void visitSwitchExpression(JCTree.JCSwitchExpression tree) {
+        var maybeSwitch = switchExpressionToConditional(tree.selector, tree.cases, tree.type);
+        if (maybeSwitch.isPresent()) {
+            result = maybeSwitch.get();
+            result.accept(this);
+            return;
+        }
+        super.visitSwitchExpression(tree);
+    }
+
+    ///
+    /// Translates a switch statement into an equivalent chained if statement.
+    ///
+    /// For example:
+    /// {@snippet :
+    ///       var num = -1;
+    ///       switch (i) {
+    ///            case 0 -> num = 10;
+    ///            case 1, 2 -> num = 20;
+    ///            case 3 -> num = 30;
+    ///            default -> num = 40;
+    ///       }
+    ///  }
+    /// Becomes:
+    /// {@snippet :
+    ///       var num = -1;
+    ///       if (i == 0) {
+    ///            num = 10;
+    ///       } else if (i == 1 || i == 2) {
+    ///            num = 20;
+    ///       } else if (i == 3) {
+    ///            num = 30;
+    ///       } else {
+    ///            num = 40;
+    ///       }
+    ///  }
+    /// If the switch was determined to be exhaustive and there is no default case label,
+    /// then an extra `else { assert false; } branch is added at the end to encode that bit.
+    ///
+    /// Arrow-form Java allows the `default` case in any position, but the
+    /// generated if-cascade has to put it last to preserve semantics — a
+    /// `default` mid-cascade lowers to `else if (true) { ... }` which makes
+    /// every later `else if` dead. Partition before recursing.
+    ///
+    /// Returns an Optional<JCStatement>. Reaching Optional.empty() means
+    /// caseLabelToExpression rejected an unknown JCCaseLabel subclass — a
+    /// future Java version added a label kind. Defensive: skip desugaring,
+    /// LOWER may then mutate the tree unpredictably, but the user will see
+    /// errors.
+    ///
+    private Optional<JCTree.JCStatement> switchToIf(JCTree.JCExpression selector, List<JCTree.JCCase> cases, boolean exhaustive) {
+        Optional<JCTree.JCCase> defaultCase = Optional.empty();
+        ListBuffer<JCTree.JCCase> nonDefault = new ListBuffer<>();
+        for (var cas : cases) {
+            if (cas.labels.size() == 1 && cas.labels.head instanceof JCTree.JCDefaultCaseLabel) {
+                defaultCase = Optional.of(cas);
+            } else {
+                nonDefault.append(cas);
+            }
+        }
+        // Hoist the selector into a fresh local so it's evaluated exactly
+        // once. Without this, side-effecting selectors (e.g. method calls
+        // that mutate state) would be evaluated by every generated equality
+        // test, costing precision in verification.
+        var selSymbol = freshSelectorSymbol(selector.type);
+        maker.pos = selector.pos;
+        var selVarDecl = maker.VarDef(selSymbol, selector);
+        var selRef = identFor(selSymbol);
+
+        final JCTree.JCStatement tail;
+        if (defaultCase.isPresent()) {
+            tail = maker.Block(0, defaultCase.get().stats);
+        } else if (exhaustive) {
+            tail = maker.Assert(maker.Literal(false), null);
+        } else {
+            tail = null;
+        }
+        // Build the if-cascade from the inside out: start with `tail` as the
+        // innermost else and prepend each non-default case in reverse.
+        // `null` tail is preserved as a missing-else (Java allows that).
+        JCTree.JCStatement chain = tail;
+        var reversed = nonDefault.toList().reverse();
+        for (var cas : reversed) {
+            var maybeHead = caseToExpression(selRef, cas, cas.labels);
+            if (maybeHead.isEmpty()) {
+                return Optional.empty();
+            }
+            maker.pos = maybeHead.get().pos;
+            chain = maker.If(maybeHead.get(), maker.Block(0, cas.stats), chain);
+        }
+        if (chain == null) {
+            return Optional.empty();
+        }
+        return Optional.of(maker.Block(0, List.of(selVarDecl, chain)));
+    }
+
+    private Symbol.VarSymbol freshSelectorSymbol(Type type) {
+        var name = names.fromString("$switchSelector" + (nextSelectorIndex++));
+        return new Symbol.VarSymbol(0, name, type, symtab.noSymbol);
+    }
+
+    private JCTree.JCIdent identFor(Symbol.VarSymbol sym) {
+        var ident = maker.Ident(sym);
+        ident.type = sym.type;
+        return ident;
+    }
+
+    private Optional<JCTree.JCExpression> caseLabelToExpression(JCTree.JCExpression selector, JCTree.JCCaseLabel label) {
+        return switch (label) {
+            case JCTree.JCConstantCaseLabel constantCaseLabel -> {
+                var methodType = new Type.MethodType(List.of(selector.type, constantCaseLabel.expr.type), symtab.booleanType, null, null);
+                yield Optional.of(makeResolvedBinary(JCTree.Tag.EQ, selector, constantCaseLabel.expr, methodType));
+            }
+            case JCTree.JCDefaultCaseLabel _ -> Optional.of(maker.Literal(true));
+            default -> Optional.empty();
+        };
+    }
+
+    private Optional<JCTree.JCExpression> caseToExpression(JCTree.JCExpression selector, JCTree.JCCase cas, List<JCTree.JCCaseLabel> labels) {
+        if (cas.caseKind == CaseTree.CaseKind.STATEMENT) {
+            return Optional.empty();
+        } else if (labels.tail.isEmpty()) {
+            return caseLabelToExpression(selector, labels.head);
+        } else {
+            return caseToExpression(selector, cas, labels.tail).flatMap(rest ->
+                caseLabelToExpression(selector, labels.head).map(head ->
+                    makeResolvedBinary(JCTree.Tag.OR, head, rest,
+                            new Type.MethodType(List.of(symtab.booleanType, symtab.booleanType), symtab.booleanType, null, null))));
+        }
+    }
+
+    private JCTree.JCBinary makeResolvedBinary(JCTree.Tag opcode, JCTree.JCExpression lhs, JCTree.JCExpression rhs, Type.MethodType resultType) {
+        var result = maker.Binary(opcode, lhs, rhs);
+        result.operator = new Symbol.OperatorSymbol(names.equals, resultType, -1, symtab.noSymbol);
+        result.type = resultType.restype;
+        return result;
+    }
+
+    ///
+    /// Translates a switch expression into an equivalent chained conditional expression.
+    ///
+    /// For example:
+    /// {@snippet :
+    ///       var num = switch (i) {
+    ///            case 0 -> 10;
+    ///            case 1, 2 -> 20;
+    ///            case 3 -> 30;
+    ///            default -> 40;
+    ///       };
+    ///  }
+    /// Becomes:
+    /// {@snippet :
+    ///       var num = (i == 0) ? 10 :
+    ///            (i == 1 || i == 2) ? 20 :
+    ///                 (i == 3) ? 30 :
+    ///                      40;
+    ///  }
+    ///
+    /// Returns an Optional<JCExpression>. Reaching Optional.empty() means
+    /// caseLabelToExpression rejected an unknown JCCaseLabel subclass, or
+    /// the default case had a non-expression body — defensive: skip
+    /// desugaring, LOWER may then mutate the tree unpredictably, but the
+    /// user will see errors.
+    ///
+    private Optional<JCTree.JCExpression> switchExpressionToConditional(JCTree.JCExpression selector, List<JCTree.JCCase> cases, Type typ) {
+        Optional<JCTree.JCExpression> defaultBody = Optional.empty();
+        ListBuffer<JCTree.JCCase> nonDefault = new ListBuffer<>();
+        for (var cas : cases) {
+            if (cas.labels.size() == 1 && cas.labels.head instanceof JCTree.JCDefaultCaseLabel) {
+                if (!(cas.body instanceof JCTree.JCExpression body)) {
+                    return Optional.empty();
+                }
+                defaultBody = Optional.of(body);
+            } else {
+                nonDefault.append(cas);
+            }
+        }
+        // Switch expressions without a default are exhaustive over a known
+        // domain (enum, sealed). javac enforces this before we run, so this
+        // path is unreachable in practice — refuse to desugar defensively
+        // rather than synthesizing a falsepart of arbitrary type.
+        if (defaultBody.isEmpty()) {
+            return Optional.empty();
+        }
+        // Hoist the selector into a fresh local so it's evaluated exactly
+        // once — same motivation as switchToIf. Wrap the conditional chain
+        // in a synthetic LetExpr; JavaToLaurelCompiler lowers it to a
+        // Laurel block (which is a StmtExpr — usable in expression position).
+        var selSymbol = freshSelectorSymbol(selector.type);
+        maker.pos = selector.pos;
+        var selVarDecl = maker.VarDef(selSymbol, selector);
+        var selRef = identFor(selSymbol);
+        return wrapCases(selRef, nonDefault.toList(), defaultBody.get(), typ)
+                .map(expr -> {
+                    var let = maker.LetExpr(selVarDecl, expr);
+                    let.type = typ;
+                    return let;
+                });
+    }
+
+    private Optional<JCTree.JCExpression> wrapCases(JCTree.JCExpression selector, List<JCTree.JCCase> cases, JCTree.JCExpression defaultBody, Type typ) {
+        if (cases.isEmpty()) {
+            return Optional.of(defaultBody);
+        }
+        if (!(cases.head.body instanceof JCTree.JCExpression headExpr)) {
+            return Optional.empty();
+        }
+        var rest = wrapCases(selector, cases.tail, defaultBody, typ);
+        if (rest.isEmpty()) {
+            return rest;
+        }
+        return caseToExpression(selector, cases.head, cases.head.labels).map(head -> {
+            var conditional = maker.Conditional(head, headExpr, rest.get());
+            conditional.type = typ;
+            return conditional;
+        });
+    }
+}

--- a/verifier/src/main/java/org/strata/jverify/verifier/compiler/frontend/SwitchDesugarer.java
+++ b/verifier/src/main/java/org/strata/jverify/verifier/compiler/frontend/SwitchDesugarer.java
@@ -110,6 +110,16 @@ public class SwitchDesugarer extends TreeTranslator {
     /// errors.
     ///
     private Optional<JCTree.JCStatement> switchToIf(JCTree.JCExpression selector, List<JCTree.JCCase> cases, boolean exhaustive) {
+        // Refuse STATEMENT-form switches uniformly. caseToExpression already
+        // refuses STATEMENT-form non-default cases; extending the check here
+        // also covers a STATEMENT-form default — wrapping its body in a
+        // plain Block would orphan any `break` it contains, retargeting
+        // them to the enclosing loop instead of the (now-removed) switch.
+        for (var cas : cases) {
+            if (cas.caseKind == CaseTree.CaseKind.STATEMENT) {
+                return Optional.empty();
+            }
+        }
         Optional<JCTree.JCCase> defaultCase = Optional.empty();
         ListBuffer<JCTree.JCCase> nonDefault = new ListBuffer<>();
         for (var cas : cases) {

--- a/verifier/src/main/java/org/strata/jverify/verifier/compiler/generator/laurel/JavaToLaurelCompiler.java
+++ b/verifier/src/main/java/org/strata/jverify/verifier/compiler/generator/laurel/JavaToLaurelCompiler.java
@@ -286,10 +286,10 @@ public class JavaToLaurelCompiler {
             procedures.add(proc);
         }
 
-        private StmtExpr convertBlock(JCTree.JCBlock blk) {
+        private StmtExpr convertBlock(JCTree.JCBlock blk, Map<String, String> renames) {
             List<StmtExpr> statements = new ArrayList<>();
             for (var statement : blk.stats) {
-                StmtExpr converted = convertStatement(statement);
+                StmtExpr converted = convertStatement(statement, renames);
                 if (converted != null) {
                     statements.add(converted);
                 }
@@ -355,25 +355,29 @@ public class JavaToLaurelCompiler {
         }
 
         private StmtExpr convertStatement(JCTree.JCStatement statement) {
+            return convertStatement(statement, Map.of());
+        }
+
+        private StmtExpr convertStatement(JCTree.JCStatement statement, Map<String, String> renames) {
             return switch (statement) {
                 case JCTree.JCAssert assertStmt ->
-                        assert_(toSourceRange(assertStmt), convertExpression(assertStmt.cond), Optional.empty());
-                case JCTree.JCExpressionStatement exprStmt -> convertExpression(exprStmt.expr);
-                case JCTree.JCBlock blk -> convertBlock(blk);
+                        assert_(toSourceRange(assertStmt), convertExpression(assertStmt.cond, renames), Optional.empty());
+                case JCTree.JCExpressionStatement exprStmt -> convertExpression(exprStmt.expr, renames);
+                case JCTree.JCBlock blk -> convertBlock(blk, renames);
                 case JCTree.JCVariableDecl varDecl -> {
                     LaurelType type = translateType(varDecl.type);
                     Optional<Initializer> optAssign = varDecl.init != null
-                            ? Optional.of(initializer(convertExpression(varDecl.init)))
+                            ? Optional.of(initializer(convertExpression(varDecl.init, renames)))
                             : Optional.empty();
                     yield varDecl(toSourceRange(varDecl), varDecl.name.toString(),
                             Optional.of(typeAnnotation(type)), optAssign);
                 }
                 case JCTree.JCIf ifStmt -> {
-                    StmtExpr cond = convertExpression(ifStmt.cond);
-                    StmtExpr thenBranch = convertStatement(ifStmt.thenpart);
+                    StmtExpr cond = convertExpression(ifStmt.cond, renames);
+                    StmtExpr thenBranch = convertStatement(ifStmt.thenpart, renames);
                     Optional<ElseBranch> elseB = Optional.empty();
                     if (ifStmt.elsepart != null) {
-                        StmtExpr elseStmt = convertStatement(ifStmt.elsepart);
+                        StmtExpr elseStmt = convertStatement(ifStmt.elsepart, renames);
                         if (elseStmt != null) {
                             elseB = Optional.of(elseBranch(elseStmt));
                         }
@@ -382,15 +386,15 @@ public class JavaToLaurelCompiler {
                 }
                 case JCTree.JCReturn retStmt -> {
                     if (retStmt.expr != null) {
-                        yield return_(toSourceRange(retStmt), convertExpression(retStmt.expr));
+                        yield return_(toSourceRange(retStmt), convertExpression(retStmt.expr, renames));
                     }
                     yield null;
                 }
                 case JCTree.JCWhileLoop whileStmt -> {
                     var sr = toSourceRange(whileStmt);
                     yield withLoopLabels(whileStmt.body, (breakLbl, continueLbl) -> {
-                        StmtExpr cond = convertExpression(whileStmt.cond);
-                        var parts = extractLoopParts(whileStmt.body);
+                        StmtExpr cond = convertExpression(whileStmt.cond, renames);
+                        var parts = extractLoopParts(whileStmt.body, renames);
                         return emitLoop(sr, cond, parts.invariants, parts.body, null, List.of(),
                                 breakLbl, continueLbl);
                     });
@@ -401,13 +405,13 @@ public class JavaToLaurelCompiler {
                     var sr = toSourceRange(forLoop);
                     yield withLoopLabels(forLoop.body, (breakLbl, continueLbl) -> {
                         StmtExpr init = forLoop.init.isEmpty() ? block(sr, List.of())
-                                : convertStatement(forLoop.init.getFirst());
+                                : convertStatement(forLoop.init.getFirst(), renames);
                         StmtExpr cond = forLoop.cond != null
-                                ? convertExpression(forLoop.cond)
+                                ? convertExpression(forLoop.cond, renames)
                                 : literalBool(sr, true);
                         StmtExpr step = forLoop.step.isEmpty() ? block(sr, List.of())
-                                : convertStatement(forLoop.step.getFirst());
-                        var parts = extractLoopParts(forLoop.body);
+                                : convertStatement(forLoop.step.getFirst(), renames);
+                        var parts = extractLoopParts(forLoop.body, renames);
                         return emitLoop(sr, cond, parts.invariants, parts.body, step, List.of(init),
                                 breakLbl, continueLbl);
                     });
@@ -426,14 +430,14 @@ public class JavaToLaurelCompiler {
                     if (labeledStmt.body instanceof JCTree.JCWhileLoop
                             || labeledStmt.body instanceof JCTree.JCForLoop
                             || labeledStmt.body instanceof JCTree.JCDoWhileLoop) {
-                        yield convertStatement(labeledStmt.body);
+                        yield convertStatement(labeledStmt.body, renames);
                     } else {
                         // Non-loop labeled statement: only break is valid (no continue)
                         String breakLbl = freshLabel("label_break");
                         labelStack.push(new LabelEntry(pendingLabel, breakLbl, null));
                         pendingLabel = null;
                         try {
-                            StmtExpr body = convertStatement(labeledStmt.body);
+                            StmtExpr body = convertStatement(labeledStmt.body, renames);
                             yield labelledBlock(toSourceRange(labeledStmt), List.of(body), breakLbl);
                         } finally {
                             labelStack.pop();
@@ -463,22 +467,22 @@ public class JavaToLaurelCompiler {
 
         private record LoopParts(List<InvariantClause> invariants, StmtExpr body) {}
 
-        private LoopParts extractLoopParts(JCTree.JCStatement body) {
+        private LoopParts extractLoopParts(JCTree.JCStatement body, Map<String, String> renames) {
             if (body instanceof JCTree.JCBlock loopBlock) {
                 MethodOrLoopContract loopContract = contractCompiler.getContract(loopBlock);
                 List<InvariantClause> invariants = new ArrayList<>();
                 for (var inv : loopContract.loopInvariants()) {
-                    invariants.add(invariantClause(convertExpression(inv.get())));
+                    invariants.add(invariantClause(convertExpression(inv.get(), renames)));
                 }
                 var implStatements = MethodOrLoopContractCompiler.getImplementationStatements(loopBlock);
                 List<StmtExpr> stmts = new ArrayList<>();
                 for (var s : implStatements) {
-                    StmtExpr converted = convertStatement(s);
+                    StmtExpr converted = convertStatement(s, renames);
                     if (converted != null) stmts.add(converted);
                 }
                 return new LoopParts(invariants, block(toSourceRange(loopBlock), stmts));
             } else {
-                return new LoopParts(List.of(), convertStatement(body));
+                return new LoopParts(List.of(), convertStatement(body, renames));
             }
         }
 
@@ -513,20 +517,43 @@ public class JavaToLaurelCompiler {
                     yield call(toSourceRange(invocation),
                             identifier(toSourceRange(invocation), calleeName), args);
                 }
+                // Synthesized by SwitchDesugarer to hoist a switch-expression's
+                // selector into a fresh local; lowers to a Laurel block (StmtExpr,
+                // usable in expression position). javac's Lower emits LetExpr for
+                // boxed compound-assign, postops, and pattern switches — all
+                // currently unsupported.
+                case JCTree.LetExpr letExpr -> {
+                    List<StmtExpr> stmts = new ArrayList<>();
+                    for (var def : letExpr.defs) {
+                        StmtExpr converted = convertStatement(def, renames);
+                        if (converted != null) stmts.add(converted);
+                    }
+                    stmts.add(convertExpression(letExpr.expr, renames));
+                    yield block(toSourceRange(letExpr), stmts);
+                }
+                // Compile-time constant field access (e.g. `Foo.CONST` where
+                // CONST is `static final int CONST = 42`). javac keeps these as
+                // JCFieldAccess with the constant value attached on the
+                // expression's type.
+                case JCTree.JCFieldAccess fa when fa.type.constValue() != null ->
+                    convertConstantValue(toSourceRange(fa), fa.type.getTag(), fa.type.constValue());
                 default -> throw new JavaViolationException("Unsupported expression: " + expr.getClass().getSimpleName());
             };
         }
 
         private StmtExpr convertLiteral(JCTree.JCLiteral literal) {
-            var sr = toSourceRange(literal);
-            return switch (literal.typetag) {
-                case BOOLEAN -> literalBool(sr, (int) literal.value != 0);
-                case INT, LONG, SHORT, BYTE -> {
-                    long val = ((Number) literal.value).longValue();
-                    yield longLiteral(sr, val);
-                }
-                case CHAR -> longLiteral(sr, ((Number) literal.value).longValue());
-                default -> throw new JavaViolationException("Unsupported literal type: " + literal.typetag);
+            return convertConstantValue(toSourceRange(literal), literal.typetag, literal.value);
+        }
+
+        /// Lower a primitive compile-time constant value to a Laurel literal.
+        /// Used by JCLiteral and JCFieldAccess (where the value is attached
+        /// via Type.constValue()). Boolean values arrive as Integer 0/1 from
+        /// Type.constValue() — Java represents booleans as int internally.
+        private StmtExpr convertConstantValue(SourceRange sr, TypeTag tag, Object v) {
+            return switch (tag) {
+                case BOOLEAN -> literalBool(sr, ((Number) v).intValue() != 0);
+                case CHAR, INT, SHORT, BYTE, LONG -> longLiteral(sr, ((Number) v).longValue());
+                default -> throw new JavaViolationException("Unsupported constant type tag: " + tag);
             };
         }
 

--- a/verifier/src/test/java/org/strata/jverify/verifier/tests/javasupport/statements/SwitchDesugaring.java
+++ b/verifier/src/test/java/org/strata/jverify/verifier/tests/javasupport/statements/SwitchDesugaring.java
@@ -1,0 +1,172 @@
+package org.strata.jverify.verifier.tests.javasupport.statements;
+
+import org.strata.jverify.testengine.JVerifyTest;
+
+import static org.strata.jverify.JVerify.check;
+import static org.strata.jverify.JVerify.postcondition;
+import static org.strata.jverify.JVerify.precondition;
+
+/**
+ * Regression test for arrow-form switches reaching JavaToLaurelCompiler as
+ * if/conditional chains. Switches.java covers more forms but stays skipped
+ * pending case-null support.
+ */
+@JVerifyTest(exitCode = 4, methodsVerified = 14, errorCount = 1)
+class SwitchDesugaring {
+    static void switchExpr(int i) {
+        int num = switch (i) {
+            case 0 -> 10;
+            case 1, 2 -> 20;
+            case 3 -> 30;
+            default -> 40;
+        };
+        check(num == 10 || num == 20 || num == 30 || num == 40);
+    }
+
+    static void switchStmt(int i) {
+        int num = -1;
+        switch (i) {
+            case 0 -> num = 10;
+            case 1, 2 -> num = 20;
+            case 3 -> num = 30;
+            default -> num = 40;
+        }
+        check(num == 10 || num == 20 || num == 30 || num == 40);
+    }
+
+    static void switchStmtNonExhaustive(int i) {
+        int num = -1;
+        switch (i) {
+            case 0 -> num = 10;
+            case 1, 2 -> num = 20;
+            case 3 -> num = 30;
+        }
+        if (i == 0) check(num == 10);
+        else if (i == 1 || i == 2) check(num == 20);
+        else if (i == 3) check(num == 30);
+        else check(num == -1);
+    }
+
+    static void switchStmtBlockBody(int i) {
+        int num = -1;
+        switch (i) {
+            case 0 -> num = 10;
+            case 1, 2 -> {
+                num = 20;
+                num = num + 5;
+            }
+            default -> num = 40;
+        }
+        check(num == 10 || num == 25 || num == 40);
+    }
+
+    static void switchExprDefaultLast(int i) {
+        int num = switch (i) {
+            case 0 -> 10;
+            default -> 40;
+        };
+        check(num == 10 || num == 40);
+    }
+
+    static void switchExprDefaultFirst(int i) {
+        int num = switch (i) {
+            default -> 99;
+            case 0 -> 10;
+            case 1 -> 20;
+        };
+        check(num == 10 || num == 20 || num == 99);
+    }
+
+    static void switchExprChar(char c) {
+        int group = switch (c) {
+            case 'a' -> 1;
+            case 'b', 'c' -> 2;
+            default -> 3;
+        };
+        check(1 <= group && group <= 3);
+    }
+
+    static void switchExprBad(int i) {
+        int num = switch (i) {
+            case 0 -> 10;
+            default -> 40;
+        };
+        check(num == 99);
+//      ^^^^^^^^^^^^^^^^ Error: assertion does not hold
+    }
+
+    static void switchStmtDefaultNotLast(int i) {
+        // Statement-form analogue of switchExprDefaultFirst. The if-cascade
+        // would mis-encode if `default` lowered to `else if (true)` —
+        // case 1's branch would be unreachable and verification would prove
+        // `i == 1 ⇒ r == 99`. Asserting r == 20 catches the bug.
+        int r = -1;
+        switch (i) {
+            case 0 -> r = 10;
+            default -> r = 99;
+            case 1 -> r = 20;
+        }
+        if (i == 0) {
+            check(r == 10);
+        } else if (i == 1) {
+            check(r == 20);
+        } else {
+            check(r == 99);
+        }
+    }
+
+    // Non-trivial selectors exercise the selector-hoisting machinery:
+    // the cascade tests $sel against each case constant, so the original
+    // selector expression should be evaluated once via the synthetic
+    // varDecl / LetExpr.
+    static void switchStmtNonTrivialSelector(int i) {
+        precondition(0 <= i && i < 100);
+        int r = -1;
+        switch (i + 1) {
+            case 1 -> r = 10;
+            case 2 -> r = 20;
+            default -> r = 99;
+        }
+        check(r == 10 || r == 20 || r == 99);
+    }
+
+    static void switchExprNonTrivialSelector(int i) {
+        precondition(0 <= i && i < 100);
+        int num = switch (i + 1) {
+            case 1 -> 10;
+            case 2 -> 20;
+            default -> 99;
+        };
+        check(num == 10 || num == 20 || num == 99);
+    }
+
+    // Regression test: switch expression inside a postcondition lambda whose
+    // selector references the lambda param. Post-SwitchDesugarer the switch
+    // becomes a LetExpr whose VarDef initializer references the lambda param —
+    // that initializer must go through the renames-aware path or Strata sees
+    // an unbound identifier.
+    static int switchInPostcondition(int r) {
+        postcondition((int x) -> 0 == switch (x) {
+            case 0 -> 0;
+            case 1 -> 0;
+            default -> 0;
+        });
+        return 0;
+    }
+
+    // Compile-time constant case labels. javac keeps these as JCFieldAccess
+    // (qualified to the declaring class); convertExpression's constValue arm
+    // folds them to literals at translation time.
+    static final int CONST_ONE = 1;
+    static class Constants { static final int OUTSIDE = 7; }
+    static void switchExprCaseConst(int i) {
+        int num = switch (i) {
+            case CONST_ONE -> 10;
+            case Constants.OUTSIDE -> 20;
+            default -> 99;
+        };
+        if (i == CONST_ONE) check(num == 10);
+        else if (i == Constants.OUTSIDE) check(num == 20);
+        else check(num == 99);
+    }
+}


### PR DESCRIPTION
Step 2a of PLAN.md §3 — switch desugaring.

## Resolves (partially)

- #401 — switch expressions and statements (arrow form). Forms requiring case-null support (Step 9) and diagnostic-quality refusals (Step 2b, #419) are not yet covered.

## Summary

Switch lowering moves into its own dedicated `SwitchDesugarer` phase that runs before `suspend(lower(unsuspend(_)))` in `JavaLowerer`. `JavaToLaurelCompiler` consumes the if/conditional shape directly, so the rewrite is one-way — no UNSUSPEND-style reversal.

Pre-LOWER tree mutations fall into two categories:
- **Defending shapes LOWER would mutate** (records, asserts) — symmetric SUSPEND/UNSUSPEND. Stays in `Suspenders`.
- **Transforming shapes into LOWER-resistant equivalents** (switches) — one-way. Lives in the new `SwitchDesugarer`.

They share a pipeline slot for non-incidental reasons (LOWER mangles switches into bytecode-flavored fall-through that loses source positions and case structure), but they're different concerns. Splitting them clarifies the contract: `Suspenders` shrinks back to its narrow symmetric purpose; `SwitchDesugarer` owns the one-way encoding plus the latent-bug fixes the prior round-trip used to mask.

## What's in this PR

**1. New `SwitchDesugarer` class** with `switchToIf` (statement form) and `switchExpressionToConditional` (expression form). Suspenders no longer touches switches.

**2. Fix latent bug: switch-expression empty-cases base case.** The old recursion produced a `false` literal as falsepart, harmless when UNSUSPEND restored the switch but a real type mismatch when the if/conditional shape survives. LOWER inserts coercion casts `JavaToLaurelCompiler` doesn't accept. Restructured to locate the default case explicitly (arrow form allows it anywhere in the list) and use its body as the innermost falsepart.

**3. Fix latent bug: switch-statement default-not-last.** `switchToIf` produced an if-cascade in source order, so `default` not last lowered to `else if (true) { ... }` making every later case unreachable — silent miscompile. Partition non-default cases from the default before building the cascade, with the default body in the trailing `else`.

**4. Fix latent bug: selector evaluated multiple times.** Selectors were inlined into every generated equality test. `switch (foo()) { case 0 -> ...; case 1 -> ...; }` lowered to `if (foo() == 0) ... else if (foo() == 1) ...` — multiple evaluations of `foo()`, costing precision in verification for impure selectors. Hoist into a fresh local (`$switchSelectorN`) and reference it from each case. For switch expressions the result is a synthesized `JCTree.LetExpr`; `JavaToLaurelCompiler#convertExpression` gains a case lowering it to a Laurel block (a `StmtExpr` usable in expression position).

**5. Make `convertStatement` renames-aware.** `convertExpression` already took a `renames` map (used to rename postcondition-lambda parameters to "result"); `convertStatement` did not. The new `LetExpr` arm reaches `convertStatement` from inside a renamed scope, so the asymmetry now matters: a hoisted-selector's `var $sel = lambdaParam` would be lowered with the original lambda-param name and Strata would see an unbound identifier. Threading `renames` through `convertStatement`, `convertBlock`, and `extractLoopParts` keeps the LetExpr arm a one-liner and prevents the same bug class in future code paths that reach `convertStatement` from a renamed scope. `SwitchDesugaring.switchInPostcondition` is the regression test.

**6. Refuse STATEMENT-form switches uniformly.** `caseToExpression` already refused STATEMENT-form non-default cases; the partition loop, however, captured a STATEMENT-form *default* case unconditionally, then wrapped its body in a plain `JCBlock`. If the body contains `break;` (targeting the original switch), the desugared form orphans that break — it now retargets the enclosing loop instead of the (now-removed) switch. Without this guard, the bug would have become a silent mistranslation when #418 (break/continue support) landed in `main`. Two-line guard at the top of `switchToIf`, symmetric with `caseToExpression`'s per-case refusal.

**7. Translate compile-time constant references in expression position.** `case CONST_INT` (where `CONST_INT` is a `static final int CONST_INT = 42`), `int x = SomeClass.MAX`, etc. javac keeps these as `JCFieldAccess` with the constant value attached on the expression's type. `JavaToLaurelCompiler#convertExpression` gains a `JCFieldAccess` arm gated on `fa.type.constValue() != null` that mirrors `convertLiteral`'s tag-based dispatch. `SwitchDesugaring.switchExprCaseConst` covers same-class and external-class constants. Empirically verified that javac's `Type.constValue()` returns `Integer` for `boolean`/`char` (not `Boolean`/`Character`), so the dispatch is on the declared type tag, not the runtime value class.

## What flips, what doesn't

`Switches.java` stays `@JVerifyTest(skip = "...")` because two of its eleven methods use `case null` on `int @Nullable []`, which depends on Step 9.

Forms `SwitchDesugarer` can't encode (case-statement groups, pattern guards, `case null`) currently fall through to LOWER, which mutates them into shapes the translator doesn't accept; those surface as method-level skips via Step 1's per-method catch in `JavaToLaurelCompiler`. Step 2b (#419) replaces those skips with diagnostic-quality refusals at SwitchDesugarer time.

## On the LetExpr arm scope

`LetExpr` is also emitted by javac's Lower for boxed compound-assign, boxed postops, switch-on-string, and pattern-matching switches. All of those require features JVerify doesn't support yet, blocking those paths before LetExpr would reach the new arm. Today, only SwitchDesugarer-synthesized LetExpr reaches it. If a future feature flip enables one of those upstream paths, the broad arm consumes those LetExprs too — semantically correct (a LetExpr is a block-with-final-expression) but a silent scope expansion worth being aware of.

## Test plan

- [x] `./gradlew :verifier:test` passes.
- [x] No new uncaught `JavaViolationException` stack traces in test output.
- [x] No green → red transitions.
- [x] `SwitchDesugaring.java` covers arrow-form switches end-to-end (statements, expressions, with default in any position, char selector, block body, non-exhaustive, non-trivial selector for hoist coverage, switch expression in postcondition lambda, compile-time constant case labels, Bad assertion).