### PR TITLE
JVerify: parse Strata's file:// diagnostic URIs as URIs, not paths

### DIFF
--- a/verifier/src/main/java/org/strata/jverify/verifier/laurel/LaurelDriver.java
+++ b/verifier/src/main/java/org/strata/jverify/verifier/laurel/LaurelDriver.java
@@ -196,7 +196,13 @@ public class LaurelDriver implements Driver {
                         int endOffset = Integer.parseInt(matcher.group(3));
                         String message = matcher.group(4);
 
-                        var uri = Paths.get(filePath).toUri();
+                        // Strata emits `file://` URIs (e.g. file:///abs/Path.java);
+                        // parse them as URIs rather than treating the URI string as
+                        // a filesystem path, which would miss the filesMap and lose
+                        // the source location (reported as 1:1).
+                        var uri = filePath.startsWith("file:")
+                                ? URI.create(filePath)
+                                : Paths.get(filePath).toUri();
 
                         var range = new Range(
                                 filesMap.computePositionFromFileOffset(uri, startOffset),


### PR DESCRIPTION
parseStrataOutput matched Strata's `<file>:<start>-<end>: <msg>` diagnostic lines and resolved the location with `Paths.get(filePath).toUri()`. But Strata emits a `file://` URI (e.g. file:///abs/Path.java), so Paths.get treated the URI string as a filesystem path, produced a bogus URI that missed the source filesMap, and every VC diagnostic was reported at 1:1-1:1. Parse `file:` URIs with URI.create so the location resolves to the real source range.

Diagnostics now show real line:col (e.g. X.java(146:9-147:54)) instead of (1:1-1:1).


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/strata-org/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
