### PR TITLE
Emit valueless return; instead of dropping it

### DIFF
--- a/verifier/src/main/java/org/strata/jverify/verifier/compiler/generator/laurel/JavaToLaurelCompiler.java
+++ b/verifier/src/main/java/org/strata/jverify/verifier/compiler/generator/laurel/JavaToLaurelCompiler.java
@@ -497,10 +497,10 @@ public class JavaToLaurelCompiler {
                     yield ifThenElse(toSourceRange(ifStmt), cond, thenBranch, elseB);
                 }
                 case JCTree.JCReturn retStmt -> {
-                    if (retStmt.expr != null) {
-                        yield return_(toSourceRange(retStmt), Optional.of(convertExpression(retStmt.expr, renames)));
-                    }
-                    yield null;
+                    Optional<StmtExpr> value = retStmt.expr != null
+                            ? Optional.of(convertExpression(retStmt.expr, renames))
+                            : Optional.empty();
+                    yield return_(toSourceRange(retStmt), value);
                 }
                 case JCTree.JCWhileLoop whileStmt -> {
                     var sr = toSourceRange(whileStmt);

--- a/verifier/src/test/java/org/strata/jverify/verifier/tests/javasupport/statements/VerifyValuelessReturn.java
+++ b/verifier/src/test/java/org/strata/jverify/verifier/tests/javasupport/statements/VerifyValuelessReturn.java
@@ -1,0 +1,47 @@
+package org.strata.jverify.verifier.tests.javasupport.statements;
+
+import org.strata.jverify.testengine.JVerifyTest;
+
+import static org.strata.jverify.JVerify.*;
+
+/** Valueless {@code return;} (#443): once dropped as {@code null}, so it crashed or lost early-exit semantics. */
+@SuppressWarnings({"ConstantValue"})
+@JVerifyTest(exitCode = 0, methodsVerified = 6, errorCount = 0)
+class VerifyValuelessReturn {
+
+    /** Crash case + soundness probe: a dropped return makes check(false) reachable. */
+    static void ifThenBareReturn() {
+        int x = 5;
+        if (x == 5) return;
+        check(false);
+    }
+
+    /** Crash case: labeled bare return. */
+    static void labeledBareReturn() {
+        int x = 5;
+        lbl: return;
+    }
+
+    /** Crash case: bare return inside a loop. */
+    static void bareReturnInLoop() {
+        int x = 0;
+        do {
+            invariant(0 <= x && x <= 2);
+            if (x == 2) return;
+            x = x + 1;
+        } while (x < 3);
+    }
+
+    /** The early return must guard the rest: dropping it makes check(x > 0) reachable with x <= 0. */
+    static void earlyReturnGuardsRest(int x) {
+        if (x <= 0) return;
+        check(x > 0);
+    }
+
+    /** Trailing bare return: must still verify. */
+    static void trailingBareReturn() {
+        int x = 1;
+        check(x == 1);
+        return;
+    }
+}


### PR DESCRIPTION
Closes #443.

### What was changed?

A bare `return;` was converted to `null` ("drop this statement"). Most consumers filtered it, but two crashed during serialization (#443) by passing it into a Laurel node constructor:

- the `JCIf` then-branch — `if (c) return;`
- the labeled non-loop body — `lbl: return;`

Where the null *was* filtered, the `return;` silently vanished, losing early-exit semantics — unsound (code after an early return became unconditionally reachable).

Strata now accepts a valueless return end-to-end (strata-org/Strata#1354; `Return none` lowers to a procedure-body exit), so this emits `return_(Optional.empty())` instead of null — fixing both the crash and the silent drop. No generated AST changes.

### How has this been tested?

- New `VerifyValuelessReturn`: the three #443 crash shapes, a soundness probe (early return guards the rest), and a trailing bare return. Fails without the fix (NPE), passes with it.
- `./gradlew :verifier:test` — full suite green.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/strata-org/jverify?tab=Apache-2.0-1-ov-file#readme).</small>