### PR TITLE
Fix NPE on valueless return in if-then and labeled statements

### DIFF
--- a/verifier/src/main/java/org/strata/jverify/verifier/compiler/generator/laurel/JavaToLaurelCompiler.java
+++ b/verifier/src/main/java/org/strata/jverify/verifier/compiler/generator/laurel/JavaToLaurelCompiler.java
@@ -433,6 +433,12 @@ public class JavaToLaurelCompiler {
                 case JCTree.JCIf ifStmt -> {
                     StmtExpr cond = convertExpression(ifStmt.cond, renames);
                     StmtExpr thenBranch = convertStatement(ifStmt.thenpart, renames);
+                    // convertStatement returns null for droppable statements (e.g. a
+                    // valueless `return;`). The Laurel node requires a non-null then-branch,
+                    // so substitute an empty block, mirroring the else-branch guard below.
+                    if (thenBranch == null) {
+                        thenBranch = block(toSourceRange(ifStmt.thenpart), List.of());
+                    }
                     Optional<ElseBranch> elseB = Optional.empty();
                     if (ifStmt.elsepart != null) {
                         StmtExpr elseStmt = convertStatement(ifStmt.elsepart, renames);
@@ -528,6 +534,11 @@ public class JavaToLaurelCompiler {
                         pendingLabel = null;
                         try {
                             StmtExpr body = convertStatement(labeledStmt.body, renames);
+                            // convertStatement returns null for droppable statements (e.g. a
+                            // valueless `return;`); the labelled block requires a non-null body.
+                            if (body == null) {
+                                body = block(toSourceRange(labeledStmt.body), List.of());
+                            }
                             yield labelledBlock(toSourceRange(labeledStmt), List.of(body), breakLbl);
                         } finally {
                             labelStack.pop();

--- a/verifier/src/test/java/org/strata/jverify/verifier/tests/javasupport/statements/VerifyBareReturn.java
+++ b/verifier/src/test/java/org/strata/jverify/verifier/tests/javasupport/statements/VerifyBareReturn.java
@@ -1,0 +1,59 @@
+package org.strata.jverify.verifier.tests.javasupport.statements;
+
+import org.strata.jverify.testengine.JVerifyTest;
+
+import static org.strata.jverify.JVerify.*;
+
+/**
+ * Regression tests for strata-org/jverify#443.
+ *
+ * <p>A valueless {@code return;} reaches {@code convertStatement} as a droppable (null)
+ * statement, because Laurel's return op cannot express a valueless return (strata-org/Strata#1353).
+ * Two node-bound sites used to pass that null straight into a Laurel node — the {@code if}
+ * then-branch and a non-loop labelled body — producing a {@code NullPointerException} during
+ * Laurel serialization. Both sites are now null-guarded with an empty block, mirroring the
+ * existing else-branch guard.
+ *
+ * <p>These tests pin the no-crash behavior. Note the bare return is <em>dropped</em> rather than
+ * modeled as control flow, so the methods below are written not to depend on the early return
+ * actually short-circuiting; they verify cleanly under the (sound but incomplete) translation.
+ */
+@SuppressWarnings({"ConstantValue", "UnusedLabel"})
+@JVerifyTest(methodsVerified = 4, errorCount = 0)
+class VerifyBareReturn {
+
+    /**
+     * {@code if (cond) return;} at method level. The bare return is the then-branch,
+     * which {@code convertStatement} drops; the then-branch must be null-guarded.
+     * Previously NPE'd at L386 (ifThenElse with a null then-branch).
+     */
+    static void ifThenBareReturn() {
+        int x = 5;
+        if (x == 5) return;
+        check(x == 5);
+    }
+
+    /**
+     * Labeled bare return: a non-loop labelled statement whose body is a droppable
+     * {@code return;}. The labelled body must be null-guarded.
+     * Previously NPE'd at L474 (labelledBlock with a null body).
+     */
+    static void labeledBareReturn() {
+        lbl:
+        return;
+    }
+
+    /**
+     * Bare return inside a (do-while) loop, reached through the loop's if-then branch.
+     * The invariant bounds {@code x} across all paths the verifier sees (including the
+     * one where the dropped return does not short-circuit).
+     */
+    static void bareReturnInsideLoop() {
+        int x = 0;
+        do {
+            invariant(0 <= x && x <= 3);
+            if (x == 2) return;
+            x = x + 1;
+        } while (x < 3);
+    }
+}


### PR DESCRIPTION
### What was changed?

Fixed a `NullPointerException` (#443) thrown during Laurel serialization when a method contains a valueless `return;` reached through control flow.

A valueless `return;` is converted to `null` in `convertStatement` as a "drop this statement" signal. Most call sites honor that contract by filtering out the `null`, but two sites passed it straight into a Laurel node constructor:

- the `JCIf` then-branch (`ifThenElse(...)`), and
- the non-loop labeled statement body (`labelledBlock(...)`).

The resulting `null` node then NPE'd when `toIon` was called during serialization. Both sites are now null-guarded by substituting an empty `block(...)`, mirroring the existing else-branch guard.

This affects valid, already-supported Java such as `if (cond) return;`, `lbl: return;`, and a bare `return;` inside a loop. Note: because Laurel cannot yet express a valueless return ([Strata#1353](https://github.com/strata-org/Strata/issues/1353)), the return is dropped rather than modeled as control flow.

Files:
- `JavaToLaurelCompiler.java` — null-guard the two node-bound sites.
- `VerifyBareReturn.java` — new regression tests.

### How has this been tested?

Added `VerifyBareReturn` regression tests covering the three previously-crashing shapes: `if (cond) return;` at method level, a labeled bare return, and a bare return inside a do-while loop. None existed before.

- The new tests pass (`./gradlew :verifier:test --tests "...VerifyBareReturn"`), confirming translation no longer crashes and the methods verify cleanly.
- The surrounding statement suites (`VerifyDoWhile`, `VerifyBreakContinue`, `VerifyStatements`, `Switches`, `SwitchDesugaring`, `AssertVsCheck`, `TranslationErrors`) still pass, confirming no regressions.


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/strata-org/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
