### PR TITLE
Test cases for documenting the limitation of do-while desugaring and for nested/labeled control flow

### DIFF
--- a/verifier/src/test/java/org/strata/jverify/verifier/tests/javasupport/statements/VerifyDoWhile.java
+++ b/verifier/src/test/java/org/strata/jverify/verifier/tests/javasupport/statements/VerifyDoWhile.java
@@ -5,7 +5,7 @@ import org.strata.jverify.testengine.JVerifyTest;
 import static org.strata.jverify.JVerify.*;
 
 @SuppressWarnings({"ConstantValue"})
-@JVerifyTest(exitCode = 4, methodsVerified = 5, errorCount = 2)
+@JVerifyTest(exitCode = 4, methodsVerified = 8, errorCount = 2)
 class VerifyDoWhile {
     /**
      * do-while with break exiting the loop early.
@@ -97,6 +97,83 @@ class VerifyDoWhile {
             x = x + 1;
         }
         check(x == 3);
+    }
+
+    /**
+     * Nested do-while loops, each exited via an unlabeled {@code break}.
+     * Exercises two stacked do-while label frames: the inner {@code break} must
+     * resolve to the inner loop's break label and the outer {@code break} to the
+     * outer loop's, leaving the loop variables at their break-time values.
+     * The postconditions are derived from the break guards (not the loop
+     * conditions), so they are unaffected by the exit-condition gap.
+     */
+    static void nestedDoWhileBreak() {
+        int i = 0;
+        do {
+            invariant(0 <= i && i <= 3);
+            int j = 0;
+            do {
+                invariant(0 <= j && j <= 2);
+                if (j == 2) {
+                    break;
+                }
+                j = j + 1;
+            } while (j < 100);
+            check(j == 2);
+            if (i == 3) {
+                break;
+            }
+            i = i + 1;
+        } while (i < 100);
+        check(i == 3);
+    }
+
+    /**
+     * Labeled do-while with {@code break} to the outer label from inside a nested loop.
+     * Exercises the {@code javaLabel = pendingLabel} capture in the do-while desugaring:
+     * the outer loop's label frame must carry {@code "outer"} so that {@code break outer}
+     * resolves to the outer break label rather than the inner one. The break fires on a
+     * known state ({@code i == 2}), so the post-loop assertion is provable.
+     */
+    static void labeledDoWhileBreakToOuter() {
+        int i = 0;
+        outer:
+        do {
+            invariant(0 <= i && i <= 2);
+            int j = 0;
+            do {
+                invariant(0 <= j && j <= 5);
+                if (i == 2) {
+                    break outer;
+                }
+                j = j + 1;
+            } while (j < 3);
+            i = i + 1;
+        } while (i < 100);
+        check(i == 2);
+    }
+
+    /**
+     * Labeled do-while with {@code continue} to the outer label from inside a nested loop.
+     * {@code continue outer} must resolve to the outer loop's continue label (re-evaluating
+     * the outer condition rather than the inner one), relying on the {@code javaLabel}
+     * capture.
+     */
+    static void labeledDoWhileContinueToOuter() {
+        int i = 0;
+        outer:
+        do {
+            invariant(0 <= i && i <= 3);
+            i = i + 1;
+            int j = 0;
+            do {
+                invariant(0 <= j && j <= 3);
+                if (j == 0) {
+                    continue outer;
+                }
+                j = j + 1;
+            } while (j < 3);
+        } while (i < 3);
     }
 
     /**

--- a/verifier/src/test/java/org/strata/jverify/verifier/tests/javasupport/statements/VerifyDoWhile.java
+++ b/verifier/src/test/java/org/strata/jverify/verifier/tests/javasupport/statements/VerifyDoWhile.java
@@ -5,7 +5,7 @@ import org.strata.jverify.testengine.JVerifyTest;
 import static org.strata.jverify.JVerify.*;
 
 @SuppressWarnings({"ConstantValue"})
-@JVerifyTest(exitCode = 4, methodsVerified = 4, errorCount = 1)
+@JVerifyTest(exitCode = 4, methodsVerified = 5, errorCount = 2)
 class VerifyDoWhile {
     /**
      * do-while with break exiting the loop early.
@@ -54,6 +54,49 @@ class VerifyDoWhile {
             x = x + 1;
         } while (x < 5);
         check(x >= 5);
+    }
+
+    /**
+     * Known-limitation test documenting the completeness gap of the
+     * {@code while(true) + exit(!cond)} do-while desugaring.
+     *
+     * <p>Because the modeled loop guard is the constant {@code true}, the verifier never
+     * learns {@code !cond} at the normal condition-exit, so a postcondition that depends
+     * on the exit condition cannot be proved. Here {@code check(x == 3)} fails even though
+     * the identical head-tested {@code while} (see {@link #whileKeepsExitCondition()}) proves it. 
+     * This is not rescuable with a stronger invariant.
+     *
+     * <p>The clean fix is a body-tested loop encoding at the Laurel level, tracked in
+     * strata-org/Strata#1350. Until then this case is expected to be rejected, and this
+     * test pins that behavior so the limitation is visible and the fix is detectable.
+     */
+    static void doWhileForgetsExitCondition() {
+        int x = 0;
+        do {
+            invariant(0 <= x && x <= 3);
+            x = x + 1;
+        } while (x < 3);
+        check(x == 3);
+//      ^^^^^^^^^^^^^ Error: assertion could not be proved
+    }
+
+    /**
+     * Head-tested {@code while} counterpart of {@link #doWhileForgetsExitCondition()}, with
+     * the identical body, invariant, and postcondition. Here {@code check(x == 3)} IS proved:
+     * the modeled guard is the real condition {@code x < 3}, so at loop exit the verifier has
+     * {@code !(x < 3)} (i.e. {@code x >= 3}) which, combined with the invariant {@code x <= 3},
+     * gives {@code x == 3}.
+     *
+     * <p>This is the behavior the do-while desugaring loses by modeling the guard as constant
+     * {@code true}, and is the gap that strata-org/Strata#1350 would close.
+     */
+    static void whileKeepsExitCondition() {
+        int x = 0;
+        while (x < 3) {
+            invariant(0 <= x && x <= 3);
+            x = x + 1;
+        }
+        check(x == 3);
     }
 
     /**


### PR DESCRIPTION
### What was changed?

#### 1. Document Completeness Gap 
Added two paired tests to `VerifyDoWhile` that document the known completeness gap in the current `while(true) + exit(!cond)` do-while desugaring (the encoding shipped in #427 as identified in [the review](https://github.com/strata-org/jverify/pull/427#pullrequestreview-4462430268)).

Because the desugaring models the loop guard as the constant `true`, the verifier never learns `!cond` at the normal condition-exit. Any postcondition that depends on the exit condition is therefore unprovable, even though it holds for the equivalent head-tested `while`.

- `doWhileForgetsExitCondition`: a `do { invariant(0 <= x && x <= 3); x = x + 1; } while (x < 3);` followed by `check(x == 3)`. The check is correctly proved for a head-tested loop but is **rejected** here ("assertion could not be proved"). This is not rescuable with a stronger invariant. The test pins the current (rejected) behavior so the limitation stays visible and the eventual fix is detectable.
- `whileKeepsExitCondition`: the head-tested `while` counterpart with the identical body, invariant, and postcondition. The same `check(x == 3)` **verifies**, because the modeled guard `x < 3` leaves `x >= 3` available at exit, which with the invariant `x <= 3` gives `x == 3`. This acts as the positive control demonstrating exactly what the do-while encoding loses.

Both tests reference the Laurel-level follow-up (a body-tested loop encoding) tracked in strata-org/Strata#1350, which would close the gap.

#### 2. Nested and Labeled Control Flow
Extended `VerifyDoWhile` with three new verification tests that exercise the do-while desugaring under nested and labeled control flow:

- `nestedDoWhileBreak`: two stacked do-while loops, each exited via an unlabeled `break`. Confirms the inner `break` resolves to the inner loop's break label and the outer `break` to the outer loop's, leaving each loop variable at its break-time value. Postconditions derive from the break guards, so they're independent of the exit-condition gap.
- `labeledDoWhileBreakToOuter`: `break outer` from inside a nested loop. Exercises the `javaLabel = pendingLabel` capture in the desugaring: the outer loop's label frame must carry `"outer"` so the break targets the outer break label rather than the inner one. The break fires on a known state (`i == 2`), so the post-loop assertion is provable.
- `labeledDoWhileContinueToOuter`: `continue outer` from inside a nested loop, re-evaluating the outer condition rather than the inner one. 


### How has this been tested?

- `./gradlew :verifier:test --tests "*VerifyDoWhile*"` passes. the `do-while` check is reported as "assertion could not be proved", the `while` check verifies clean. Nested and labeled control flow tests pass as well.


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/strata-org/jverify?tab=Apache-2.0-1-ov-file#readme).</small>