### PR TITLE
JVerify front-end: set synthetic constructor type to fix javac Lower NPE

### DIFF
--- a/verifier/src/main/java/org/strata/jverify/verifier/compiler/simplifications/LambdaToAnonymousClassCompiler.java
+++ b/verifier/src/main/java/org/strata/jverify/verifier/compiler/simplifications/LambdaToAnonymousClassCompiler.java
@@ -215,6 +215,13 @@ public class LambdaToAnonymousClassCompiler extends TreeTranslator {
                 null
         );
         result.sym = methodSymbol;
+        // Without setting result.type, javac's Lower.visitMethodDef
+        // (Lower.java:2664) NPEs on tree.type.getReturnType() when
+        // walking the synthetic anonymous class.
+        // createImplementationMethod sets it for the SAM method; mirror
+        // that here for the synthetic constructor so both methods of the
+        // lambda's anonymous class survive Lower.
+        result.type = methodSymbol.type;
         return result;
     }
 


### PR DESCRIPTION
LambdaToAnonymousClassCompiler.createConstructor missed setting result.type, causing javac's Lower.visitMethodDef:2664 to NPE on tree.type.getReturnType() when walking the synthetic anonymous class. Mirror what createImplementationMethod already does.


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/strata-org/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
