### PR TITLE
Fix hat-annotation span when the annotated line is the first line

### DIFF
--- a/test-engine/src/main/java/org/strata/jverify/testengine/TestMarkup.java
+++ b/test-engine/src/main/java/org/strata/jverify/testengine/TestMarkup.java
@@ -44,6 +44,13 @@ public class TestMarkup {
     private static final String SPAN_START_STRING = "[>";
     private static final String SPAN_END_STRING = "<]";
 
+    /**
+     * Sentinel for {@code annotatedIndex} meaning "no preceding
+     * non-annotation line has been seen yet". 0 cannot be used
+     * because it is a valid line index.
+     */
+    private static final int NO_ANNOTATED_INDEX = -1;
+
     private static String parse(String input, List<Integer> positions, List<AnnotatedSpan> spans) {
 
         var outputParts = parseParts(input, positions, spans);
@@ -130,7 +137,8 @@ public class TestMarkup {
 
         int[] cumulativePositions = new int[lines.length];
         cumulativePositions[0] = 0;
-        int annotatedIndex = 0;
+        // 0 cannot be the sentinel because it is a valid line index.
+        int annotatedIndex = NO_ANNOTATED_INDEX;
         for (int i = 0; i < lines.length; i++) {
             if (i > 0) {
                 cumulativePositions[i] = cumulativePositions[i - 1] + lines[i - 1].length() + 1; // +1 for newline
@@ -146,7 +154,7 @@ public class TestMarkup {
 
                 int caretStartIndex = nextLine.indexOf(carets);
 
-                if (annotatedIndex == 0) {
+                if (annotatedIndex == NO_ANNOTATED_INDEX) {
                     TextSpan span = new TextSpan(0, 1);
                     result.add(new AnnotatedSpan(annotation, span));
                     continue;


### PR DESCRIPTION
findHatAnnotationSpans used annotatedIndex == 0 as a sentinel for "no preceding code line has been seen yet". Because 0 is also a valid line index, a '// ^^^^^' annotation attached to the very first line wrongly took the fallback branch and produced TextSpan(0, 1) instead of the real caret range.

Use a named NO_ANNOTATED_INDEX (= -1) sentinel so line 0 is treated as a normal annotated line. The named constant (rather than a bare -1 literal) documents the sentinel's meaning at the declaration, the initialization, and the check.

This bug was previously masked because the test-engine unit tests were never being discovered; they will run once #429 is merged and TestMarkupTest.testHatAnnotations passes with this fix.


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/strata-org/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
