### PR TITLE
improve prerequisites in installation guide

### DIFF
--- a/docs/guide/src/installation.md
+++ b/docs/guide/src/installation.md
@@ -5,8 +5,10 @@ JVerify can currently only be used by building it from source.
 ## Prerequisites
 
 1. **Java 23.** If you have a different default Java version installed, pass `-Dorg.gradle.java.home=path-to-java-23` to the gradle commands below.
-2. **[Lean 4](https://lean-lang.org/)** (via `elan`) — needed to build the [Strata](https://github.com/strata-org/Strata) verification back-end.
-3. **[cvc5](https://cvc5.github.io/)** SMT solver on your `PATH`.
+2. **Java 17.** Required by the subprojects library, common, and javac-plugin.
+3. **[Lean 4](https://lean-lang.org/)** (via `elan`) — needed to build the [Strata](https://github.com/strata-org/Strata) verification back-end.
+4. **[cvc5](https://cvc5.github.io/)** SMT solver on your `PATH`.
+5. **[z3](https://github.com/Z3Prover/z3)** SMT solver (v4.15.2 recommended) on your `PATH`. 
 
 ## Building
 


### PR DESCRIPTION
### What was changed?
Added two missing prerequisites to [installation.md](https://github.com/strata-org/jverify/blob/main/docs/guide/src/installation.md):

**Java 17** — `build.gradle.kts` sets `languageVersion = JavaLanguageVersion.of(17)` on `library`, `common`, and `javac-plugin` subprojects.

**z3** — `LaurelDriver.java:112` passes `--solver z3` to the Strata back-end. Without z3 on PATH the verifier fails at runtime. 


### How has this been tested?
Manually tested by running the verifier as described in [first_verification.md](https://github.com/strata-org/jverify/blob/main/docs/guide/src/first_verification.md)

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/strata-org/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
