### PR TITLE
JavaToLaurelCompiler: collapse reference comparison against null to a constant

### DIFF
--- a/verifier/src/main/java/org/strata/jverify/verifier/compiler/generator/laurel/JavaToLaurelCompiler.java
+++ b/verifier/src/main/java/org/strata/jverify/verifier/compiler/generator/laurel/JavaToLaurelCompiler.java
@@ -558,6 +558,36 @@ public class JavaToLaurelCompiler {
         }
 
         private StmtExpr convertBinary(JCTree.JCBinary binary, Map<String, String> renames) {
+            // Handle comparisons against the `null` literal before
+            // recursing into operand conversion. In JVerify's
+            // array-as-map model an array-typed value is never null, so
+            // `arr == null` / `arr != null` fold to a boolean constant
+            // (and the BOT-typed null literal stays off the
+            // convertLiteral path). The fold is restricted to array-
+            // typed operands so it can't silently mask the nullability
+            // of ordinary object references.
+            if (binary.getTag() == JCTree.Tag.EQ || binary.getTag() == JCTree.Tag.NE) {
+                boolean lhsNull = (binary.lhs instanceof JCTree.JCLiteral l)
+                        && l.typetag == TypeTag.BOT;
+                boolean rhsNull = (binary.rhs instanceof JCTree.JCLiteral r)
+                        && r.typetag == TypeTag.BOT;
+                if (lhsNull && rhsNull) {
+                    // null == null -> true; null != null -> false.
+                    SourceRange sr = toSourceRange(binary);
+                    return literalBool(sr, binary.getTag() == JCTree.Tag.EQ);
+                }
+                if (lhsNull ^ rhsNull) {
+                    // Only fold when the non-null operand is an array-
+                    // typed (map-backed) expression; other reference
+                    // comparisons fall through to the normal path.
+                    var other = lhsNull ? binary.rhs : binary.lhs;
+                    if (other.type instanceof com.sun.tools.javac.code.Type.ArrayType) {
+                        // x == null -> false; x != null -> true.
+                        SourceRange sr = toSourceRange(binary);
+                        return literalBool(sr, binary.getTag() == JCTree.Tag.NE);
+                    }
+                }
+            }
             StmtExpr lhs = convertExpression(binary.lhs, renames);
             StmtExpr rhs = convertExpression(binary.rhs, renames);
             SourceRange sr = toSourceRange(binary);


### PR DESCRIPTION
In JVerify's array-as-map model an array-typed value is never null, so `arr == null` / `arr != null` (detected via a BOT-typed null-literal operand) is folded to a boolean constant — `false` / `true` respectively — before operand conversion. This keeps the BOT-typed null literal off the `convertLiteral` path.

The fold is **restricted to comparisons whose non-null operand is array-typed** (map-backed), so it does not silently mask the nullability of ordinary object references — those fall through to the normal conversion path. The degenerate `null == null` / `null != null` case folds to `true` / `false` respectively.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/strata-org/jverify?tab=Apache-2.0-1-ov-file#readme).</small>