### PR TITLE
JVerify: a non-zero exit must never read as a vacuous "0 errors"

### DIFF
--- a/verifier/src/main/java/org/strata/jverify/verifier/Driver.java
+++ b/verifier/src/main/java/org/strata/jverify/verifier/Driver.java
@@ -57,13 +57,25 @@ public interface Driver {
         }
         
         var verificationResults = results.verificationResults();
+        int errorCount = verificationResults != null
+                ? verificationResults.verificationFailedAssertions()
+                : results.diagnostics().size();
+        // Soundness backstop: a non-zero exit code must never be reported
+        // as "0 errors". Any failure path that reaches here without a
+        // counted diagnostic (e.g. Strata failing to start) is surfaced as
+        // a failure rather than a vacuous success.
+        if (errorCount == 0 && results.exitCode() != 0) {
+            pw.println("Verification did not complete (exit code "
+                    + results.exitCode() + "); reporting as failed.");
+            errorCount = 1;
+        }
         if (verificationResults != null) {
-            pw.println(String.format("Found %s errors", verificationResults.verificationFailedAssertions()));
+            pw.println(String.format("Found %s errors", errorCount));
             pw.println(String.format("Verified methods: %s", verificationResults.verificationPassedMethods()));
             pw.println(String.format("Failed methods: %s", verificationResults.verificationFailedMethods()));
             pw.println(String.format("Skipped methods: %s", verificationResults.verificationSkippedMethods()));
         } else {
-            pw.println(String.format("Found %s errors", results.diagnostics().size()));
+            pw.println(String.format("Found %s errors", errorCount));
         }
     }
 

--- a/verifier/src/main/java/org/strata/jverify/verifier/laurel/LaurelDriver.java
+++ b/verifier/src/main/java/org/strata/jverify/verifier/laurel/LaurelDriver.java
@@ -241,6 +241,26 @@ public class LaurelDriver implements Driver {
             int verifierExitCode = process.waitFor();
             if (verifierExitCode != 0 && diagnostics.isEmpty()) {
                 options.outWriter().println("Strata exited with code " + verifierExitCode + ":\n" + preDiagnosticOutput);
+                // Soundness: a non-zero Strata exit with no parsed
+                // diagnostics means verification aborted (e.g. an internal
+                // Strata exception such as a failed termination check).
+                // Surface it as an error so the result can never be read as
+                // a vacuous "0 errors / verified" -- the same invariant the
+                // Laurel-to-Core soundness net enforces on the Strata side.
+                var abortUri = methodStatuses.keySet().stream().findFirst()
+                        .orElse(Paths.get("strata").toUri());
+                var abortPos = new org.strata.jverify.common.Position(1, 1);
+                diagnostics.add(new StrataDiagnostic(abortUri,
+                        new Range(abortPos, abortPos),
+                        "verification aborted: Strata exited with code "
+                        + verifierExitCode + " without reporting diagnostics: "
+                        + preDiagnosticOutput.toString().strip()));
+                failedAssertionsCount.setValue(failedAssertionsCount.getValue() + 1);
+                // The run aborted before producing per-method results, so
+                // the optimistic "Verified" defaults are not trustworthy:
+                // do not report any method as verified or skipped.
+                verifiedCount = 0;
+                skippedCount = 0;
             }
             var exitCode = verifierExitCode == 0 ? (diagnostics.isEmpty() ? 0 : 4) : verifierExitCode;
             return new JVerifyResults(diagnostics, exitCode,

--- a/verifier/src/test/java/org/strata/jverify/verifier/NonZeroExitReportingTest.java
+++ b/verifier/src/test/java/org/strata/jverify/verifier/NonZeroExitReportingTest.java
@@ -1,0 +1,57 @@
+package org.strata.jverify.verifier;
+
+import org.junit.jupiter.api.Test;
+import org.strata.jverify.testengine.JVerifyTestEngine;
+
+import javax.tools.JavaFileObject;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * #447 soundness backstop: a non-zero exit code must never be reported as a
+ * vacuous "Found 0 errors". Drives the real verifyJavaFilesExit ->
+ * outputVerificationResults path with a stub Driver returning a canned
+ * JVerifyResults, asserting on the reported error count.
+ */
+class NonZeroExitReportingTest {
+
+    private static final Pattern FOUND_ERRORS = Pattern.compile("Found (\\d+) errors");
+
+    private static int reportedErrorCount(JVerifyResults canned) throws Exception {
+        var out = new StringWriter();
+        var base = JVerifyTestEngine.getVerifierOptions(
+                JVerifyTestEngine.makeJVerifyTestAnnotation(0, 0), null);
+        var options = new VerifierOptions(new PrintWriter(out),
+                base.workingDirectory(), base.backendPath(), base.extraClassPathEntries(),
+                base.printSerializedOutputProgram(), base.emitLaurelOnly(), base.showRanges(),
+                base.contractSourcePath(), base.showFilepaths(), base.verifyByDefault(),
+                base.continueOnErrors(), base.positionFilter(), base.verbose(), base.shouldTrackTime());
+        Driver driver = new Driver() {
+            @Override public VerifierOptions getVerifierOptions() { return options; }
+            @Override public JVerifyResults verifyJavaFiles(List<JavaFileObject> readFiles) { return canned; }
+        };
+        int exit = driver.verifyJavaFilesExit(List.of());
+        assertEquals(canned.exitCode(), exit, "exit code must pass through unchanged");
+        Matcher m = FOUND_ERRORS.matcher(out.toString());
+        assertTrue(m.find(), "report must contain a 'Found N errors' line, got:\n" + out);
+        return Integer.parseInt(m.group(1));
+    }
+
+    @Test
+    void nonZeroExitWithNoDiagnosticsReportsAtLeastOneError() throws Exception {
+        assertTrue(reportedErrorCount(new JVerifyResults(List.of(), -1, null)) >= 1,
+                "a non-zero exit with no diagnostics must report at least one error, not a vacuous 0");
+    }
+
+    @Test
+    void zeroExitWithNoErrorsStillReportsZero() throws Exception {
+        assertEquals(0, reportedErrorCount(new JVerifyResults(List.of(), 0,
+                new VerificationResults(3, 0, 0, 0))));
+    }
+}


### PR DESCRIPTION
Soundness backstop at both driver boundaries: a verification run that aborts (non-zero exit) without a counted per-property diagnostic must not be reported as a clean "Found 0 errors / verified" success. This is the verifier-side analog of the Laurel-to-Core silent-discard soundness net.

**LaurelDriver** (Strata subprocess boundary): when Strata exits non-zero but no diagnostics were parsed -- e.g. an internal Strata exception such as a failed termination check -- inject a synthetic `verification aborted: Strata exited with code N ...` diagnostic and count it, instead of returning an empty diagnostics list. The optimistic per-method "Verified" defaults are also zeroed, so an aborted run never reports verified or skipped methods.

**Driver.outputVerificationResults** (overall-verifier boundary): when the exit code is non-zero but the error count is zero -- e.g. Strata failing to start (the `runVerifier` IOException path returns empty diagnostics with exit -1) -- surface it as `Verification did not complete (exit code N); reporting as failed` and force the count to >= 1.

Originally surfaced by a recursive-spec helper that trips a Strata termination check, which now reports the abort instead of vacuously "verified" methods. Normal runs (exit 0, or non-zero with real diagnostics) are unchanged.

### Testing

`NonZeroExitReportingTest` covers the `Driver`-guard half by driving the real `verifyJavaFilesExit -> outputVerificationResults` path with a stub driver and canned `JVerifyResults` (no Strata): a non-zero exit with no diagnostics reports >= 1 error, while a clean exit-0 run still reports 0. The `LaurelDriver` abort half needs a real aborting Strata subprocess and is left uncovered.


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/strata-org/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
