### PR TITLE
JVerify: emit @Pure functions with loop bodies as uninterpreted

### DIFF
--- a/verifier/src/main/java/org/strata/jverify/verifier/compiler/generator/laurel/JavaToLaurelCompiler.java
+++ b/verifier/src/main/java/org/strata/jverify/verifier/compiler/generator/laurel/JavaToLaurelCompiler.java
@@ -257,6 +257,24 @@ public class JavaToLaurelCompiler {
             return found[0];
         }
 
+        /** Check if a method body contains any loop. A @Pure function with
+         *  a loop cannot be a transparent (pure-expression) function body --
+         *  Strata function bodies allow only let-bindings and a final
+         *  if-then-else -- so we emit such a function uninterpreted. */
+        private boolean bodyContainsLoop(JCTree.JCBlock body) {
+            boolean[] found = {false};
+            body.accept(new TreeScanner() {
+                @Override public void visitForLoop(JCTree.JCForLoop tree) { found[0] = true; }
+                // Foreach is future-proofing: it is not yet reachable here
+                // (there is no supported iterable type and no enhanced-for
+                // translation case), so it cannot be exercised by a test yet.
+                @Override public void visitForeachLoop(JCTree.JCEnhancedForLoop tree) { found[0] = true; }
+                @Override public void visitWhileLoop(JCTree.JCWhileLoop tree) { found[0] = true; }
+                @Override public void visitDoLoop(JCTree.JCDoWhileLoop tree) { found[0] = true; }
+            });
+            return found[0];
+        }
+
         private String freshLabel(String prefix) {
             return prefix + "_" + (labelCounter++);
         }
@@ -375,11 +393,27 @@ public class JavaToLaurelCompiler {
                 }
             }
 
+            boolean isPure = jverifyUtils.isPure(method.sym);
+            // A @Pure function whose body contains a loop cannot be a
+            // transparent (pure-expression) function body, so drop the
+            // body and emit it uninterpreted (a sound over-approximation)
+            // rather than producing an untranslatable block expression.
+            if (isPure && method.body != null && methodBody != null
+                    && bodyContainsLoop(method.body)) {
+                if (!ensures.isEmpty()) {
+                    // Dropping the body would silently discard the
+                    // postcondition (it cannot be checked against an
+                    // uninterpreted function), so refuse instead.
+                    throw new JavaViolationException(
+                        "@Pure function with a loop and a postcondition is not yet supported");
+                }
+                methodBody = null;
+            }
+
             Optional<Body> optBody = methodBody != null
                     ? Optional.of(body(methodBody))
                     : Optional.empty();
 
-            boolean isPure = jverifyUtils.isPure(method.sym);
             // Strata rejects transparent (visible-body) procedures unless they're functional;
             // emit an OpaqueSpec to mark the body opaque otherwise. Pure functions stay
             // transparent only when they have no ensures clauses (the schema can't carry

--- a/verifier/src/test/java/org/strata/jverify/verifier/tests/verification/pure/PureLoopWithPostcondition.java
+++ b/verifier/src/test/java/org/strata/jverify/verifier/tests/verification/pure/PureLoopWithPostcondition.java
@@ -1,0 +1,34 @@
+package org.strata.jverify.verifier.tests.verification.pure;
+
+import org.strata.jverify.Pure;
+import org.strata.jverify.testengine.JVerifyTest;
+
+import static org.strata.jverify.JVerify.postcondition;
+import static org.strata.jverify.JVerify.precondition;
+
+/**
+ * A @Pure method whose body contains a loop is emitted uninterpreted by
+ * dropping its body. If it also has a postcondition, dropping the body would
+ * silently discard that postcondition (it cannot be checked against an
+ * uninterpreted function): a contradictory postcondition would vacuously
+ * "verify". The translator must refuse this case rather than pass it.
+ *
+ * <p>The contradictory postcondition below would verify clean (exit 0) if the
+ * postcondition were silently dropped; instead the run must report that the
+ * combination is not yet supported.
+ */
+@JVerifyTest(exitCode = 2)
+class PureLoopWithPostcondition {
+
+    @Pure
+    static boolean loopWithPostcondition(int n) {
+//                 ^ error: @Pure function with a loop and a postcondition is not yet supported
+        precondition(n >= 0);
+        postcondition((boolean r) -> r == true && r == false);
+        boolean acc = false;
+        for (int i = 0; i < n; i = i + 1) {
+            acc = !acc;
+        }
+        return acc;
+    }
+}

--- a/verifier/src/test/java/org/strata/jverify/verifier/tests/verification/pure/PureMethodWithLoop.java
+++ b/verifier/src/test/java/org/strata/jverify/verifier/tests/verification/pure/PureMethodWithLoop.java
@@ -1,0 +1,72 @@
+package org.strata.jverify.verifier.tests.verification.pure;
+
+import org.strata.jverify.Pure;
+import org.strata.jverify.testengine.JVerifyTest;
+
+import static org.strata.jverify.JVerify.check;
+import static org.strata.jverify.JVerify.precondition;
+
+/**
+ * A @Pure method whose body contains a loop cannot be a transparent Laurel
+ * function body (Strata function bodies allow only let-bindings and a final
+ * if-then-else), so it is emitted uninterpreted instead of an untranslatable
+ * block expression.
+ *
+ * <p>The test running at all is the regression guard: previously such a method
+ * crashed translation with "block expression should have been lowered". The
+ * checks confirm the resulting function is congruent (same input, same output)
+ * but its interpreted loop result is not provable. (The helpers return boolean
+ * to avoid the unrelated "constrained return types on functions" limitation.)
+ */
+@JVerifyTest(exitCode = 4, methodsVerified = 5, errorCount = 1)
+class PureMethodWithLoop {
+
+    @Pure
+    static boolean withForLoop(int n) {
+        precondition(n >= 0);
+        boolean acc = false;
+        for (int i = 0; i < n; i = i + 1) {
+            acc = !acc;
+        }
+        return acc;
+    }
+
+    @Pure
+    static boolean withWhileLoop(int n) {
+        precondition(n >= 0);
+        boolean acc = false;
+        int i = 0;
+        while (i < n) {
+            acc = !acc;
+            i = i + 1;
+        }
+        return acc;
+    }
+
+    @Pure
+    static boolean withDoLoop(int n) {
+        precondition(n >= 0);
+        boolean acc = false;
+        int i = 0;
+        do {
+            acc = !acc;
+            i = i + 1;
+        } while (i < n);
+        return acc;
+    }
+
+    // Uninterpreted functions are congruent: equal inputs give equal outputs.
+    static void congruenceHolds() {
+        check(withForLoop(3) == withForLoop(3));
+        check(withWhileLoop(3) == withWhileLoop(3));
+        check(withDoLoop(3) == withDoLoop(3));
+    }
+
+    // The interpreted loop result is NOT provable: the body was dropped and
+    // the function emitted uninterpreted, so its value is unknown.
+    static void interpretedResultNotProvable(int n) {
+        precondition(n >= 0);
+        check(withForLoop(n));
+//      ^^^^^^^^^^^^^^^^^^^^^ Error: assertion does not hold
+    }
+}


### PR DESCRIPTION
A Strata function body may contain only let-bindings and a final if-then-else -- no loops. A `@Pure` Java helper whose body contains a `for`/`while`/`foreach` loop was emitted as a transparent function body, which the Laurel-to-Core translator then rejected with "block expression should have been lowered in a separate pass".

**Fix:** detect a loop in a `@Pure` function body (`bodyContainsLoop`) and drop the body, emitting the function uninterpreted -- a sound over-approximation (congruent, usable in spec positions) instead of an untranslatable block.

Dropping the body is only sound when the function has no postcondition: an uninterpreted function cannot be checked against an `ensures`, so a dropped body would silently discard the postcondition (a contradictory postcondition would vacuously "verify"). The translator now refuses `@Pure` + loop + postcondition with a clear "not yet supported" diagnostic instead, matching the existing non-loop `@Pure` + postcondition behaviour.

### Testing

Two runnable (non-skipped) regression tests:

- `PureMethodWithLoop`: three `@Pure` helpers using `for`/`while`/`do` loops translate without crashing, their uninterpreted results are congruent (provable), and the interpreted loop result is correctly not provable. The helpers return `boolean` to avoid the unrelated "constrained return types on functions" limitation.
- `PureLoopWithPostcondition`: a `@Pure` loop helper with a contradictory postcondition is reported as not-yet-supported rather than vacuously verifying.

The `foreach` arm of `bodyContainsLoop` is future-proofing: it is not yet reachable (no supported iterable type, and no enhanced-for translation case), so it cannot be exercised by a test yet.


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/strata-org/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
