### PR TITLE
Support 0-argument precondition/postcondition lambdas (e.g. for void methods)

### DIFF
--- a/library/src/main/java/org/strata/jverify/JVerify.java
+++ b/library/src/main/java/org/strata/jverify/JVerify.java
@@ -80,6 +80,18 @@ public class JVerify {
     }
 
     /**
+     * Declare a postcondition for a void method (or any method whose return
+     * value is not needed). The {@link BooleanSupplier} takes no arguments and
+     * captures the enclosing scope directly, e.g.
+     * {@code postcondition(() -> x >= 0)}.
+     * <p>
+     * Like the other JVerify contract primitives, this is a marker interpreted
+     * by the verifier and has no effect at runtime.
+     */
+    public static void postcondition(BooleanSupplier predicate) {
+    }
+
+    /**
      * Return the precondition of the given expression
      * Currently only works when the expression is a method call
      * and only works for method calls that return a value.

--- a/verifier/src/main/java/org/strata/jverify/verifier/compiler/generator/laurel/JavaToLaurelCompiler.java
+++ b/verifier/src/main/java/org/strata/jverify/verifier/compiler/generator/laurel/JavaToLaurelCompiler.java
@@ -26,6 +26,11 @@ import java.util.*;
 import static org.strata.jverify.laurel.Laurel.*;
 
 public class JavaToLaurelCompiler {
+    /// The name Laurel binds a procedure's return value to inside ensures
+    /// clauses. A 1-parameter postcondition lambda's parameter is renamed
+    /// to this so the clause refers to the return value correctly.
+    private static final String LAUREL_RESULT_BINDING = "result";
+
     private final JavaLowerer lowerer;
     private final MethodOrLoopContractCompiler contractCompiler;
     private final JVerifyUtils jverifyUtils;
@@ -238,13 +243,24 @@ public class JavaToLaurelCompiler {
             if (method.body != null) {
                 MethodOrLoopContract contract = contractCompiler.getContract(method.body);
                 for (var pre : contract.preconditions()) {
-                    requires.add(requiresClause(convertExpression(pre.get()), Optional.empty()));
+                    var preExpr = pre.get();
+                    StmtExpr converted = (preExpr instanceof JCTree.JCLambda lambda)
+                            ? convertLambdaBody(lambda, Map.of())
+                            : convertExpression(preExpr);
+                    requires.add(requiresClause(converted, Optional.empty()));
                 }
                 for (var post : contract.postconditions()) {
                     var postExpr = post.get();
-                    if (postExpr instanceof JCTree.JCLambda lambda && lambda.params.size() == 1) {
-                        var paramName = lambda.params.getFirst().name.toString();
-                        var renames = Map.of(paramName, "result");
+                    if (postExpr instanceof JCTree.JCLambda lambda) {
+                        // A 1-param postcondition lambda binds the return
+                        // value (renamed to Laurel's canonical
+                        // LAUREL_RESULT_BINDING); a 0-param lambda
+                        // (postcondition(BooleanSupplier), e.g. on a void
+                        // method) captures the enclosing scope directly and
+                        // needs no rename.
+                        Map<String, String> renames = lambda.params.size() == 1
+                                ? Map.of(lambda.params.getFirst().name.toString(), LAUREL_RESULT_BINDING)
+                                : Map.of();
                         ensures.add(ensuresClause(convertLambdaBody(lambda, renames), Optional.empty()));
                     } else {
                         ensures.add(ensuresClause(convertExpression(postExpr), Optional.empty()));

--- a/verifier/src/test/java/org/strata/jverify/verifier/tests/verification/MethodContractsVerification.java
+++ b/verifier/src/test/java/org/strata/jverify/verifier/tests/verification/MethodContractsVerification.java
@@ -10,7 +10,7 @@ import java.util.function.IntPredicate;
 import static org.strata.jverify.JVerify.postcondition;
 import static org.strata.jverify.JVerify.precondition;
 
-@JVerifyTest(methodsVerified = 10, errorCount = 0)
+@JVerifyTest(methodsVerified = 11, errorCount = 0)
 public class MethodContractsVerification {
 
     private int y;
@@ -56,6 +56,15 @@ public class MethodContractsVerification {
         int res;
         res = x;
         return res;
+    }
+
+    // 0-argument postcondition (postcondition(BooleanSupplier)): the lambda
+    // takes no parameters and captures the enclosing scope directly rather
+    // than binding the return value. Paired with a 0-argument precondition.
+    int zeroArgPostcondition(int x) {
+        precondition(() -> x > 0);
+        postcondition(() -> x > 0);
+        return x;
     }
 
     /**


### PR DESCRIPTION
### What was changed?

Adds the `postcondition(BooleanSupplier)` overload (the 0-argument form, for void methods or any method whose return value is not needed) **and makes the 0-argument pre/postcondition forms actually work** in the Java → Laurel front end.

Previously the API existed (`postcondition(BooleanSupplier)` is new here; `precondition(BooleanSupplier)` already existed) but **neither was functional**: `translateStaticMethod` only special-cased a 1-parameter postcondition lambda and converted preconditions via `convertExpression`, which has no `JCLambda` case — so a 0-argument `() -> …` raised `Unsupported expression: JCLambda`.

Now:
- **preconditions** — a lambda argument is converted via `convertLambdaBody` (no rename); a plain expression behaves as before.
- **postconditions** — any lambda is converted via `convertLambdaBody`, binding the return value to Laurel's result binding (named via the `LAUREL_RESULT_BINDING` constant) only for the 1-parameter form; the 0-parameter form captures the enclosing scope directly.

### How has this been tested?

Adds a 0-argument pre/postcondition case to `MethodContractsVerification` (rather than a separate `@JVerifyTest`, to avoid the per-test overhead). `./gradlew :verifier:test` passes.

### Known follow-up

A *failing* 0-argument postcondition currently reports at `1:1` (the lambda body's source range is not yet threaded into the diagnostic). Tracked as a follow-up; it does not affect verification outcomes.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/strata-org/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
