### PR TITLE
Add an assigns(...) write-frame declaration to the JVerify contract API

### DIFF
--- a/library/src/main/java/org/strata/jverify/JVerify.java
+++ b/library/src/main/java/org/strata/jverify/JVerify.java
@@ -61,6 +61,15 @@ public class JVerify {
     public static void decreases(int value) {}
     public static void decreases(int value1, int value2) {}
 
+    /**
+     * Declare the frame of writes a method may perform.
+     * Each argument names a target the method is permitted to write
+     * (a field, an array slot, a static, etc.). At a modular call
+     * site, only the named targets will be havocked; everything else is
+     * preserved. The shape parallels CBMC's __CPROVER_assigns(...).
+     */
+    public static void assigns(Object... targets) {}
+
     public static void invariant(boolean condition) {
     }
     


### PR DESCRIPTION
Introduce JVerify.assigns(Object... targets) alongside the existing contract-declaration primitives (decreases / reads / modifies). Each argument names a target the method is permitted to write — a field, an array slot, a static, and so on. The intended semantics, per the Javadoc, is that at a modular call site only the named targets are havocked while everything else is preserved, mirroring CBMC's __CPROVER_assigns(...).

Like the other primitives in this class the method has an empty body: it is a marker recognized as a contract annotation, not executed at runtime. This commit adds only the public method and its Javadoc to the library module; no other files change.


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/strata-org/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
