### PR TITLE
Migrate from Java 23 / Gradle 8.14 to Java 25 / Gradle 9.4.0

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
-          java-version: '23'
+          java-version: '25'
           cache: gradle
       - name: Build Strata
         uses: leanprover/lean-action@v1

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ allprojects {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(23))
+        languageVersion.set(JavaLanguageVersion.of(25))
     }
 }
 
@@ -374,6 +374,9 @@ project(":test-engine") {
         // Must be transitive in order to export our engine, which subclasses HierarchicalTestEngine
         api("org.junit.platform:junit-platform-engine:1.12.2")
 
+        // Explicit junit-platform-launcher dependency ensures alignment of JUnit artifacts on test runtime classpath.
+        testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
         implementation("org.hamcrest:hamcrest:2.2")
         implementation("org.hamcrest:hamcrest-library:2.2")
 
@@ -382,6 +385,10 @@ project(":test-engine") {
         // for test engine registration
         implementation("com.google.auto.service:auto-service-annotations:1.0.1")
         annotationProcessor("com.google.auto.service:auto-service:1.0.1")
+    }
+
+    tasks.test {
+        useJUnitPlatform()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Java 23 does not seem to be widely available (missing in Homebrew, Ubuntu 24, for example). Upgrade the main project toolchain to Java 25 (the installed JDK) and the Gradle wrapper to 9.4.0 (the first Gradle version with Java 25 support). Subprojects targeting Java 17 are unchanged — they use the Java 17 toolchain via Gradle's toolchain auto-detection.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/strata-org/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
