### PR TITLE
builtin-contracts: add pure List.subList and List.equals contracts

### DIFF
--- a/builtin-contracts/src/main/java/org/strata/jverify/builtin/ListContract.java
+++ b/builtin-contracts/src/main/java/org/strata/jverify/builtin/ListContract.java
@@ -76,4 +76,39 @@ abstract class ListContract<E> implements List<E> {
                         0 <= i && i < size() && get(i).equals(o)));
         throw new ContractException();
     }
+
+    @Override
+    @Pure
+    public List<E> subList(@Nat int fromIndex, @Nat int toIndex) {
+        reads(everything());
+        decreases(0);
+        precondition(0 <= fromIndex && fromIndex <= toIndex && toIndex <= size());
+        // The sublist has length toIndex-fromIndex and its element i is
+        // the receiver's element fromIndex+i. Mirrors the JBMC List model's
+        // element-array view (java_bytecode_axiomatic.cpp LIST_GET).
+        postcondition((List<E> r) ->
+                r.size() == toIndex - fromIndex &&
+                JVerify.forall((int i) ->
+                        i < 0 || i >= r.size() || r.get(i) == get(fromIndex + i)));
+        throw new ContractException();
+    }
+
+    @Override
+    @Pure
+    public boolean equals(Object o) {
+        reads(everything());
+        decreases(0);
+        // Extensional list equality: same length and pointwise-equal
+        // elements. Element comparison uses JVerify.jequals (structural
+        // equality for pure element types, reference equality for impure
+        // ones) to match java.util.List#equals, rather than `==`, which
+        // would model reference equality and be unsound for
+        // distinct-but-equal elements.
+        postcondition((boolean r) ->
+                r == (o instanceof List<?> other &&
+                        other.size() == size() &&
+                        JVerify.forall((int i) ->
+                                i < 0 || i >= size() || JVerify.jequals(get(i), other.get(i)))));
+        throw new ContractException();
+    }
 }

--- a/verifier/src/test/java/org/strata/jverify/verifier/tests/jcl/CollectionsTest.java
+++ b/verifier/src/test/java/org/strata/jverify/verifier/tests/jcl/CollectionsTest.java
@@ -18,6 +18,14 @@ public class CollectionsTest {
         check(s.get(1).equals("two"));
         check(s.contains("two"));
 
+        // subList is a view over the corresponding slice.
+        var sub = s.subList(1, 3);
+        check(sub.size() == 2);
+        check(sub.get(0).equals("two"));
+
+        // extensional list equality (reflexive here).
+        check(s.equals(s));
+
         var s2 = List.of();
         check(s2.isEmpty());
     }


### PR DESCRIPTION
Extends ListContract with two pure methods:

  subList(from, to): precondition 0<=from<=to<=size; postcondition
    result.size()==to-from and forall i. result.get(i)==get(from+i).
  equals(o): extensional — same length and pointwise-equal elements.

Both are @Pure and reuse the existing get/size contracts. No behavioural change to the already-present of/get/size/isEmpty/ contains contracts.

<!-- Please remove these Markdown comments before publishing this PR, since the PR message is often used as the commit description. 
We only allow squash merging and GH suggests the PR details as a default commit message. -->

### What was changed?
<!-- Is this a user-visible change? Remember to update RELEASE_NOTES.md -->

### How has this been tested?

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/strata-org/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
