### PR TITLE
do-while desugaring

### DIFF
--- a/verifier/src/main/java/org/strata/jverify/verifier/compiler/generator/laurel/JavaToLaurelCompiler.java
+++ b/verifier/src/main/java/org/strata/jverify/verifier/compiler/generator/laurel/JavaToLaurelCompiler.java
@@ -152,6 +152,7 @@ public class JavaToLaurelCompiler {
                 // Don't descend into nested loops — their break/continue don't target us
                 @Override public void visitWhileLoop(JCTree.JCWhileLoop tree) {}
                 @Override public void visitForLoop(JCTree.JCForLoop tree) {}
+                @Override public void visitDoLoop(JCTree.JCDoWhileLoop tree) {}
             });
             return found[0];
         }
@@ -415,6 +416,38 @@ public class JavaToLaurelCompiler {
                         return emitLoop(sr, cond, parts.invariants, parts.body, step, List.of(init),
                                 breakLbl, continueLbl);
                     });
+                }
+                case JCTree.JCDoWhileLoop doWhile -> {
+                    // Desugar do-while using while(true) + exit(!cond):
+                    //   labelledBlock(breakLbl, [
+                    //     while (true) invariants:[I] {
+                    //       labelledBlock(continueLbl, [ body ]);
+                    //       if (!cond) exit(breakLbl);
+                    //     }
+                    //   ])
+                    // The exit(!cond) is OUTSIDE the continueLbl block so that
+                    // continue re-evaluates the condition (doesn't skip it).
+                    // Invariant is checked at while-entry before every iteration
+                    // including the first — no soundness gap as discussed in #418.
+                    var sr = toSourceRange(doWhile);
+                    // Do-while always needs labels: the desugaring itself uses exit(breakLbl)
+                    var breakLbl = freshLabel("loop_break");
+                    var continueLbl = freshLabel("loop_continue");
+                    var javaLabel = pendingLabel;
+                    pendingLabel = null;
+                    labelStack.push(new LabelEntry(javaLabel, breakLbl, continueLbl));
+                    try {
+                        var cond = convertExpression(doWhile.cond, renames);
+                        var parts = extractLoopParts(doWhile.body, renames);
+                        var exitIfDone = ifThenElse(sr, not(sr, cond),
+                                exit(sr, breakLbl), Optional.empty());
+                        var wrappedBody = labelledBlock(sr, List.of(parts.body), continueLbl);
+                        var whileBody = block(sr, List.of(wrappedBody, exitIfDone));
+                        var whileNode = while_(sr, literalBool(sr, true), parts.invariants, whileBody);
+                        yield labelledBlock(sr, List.of(whileNode), breakLbl);
+                    } finally {
+                        labelStack.pop();
+                    }
                 }
                 case JCTree.JCBreak breakStmt -> {
                     yield exit(toSourceRange(breakStmt), resolveBreakLabel(breakStmt));

--- a/verifier/src/test/java/org/strata/jverify/verifier/tests/javasupport/statements/VerifyDoWhile.java
+++ b/verifier/src/test/java/org/strata/jverify/verifier/tests/javasupport/statements/VerifyDoWhile.java
@@ -1,0 +1,69 @@
+package org.strata.jverify.verifier.tests.javasupport.statements;
+
+import org.strata.jverify.testengine.JVerifyTest;
+
+import static org.strata.jverify.JVerify.*;
+
+@SuppressWarnings({"ConstantValue"})
+@JVerifyTest(exitCode = 4, methodsVerified = 4, errorCount = 1)
+class VerifyDoWhile {
+    /**
+     * do-while with break exiting the loop early.
+     */
+    static void doWhileWithBreak() {
+        int x = 0;
+        do {
+            invariant(x >= 0 && x <= 3);
+            if (x == 3) {
+                break;
+            }
+            x = x + 1;
+        } while (x < 10);
+        check(x == 3);
+    }
+
+    /**
+     * do-while with continue re-evaluating the condition.
+     * When continue is hit, execution should skip the rest of the body
+     * but still check the while-condition.
+     */
+    static void doWhileWithContinue() {
+        int x = 0;
+        int sum = 0;
+        do {
+            invariant(x >= 0 && x <= 5);
+            invariant(x <= 2 ? sum == x : sum == 2);
+            if (x >= 2) {
+                x = x + 1;
+                continue;
+            }
+            sum = sum + 1;
+            x = x + 1;
+        } while (x < 5);
+        check(sum == 2);
+    }
+
+    /**
+     * Numeric loop variable bounded by the invariant.
+     * Exercises the sentinel-weakening case (Bug 2) from the original review in #418.
+     */
+    static void doWhileNumericInvariant() {
+        int x = 0;
+        do {
+            invariant(0 <= x && x < 100);
+            x = x + 1;
+        } while (x < 5);
+        check(x >= 5);
+    }
+
+    /**
+     * Negative regression test for unsoundness case (Bug 3) from the original review in #418:
+     * The invariant is FALSE on the first iteration (x == -1 violates x >= 0).
+     * This MUST be rejected by the verifier.
+     */
+    static void doWhileBadInitialInvariant() {
+        int x = -1;
+        do { invariant(x >= 0); x = x + 1; } while (x < 5);
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Error: assertion could not be proved
+    }
+}


### PR DESCRIPTION
<!-- Please remove these Markdown comments before publishing this PR, since the PR message is often used as the commit description. 
We only allow squash merging and GH suggests the PR details as a default commit message. -->

### What was changed?
Implements do-while loop desugaring as described in #421, i.e., the while(true) + exit(!cond) approach from the prototype branch over the body-duplication approach that was reverted in #418.

Desugaring shape:


```
labelledBlock(breakLbl, [
    while (true) invariants:[I] {
        labelledBlock(continueLbl, [body]);
        if (!cond) exit(breakLbl);
    }
])
```


Why this approach (per the design discussion in #418 and #421):

Invariant is checked at while-entry before every iteration including the first — fixes the soundness gap where body-duplication silently passed invariants that were false at first iteration (Bug 3 in #421)
No body duplication, single extractLoopParts call
Correct continue semantics: `exit(continueLbl)` skips the rest of the body but falls through to the condition check — the if `(!cond) exit(breakLbl)` is outside the continue-labelled block (as called out in #421)

####  Changes: 

`JavaToLaurelCompiler.java`: Added case `JCTree.JCDoWhileLoop` in `convertStatement`, and added `visitDoLoop` override in `containsBreakOrContinue`
`VerifyDoWhile.java:` New test file with the 4 test cases requested in #421
Resolves #421. Parent: #407.

### How has this been tested?
New test file `VerifyDoWhile.java` with the tests specified in #421:

`doWhileWithBreak` — do-while with break exiting the loop
`doWhileWithContinue` — do-while with continue re-evaluating the condition
`doWhileNumericInvariant` — numeric loop variable bounded by the invariant with decreases clause (the Bug 2 sentinel-weakening case from #418)
`doWhileBadInitialInvariant` — negative regression test for the Bug 3 unsoundness (invariant false at first iteration, correctly rejected with "assertion could not be proved")
Additionally:

Existing `cVerifyStatements.doWhileLoop()` passes
Full `./gradlew :verifier:test` suite passes



**Follow-up**: When a do-while invariant fails, the error range covers the entire do-while statement (e.g., do { ... } while (cond);) rather than pointing at just the invariant(...) expression. So `doWhileBadInitialInvariant` in `VerifyDoWhile` uses a single-line do-while — it's the only way the test annotation can match the reported range. I believe this should be improved to provide more a fine-grained error message. The follow up issue: #437


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/strata-org/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
