### PR TITLE
Emit per-construct diagnostics for unsupported switch forms

### DIFF
--- a/verifier/src/main/java/org/strata/jverify/verifier/compiler/frontend/SwitchDesugarer.java
+++ b/verifier/src/main/java/org/strata/jverify/verifier/compiler/frontend/SwitchDesugarer.java
@@ -1,9 +1,11 @@
 package org.strata.jverify.verifier.compiler.frontend;
 
+import org.strata.jverify.verifier.compiler.Reporter;
 import com.sun.source.tree.CaseTree;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symtab;
 import com.sun.tools.javac.code.Type;
+import com.sun.tools.javac.code.TypeTag;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.TreeMaker;
 import com.sun.tools.javac.tree.TreeTranslator;
@@ -15,29 +17,30 @@ import com.sun.tools.javac.util.Names;
 import java.util.Optional;
 
 /// Lowers Java switch statements and switch expressions into chained
-/// if-statements and ?: conditionals respectively. Runs as its own phase in
-/// JavaLowerer's pipeline before LOWER, because LOWER would otherwise mangle
-/// switches into bytecode-flavored fall-through shapes JavaToLaurelCompiler
-/// doesn't accept.
+/// if-statements and ?: conditionals. Runs as its own phase before LOWER,
+/// which would otherwise mangle switches into bytecode-flavored fall-through
+/// that loses source positions and case structure.
 ///
 /// JavaToLaurelCompiler consumes the if/conditional shape directly, so the
-/// rewrite is one-way (no UNSUSPEND-style reversal). Forms that can't be
-/// encoded (case-statement groups, non-literal labels, pattern guards,
-/// block/throw bodies in switch expressions, `case null`) fall through to
-/// LOWER and surface as method-level skips via JavaToLaurelCompiler's
-/// per-method catch. Step 2b of PLAN.md §3 will replace those skips with
-/// per-construct refusal diagnostics emitted at this phase.
+/// rewrite is one-way. Forms that can't be encoded (case-statement groups,
+/// pattern guards, block/throw bodies in switch expressions) are caught by a
+/// pre-walk; each emits a `notSupported` diagnostic and the switch is
+/// replaced with a typed placeholder so LOWER doesn't mutate the refused
+/// tree. `case null` slips through as a `selector == null` comparison and
+/// fails at translation pending Step 9's nullable support.
 public class SwitchDesugarer extends TreeTranslator {
 
     private final TreeMaker maker;
     private final Names names;
     private final Symtab symtab;
+    private final Reporter reporter;
     private int nextSelectorIndex = 0;
 
     public SwitchDesugarer(Context context) {
         this.maker = TreeMaker.instance(context);
         this.names = Names.instance(context);
         this.symtab = Symtab.instance(context);
+        this.reporter = Reporter.instance(context);
     }
 
     public java.util.List<JCTree.JCCompilationUnit> transform(java.util.List<JCTree.JCCompilationUnit> envs) {
@@ -48,7 +51,22 @@ public class SwitchDesugarer extends TreeTranslator {
     }
 
     @Override
+    public void visitTopLevel(JCTree.JCCompilationUnit tree) {
+        reporter.compilationUnit = tree;
+        super.visitTopLevel(tree);
+    }
+
+    @Override
     public void visitSwitch(JCTree.JCSwitch tree) {
+        // Pre-walk for per-construct refusal diagnostics anchored at the
+        // offending element. Post-hoc Optional.empty() detection would only
+        // produce one method-level diagnostic.
+        var refusals = findRefusals(tree.cases, false);
+        if (!refusals.isEmpty()) {
+            emit(refusals);
+            result = maker.Block(0, List.nil());
+            return;
+        }
         var maybeIf = switchToIf(tree.selector, tree.cases, tree.isExhaustive);
         if (maybeIf.isPresent()) {
             result = maybeIf.get();
@@ -60,6 +78,15 @@ public class SwitchDesugarer extends TreeTranslator {
 
     @Override
     public void visitSwitchExpression(JCTree.JCSwitchExpression tree) {
+        var refusals = findRefusals(tree.cases, true);
+        if (!refusals.isEmpty()) {
+            emit(refusals);
+            // Typed placeholder so LOWER doesn't see the refused shape and
+            // the translator doesn't emit a duplicate skip on top of the
+            // refusals.
+            result = placeholderFor(tree.type);
+            return;
+        }
         var maybeSwitch = switchExpressionToConditional(tree.selector, tree.cases, tree.type);
         if (maybeSwitch.isPresent()) {
             result = maybeSwitch.get();
@@ -67,6 +94,60 @@ public class SwitchDesugarer extends TreeTranslator {
             return;
         }
         super.visitSwitchExpression(tree);
+    }
+
+    private record RefusalReport(JCTree node, String arg) {}
+
+    /// Collects refused constructs: STATEMENT-form (anchored at case), pattern
+    /// labels (anchored at case), and — for switch expressions only —
+    /// block/throw bodies (anchored at body). Switch-statement arrow bodies
+    /// aren't checked; body-shape issues there surface during normal statement
+    /// translation.
+    private List<RefusalReport> findRefusals(List<JCTree.JCCase> cases, boolean isSwitchExpression) {
+        var reports = new ListBuffer<RefusalReport>();
+        for (var cas : cases) {
+            if (cas.caseKind == CaseTree.CaseKind.STATEMENT) {
+                reports.append(new RefusalReport(cas, "switch labeled statement group"));
+                continue; // STATEMENT-form has cas.body == null; nothing more to check
+            }
+            for (var label : cas.labels) {
+                if (label instanceof JCTree.JCPatternCaseLabel) {
+                    reports.append(new RefusalReport(cas, "case pattern"));
+                }
+            }
+            if (isSwitchExpression) {
+                switch (cas.body) {
+                    case JCTree.JCBlock _ ->
+                        reports.append(new RefusalReport(cas.body, "switch rule block"));
+                    case JCTree.JCThrow _ ->
+                        reports.append(new RefusalReport(cas.body, "switch rule throw statement"));
+                    default -> { /* JCExpression body: OK */ }
+                }
+            }
+        }
+        return reports.toList();
+    }
+
+    private void emit(List<RefusalReport> reports) {
+        for (var r : reports) {
+            reporter.reportError(r.node(), "notSupported", r.arg());
+        }
+    }
+
+    /// Typed placeholder for a refused switch. Primitive types: zero literal.
+    /// Reference types: typed null — JavaToLaurelCompiler can't translate it
+    /// today, so the user sees an extra method-level skip on top of the
+    /// refusal-specific diagnostic. Cosmetic noise; the refusal still locates
+    /// the construct.
+    private JCTree.JCExpression placeholderFor(Type typ) {
+        if (typ != null && typ.isPrimitive()) {
+            var lit = maker.Literal(typ.getTag(), 0);
+            lit.type = typ;
+            return lit;
+        }
+        var lit = maker.Literal(TypeTag.BOT, null);
+        lit.type = typ != null ? typ : symtab.botType;
+        return lit;
     }
 
     ///
@@ -103,11 +184,11 @@ public class SwitchDesugarer extends TreeTranslator {
     /// `default` mid-cascade lowers to `else if (true) { ... }` which makes
     /// every later `else if` dead. Partition before recursing.
     ///
-    /// Returns an Optional<JCStatement>. Reaching Optional.empty() means
-    /// caseLabelToExpression rejected an unknown JCCaseLabel subclass — a
-    /// future Java version added a label kind. Defensive: skip desugaring,
-    /// LOWER may then mutate the tree unpredictably, but the user will see
-    /// errors.
+    /// Refused forms are caught upstream by findRefusals; reaching
+    /// Optional.empty() here means caseLabelToExpression hit an unknown
+    /// JCCaseLabel subclass (a future Java version added a label kind). The
+    /// bail lets LOWER process the tree, after which the translator surfaces
+    /// an error.
     ///
     private Optional<JCTree.JCStatement> switchToIf(JCTree.JCExpression selector, List<JCTree.JCCase> cases, boolean exhaustive) {
         // Refuse STATEMENT-form switches uniformly. caseToExpression already
@@ -227,11 +308,11 @@ public class SwitchDesugarer extends TreeTranslator {
     ///                      40;
     ///  }
     ///
-    /// Returns an Optional<JCExpression>. Reaching Optional.empty() means
-    /// caseLabelToExpression rejected an unknown JCCaseLabel subclass, or
-    /// the default case had a non-expression body — defensive: skip
-    /// desugaring, LOWER may then mutate the tree unpredictably, but the
-    /// user will see errors.
+    /// Refused forms are caught upstream by findRefusals; reaching
+    /// Optional.empty() here means caseLabelToExpression hit an unknown
+    /// JCCaseLabel subclass, or the default case had a non-expression body.
+    /// The bail lets LOWER process the tree, after which the translator
+    /// surfaces an error.
     ///
     private Optional<JCTree.JCExpression> switchExpressionToConditional(JCTree.JCExpression selector, List<JCTree.JCCase> cases, Type typ) {
         Optional<JCTree.JCExpression> defaultBody = Optional.empty();

--- a/verifier/src/test/java/org/strata/jverify/verifier/tests/javasupport/statements/SwitchRefusal.java
+++ b/verifier/src/test/java/org/strata/jverify/verifier/tests/javasupport/statements/SwitchRefusal.java
@@ -1,0 +1,67 @@
+package org.strata.jverify.verifier.tests.javasupport.statements;
+
+import org.strata.jverify.Contract;
+import org.strata.jverify.testengine.JVerifyTest;
+
+/**
+ * Regression test for SwitchDesugarer's refusal-time diagnostics on switch
+ * forms that can't be encoded as if/conditional chains. Each refused
+ * construct should produce a notSupported diagnostic at its source position
+ * rather than a generic JavaViolationException → method-skip.
+ *
+ * Methods are non-static deliberately. JavaToLaurelCompiler.translateStaticMethod
+ * only runs on static methods, so e.g. casePattern's `Object` parameter
+ * doesn't trigger a separate `Unsupported type` diagnostic that would clutter
+ * the diagnostic-list comparison. Refusal diagnostics fire at the desugaring
+ * phase, before any per-method translation runs.
+ */
+@JVerifyTest(exitCode = 2)
+class SwitchRefusal {
+    int statementGroup(int i) {
+        return switch (i) {
+            case 0:
+//          ^ error: switch labeled statement group is not supported
+                yield 0;
+            case 1, 2:
+//          ^ error: switch labeled statement group is not supported
+                yield 1;
+            default:
+//          ^ error: switch labeled statement group is not supported
+                yield -1;
+        };
+    }
+
+    int casePattern(Object o) {
+        return switch (o) {
+            case Integer ii when ii < 0 -> -1;
+//          ^ error: case pattern is not supported
+            default -> 0;
+        };
+    }
+
+    int blockBodyInExpression(int i) {
+        return switch (i) {
+            case 0 -> {
+//                    ^ error: switch rule block is not supported
+                yield 0;
+            }
+            default -> 1;
+        };
+    }
+
+    int throwBodyInExpression(int i) {
+        return switch (i) {
+            case 0 -> throw new RuntimeException();
+//                    ^ error: switch rule throw statement is not supported
+            default -> 1;
+        };
+    }
+
+    // RuntimeException needs a contract; without it MissingContractCompiler
+    // emits a warning that adds noise to the diagnostic-list comparison.
+    @Contract(RuntimeException.class)
+    static class RuntimeExceptionContract {
+        public RuntimeExceptionContract() {
+        }
+    }
+}

--- a/verifier/src/test/java/org/strata/jverify/verifier/tests/javasupport/statements/TranslationErrors.java
+++ b/verifier/src/test/java/org/strata/jverify/verifier/tests/javasupport/statements/TranslationErrors.java
@@ -50,8 +50,6 @@ class TranslationErrors {
                 yield 0;
             case 1, 2, 3:
 //          ^ error: switch labeled statement group is not supported
-//          ^ error: switch labeled statement group is not supported
-//          ^ error: switch labeled statement group is not supported
                 acc += 200;
                 yield i * 2;
             default:
@@ -65,7 +63,6 @@ class TranslationErrors {
         return switch (i) {
             case 0, 1 -> 0;
             case 1 + 1 -> 1;
-//                 ^ error: non-literal case constant is not supported
             default -> 2;
         };
     }
@@ -92,8 +89,6 @@ class TranslationErrors {
         return switch (i) {
             case 0 -> 0;
             case 1, 2, 3 -> {
-//          ^ error: switch labeled statement group is not supported
-//          ^ error: switch labeled statement group is not supported
 //                          ^ error: switch rule block is not supported
                 var acc = 0;
                 for (int j = 0; j < i; j++) {
@@ -110,7 +105,6 @@ class TranslationErrors {
             case 0 -> throw new RuntimeException();
 //                    ^ error: switch rule throw statement is not supported
             case 1, 2 -> -i;
-//          ^ error: switch labeled statement group is not supported
             default -> i * i * i;
         };
     }


### PR DESCRIPTION
Step 2b of PLAN.md §3 — refusal-time diagnostics for switch forms `SwitchDesugarer` can't encode as if/conditional chains.

## Resolves

- #401 (switch encoding) — together with #417, this closes the switch-desugaring portion. `case null` is deferred to Step 9 alongside Option-type synthesis.

## Summary

`SwitchDesugarer`'s `switchToIf`/`switchExpressionToConditional` return `Optional.empty()` for forms they can't encode. Today those refused trees fall through to LOWER, which mutates them into shapes `JavaToLaurelCompiler` can't translate, surfacing as a `JavaViolationException` → method-level skip via Step 1's catch. The error points at the method, not the offending construct.

This PR replaces the fall-through with refusal-time diagnostics emitted at each offending element's source position. The check happens at the SwitchDesugarer phase, before LOWER runs:

| Construct | Diagnostic | Anchor |
|---|---|---|
| `case A:` (statement-form) | `notSupported "switch labeled statement group"` | case node |
| `case Pattern p when ...` | `notSupported "case pattern"` | case node |
| `case 0 -> { block }` (switch expr only) | `notSupported "switch rule block"` | body |
| `case 0 -> throw ...` (switch expr only) | `notSupported "switch rule throw statement"` | body |

After diagnostics, the offending switch is replaced with a typed placeholder (empty block for statement form, typed-zero / typed-null literal for expression form) so LOWER doesn't see the refused tree shape and `JavaToLaurelCompiler` doesn't emit a duplicate generic-skip diagnostic on top of the refusal-specific ones.

## Implementation notes

**Pre-walk for refusal detection.** A pre-walk (`findRefusals`) inspects all labels and body shapes before encoding and is the source of truth for refusal. Post-hoc `Optional.empty()` detection isn't sufficient: the encoder silently accepts pattern labels and statement-form bodies in some shapes.

**One diagnostic per case for STATEMENT-form.** `case 1, 2, 3:` emits a single "switch labeled statement group" diagnostic anchored at the case node. The label count is incidental to the refusal (the `:` makes it STATEMENT-form regardless of how many labels are listed); separate per-label diagnostics added noise without locating distinct constructs.

**Reference-typed switch expressions.** Pattern-label refusals on a reference-typed expression switch substitute a typed-null placeholder. The placeholder reaches `JavaToLaurelCompiler.convertLiteral` which doesn't handle `BOT` and surfaces a method-level skip via Step 1's catch — adding a generic diagnostic on top of the refusal-specific one. Cosmetic noise, not wrong; the refusal-specific diagnostic still locates the offending construct precisely.

## Fixture changes

`TranslationErrors.java` stays `@JVerifyTest(skip = "...")` — its non-switch markers (lines 18, 24, 125, 148, 155, 160, 183) gate the file flip on Steps 8-9. Two aspirational "switch labeled statement group" markers on multi-label arrow cases (lines 94 and 112) removed: those weren't real refusal targets, multi-label arrow form with a valid body is supported by Step 2a (`Switches.switchExprInt` exercises `case 1, 2 -> 20;` and verifies). Duplicate per-label markers on multi-label statement-form cases collapsed to one-per-case. The aspirational `^ error: non-literal case constant` marker on `case 1 + 1` is also removed: that form is now supported by 2a's compile-time-constant arm in `convertExpression`. When the rest of the fixture clears in Steps 8-9, `TranslationErrors` will flip cleanly.

## Test plan

- [x] `./gradlew :verifier:test` passes.
- [x] No new uncaught `JavaViolationException` stack traces in test output.
- [x] No green → red transitions.
- [x] `SwitchRefusal.java` covers the four refusal classes end-to-end.