### PR TITLE
Bump Strata to latest and adapt to StrataCLI sub-package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 generate-laurel-ast:
 	rm -rf verifier/src/main/java/org/strata/jverify/laurel
-	cd Strata && lake exe strata javaGen Laurel org.strata.jverify.laurel ../verifier/src/main/java
+	cd Strata/StrataCLI && lake exe strata javaGen Laurel org.strata.jverify.laurel ../../verifier/src/main/java

--- a/docs/guide/src/installation.md
+++ b/docs/guide/src/installation.md
@@ -22,12 +22,15 @@ JVerify can currently only be used by building it from source.
    ./gradlew installDist     # macOS / Linux
    ./gradlew.bat installDist # Windows
    ```
-4. Build the Strata back-end:
+4. Build the Strata back-end. The `strata` command-line executable lives in the `StrataCLI`
+   sub-package, so build from there (this also builds the `Strata` library it depends on):
    ```
-   cd Strata && lake build && cd ..
+   cd Strata/StrataCLI && lake build && cd ../..
    ```
 5. Point JVerify at the Strata project directory by setting the `JVERIFY_STRATA` environment variable:
    ```
    export JVERIFY_STRATA=$(pwd)/Strata
    ```
-   (or pass `--strata /path/to/Strata` on every JVerify invocation).
+   (or pass `--strata /path/to/Strata` on every JVerify invocation). This is the Strata
+   repository root, *not* the `StrataCLI` sub-directory — JVerify locates the `strata`
+   executable under `StrataCLI` itself.

--- a/verifier/src/main/java/org/strata/jverify/verifier/laurel/LaurelDriver.java
+++ b/verifier/src/main/java/org/strata/jverify/verifier/laurel/LaurelDriver.java
@@ -110,7 +110,8 @@ public class LaurelDriver implements Driver {
         var processBuilder = new ProcessBuilder(
                 "lake", "exe", "-q", "strata", "laurelAnalyzeBinary", "--solver", "z3"
         );
-        processBuilder.directory(verifierOptions.backendPath().toFile());
+        // The `strata` executable lives in the StrataCLI subpackage, so `lake` must be invoked from there.
+        processBuilder.directory(verifierOptions.backendPath().resolve("StrataCLI").toFile());
         return verifierOptions.time("Running Strata", () -> {
             try (var process = new AutoClosingProcessWrapper(processBuilder.redirectErrorStream(true).start()))
             {


### PR DESCRIPTION
Strata moved the `strata` command-line executable out of the repo root into a new `StrataCLI` sub-package, so `lake exe strata ...` now only resolves when run from `Strata/StrataCLI`. Update the two places JVerify shells out to Strata accordingly:

- Makefile (generate-laurel-ast): run from Strata/StrataCLI
- LaurelDriver: invoke `lake` from backendPath()/StrataCLI

JVERIFY_STRATA continues to point at the Strata repository root. The regenerated Laurel AST is byte-identical, and the full test suite passes.

Also document the new structure in the installation guide.

<!-- Please remove these Markdown comments before publishing this PR, since the PR message is often used as the commit description. 
We only allow squash merging and GH suggests the PR details as a default commit message. -->

### What was changed?
<!-- Is this a user-visible change? Remember to update RELEASE_NOTES.md -->

### How has this been tested?

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/strata-org/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
