### PR TITLE
Avoid 'result' name clash when a user parameter is named result

### DIFF
--- a/verifier/src/main/java/org/strata/jverify/verifier/compiler/generator/laurel/JavaToLaurelCompiler.java
+++ b/verifier/src/main/java/org/strata/jverify/verifier/compiler/generator/laurel/JavaToLaurelCompiler.java
@@ -143,6 +143,18 @@ public class JavaToLaurelCompiler {
         private final Deque<LabelEntry> labelStack = new ArrayDeque<>();
         private String pendingLabel = null;
 
+        // Per-method parameter renames. Set at the start of
+        // visitMethodDef when a parameter name clashes with a
+        // Laurel-reserved identifier (currently only "result").
+        // Saved / restored per method visit (see visitMethodDef)
+        // so renames stay scoped to the method subtree. Read by
+        // the single-arg convertExpression / convertStatement
+        // overloads as the default renames map, so the rewrite
+        // propagates into precondition / postcondition /
+        // assertion / body translations without threading the
+        // map manually through every call site.
+        private Map<String, String> currentParamRenames = Map.of();
+
         /** Check if a statement tree contains break or continue (at the current loop level). */
         private boolean containsBreakOrContinue(JCTree.JCStatement stmt) {
             boolean[] found = {false};
@@ -203,15 +215,23 @@ public class JavaToLaurelCompiler {
 
         @Override
         public void visitMethodDef(JCTree.JCMethodDecl method) {
-            if ((method.mods.flags & Flags.STATIC) != 0) {
-                try {
-                    translateStaticMethod(method);
-                } catch (JavaViolationException e) {
-                    reporter.reportError(method, "translatorError", e.getMessage());
-                    annotationCompiler.markSkipped(currentCompilationUnit, method);
+            // Save / restore the per-method rename state so it stays
+            // scoped to this method (and its nested declarations) and
+            // never leaks to sibling methods.
+            Map<String, String> previousParamRenames = currentParamRenames;
+            try {
+                if ((method.mods.flags & Flags.STATIC) != 0) {
+                    try {
+                        translateStaticMethod(method);
+                    } catch (JavaViolationException e) {
+                        reporter.reportError(method, "translatorError", e.getMessage());
+                        annotationCompiler.markSkipped(currentCompilationUnit, method);
+                    }
                 }
+                super.visitMethodDef(method);
+            } finally {
+                currentParamRenames = previousParamRenames;
             }
-            super.visitMethodDef(method);
         }
 
         private void translateStaticMethod(JCTree.JCMethodDecl method) {
@@ -220,9 +240,34 @@ public class JavaToLaurelCompiler {
             String methodName = qualifiedMethodName(method.sym);
 
             List<Parameter> params = new ArrayList<>();
+            // When a user parameter is literally named "result"
+            // it would clash with Strata's reserved binding for
+            // the procedure return value (which the
+            // postcondition lambda also renames to). Rename
+            // the parameter to a fresh name and propagate the
+            // rewrite into all body / contract conversions
+            // via currentParamRenames (a visitor-scope field).
+            Set<String> existingParamNames = new HashSet<>();
             for (var param : method.params) {
-                params.add(parameter(param.name.toString(), translateType(param.type)));
+                existingParamNames.add(param.name.toString());
             }
+            Map<String, String> paramRenames = new HashMap<>();
+            for (var param : method.params) {
+                String pname = param.name.toString();
+                if (pname.equals("result")) {
+                    // Pick a target that does not collide with any
+                    // other parameter, so the rename cannot
+                    // reintroduce the very clash we are avoiding.
+                    String renamed = freshName("__user_result", existingParamNames);
+                    paramRenames.put(pname, renamed);
+                    pname = renamed;
+                }
+                params.add(parameter(pname, translateType(param.type)));
+            }
+            // Map.copyOf is an immutable snapshot, so the per-method
+            // rename state cannot be mutated in place; visitMethodDef
+            // saves and restores this field around the subtree.
+            currentParamRenames = Map.copyOf(paramRenames);
 
             Optional<ReturnType> retType = Optional.empty();
             if (method.restype != null && method.restype.type != null
@@ -243,7 +288,14 @@ public class JavaToLaurelCompiler {
                     var postExpr = post.get();
                     if (postExpr instanceof JCTree.JCLambda lambda && lambda.params.size() == 1) {
                         var paramName = lambda.params.getFirst().name.toString();
-                        var renames = Map.of(paramName, "result");
+                        // result is Strata-canonical for return
+                        // bindings. Combine the lambda-parameter
+                        // rename with the user-parameter renames
+                        // (e.g. when a parameter is named
+                        // "result") so both rewrites apply
+                        // inside the postcondition body.
+                        Map<String, String> renames = new HashMap<>(paramRenames);
+                        renames.put(paramName, "result");
                         ensures.add(ensuresClause(convertLambdaBody(lambda, renames), Optional.empty()));
                     } else {
                         ensures.add(ensuresClause(convertExpression(postExpr), Optional.empty()));
@@ -284,6 +336,22 @@ public class JavaToLaurelCompiler {
                     : procedure(toSourceRange(method), methodName, params,
                             retType, Optional.empty(), requires, Optional.empty(), optSpec, optBody);
             procedures.add(proc);
+        }
+
+        /// Returns `base` if it is not already present in `taken`,
+        /// otherwise appends the smallest positive integer suffix
+        /// that makes the name unique. Used to choose a rename
+        /// target for a user parameter named "result" that cannot
+        /// collide with another parameter in the same procedure.
+        private static String freshName(String base, Set<String> taken) {
+            if (!taken.contains(base)) {
+                return base;
+            }
+            int suffix = 1;
+            while (taken.contains(base + suffix)) {
+                suffix++;
+            }
+            return base + suffix;
         }
 
         private StmtExpr convertBlock(JCTree.JCBlock blk, Map<String, String> renames) {
@@ -450,7 +518,11 @@ public class JavaToLaurelCompiler {
         }
 
         private StmtExpr convertExpression(JCTree.JCExpression expr) {
-            return convertExpression(expr, Map.of());
+            // Use the per-method parameter renames so any
+            // user-parameter rewrite (e.g. "result" -> "__user_result")
+            // is applied transparently throughout the method's
+            // contracts and body.
+            return convertExpression(expr, currentParamRenames);
         }
 
         private StmtExpr convertLambdaBody(JCTree.JCLambda lambda, Map<String, String> renames) {


### PR DESCRIPTION
Strata uses 'result' as the canonical binding for a procedure's return value in postcondition (ensures) clauses; JVerify's translator already renames the postcondition lambda's parameter to 'result' so the ensures expression refers to the return correctly. With BOTH the user parameter AND the renamed lambda variable mapped to 'result' in the same procedure scope, Strata complained:

  <unknown>(1:1-1:1): Error: Duplicate definition 'result'
                            is already defined in this scope

Fix: rename the user's parameter (only) when its name is exactly 'result'. The rename is applied to:

  * The Laurel parameter declaration (so the procedure signature declares the renamed parameter instead of result).
  * The current method's preconditions, postconditions, and body via a per-method currentParamRenames field on the StaticMethodCollector visitor that the single-arg convertExpression / convertStatement overloads consult.  This avoids threading a renames Map through every recursive call site (~30+ locations in convertStatement alone).

Rename target: the base is '__user_result' (leading-underscore convention mirrors the JVerify shim's __jverify_old_<n> capture names, and it is obvious in raw_stdout / line-map diagnostics).  Rather than trusting that base to be unique, freshName() checks it against the procedure's other parameter names and appends the smallest integer suffix needed, so the rename can never reintroduce the very duplicate-definition clash it avoids.  (Residual: a body-local variable literally named '__user_result' is not yet considered; full identifier hygiene would require scanning the method body.)

Robustness of the visitor-scope field (per review feedback):

  * currentParamRenames is declared private and holds an immutable Map.copyOf snapshot, so the per-method rename state cannot be mutated in place.
  * visitMethodDef saves and restores the field in a try/finally, scoping renames to the method (and its nested declarations) and guaranteeing no state leaks to sibling methods.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/strata-org/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
