### PR TITLE
feat(verifier): Add --keep-all-files option

### DIFF
--- a/test-engine/src/main/java/org/strata/jverify/testengine/JVerifyTestEngine.java
+++ b/test-engine/src/main/java/org/strata/jverify/testengine/JVerifyTestEngine.java
@@ -270,7 +270,7 @@ public class JVerifyTestEngine extends HierarchicalTestEngine<EngineExecutionCon
                 true,
                 annotation.verifyByDefault(),
                 annotation.continueOnErrors(),
-                positionFilter, true, false
+                positionFilter, true, false, null
         );
     }
 

--- a/verifier/src/main/java/org/strata/jverify/verifier/Main.java
+++ b/verifier/src/main/java/org/strata/jverify/verifier/Main.java
@@ -70,6 +70,12 @@ class AppCommand implements Callable<Integer> {
     @Option(names = "--track-time", description = "")
     private boolean trackTime;
 
+    @Option(names = "--keep-all-files", paramLabel = "DIR",
+            description = "Keep the intermediate Strata IR (Laurel and Core programs emitted after each "
+                    + "pipeline phase) in this directory. The directory is created if it does not exist. "
+                    + "Useful for debugging verification.")
+    private Path keepAllFilesDir;
+
     @Override
     public Integer call() throws IOException {
         var writer = new PrintWriter(spec.commandLine().getOut());
@@ -97,7 +103,7 @@ class AppCommand implements Callable<Integer> {
         var verifierOptions = new VerifierOptions(writer, workingDirectory, strataPath, classpathEntries,
                 emitLaurel, emitLaurel != null, showRanges, contractPathEntries,
                 paths, verifyByDefault, false, 
-                positionFilter, verbose, trackTime);
+                positionFilter, verbose, trackTime, keepAllFilesDir);
         
         return verifierOptions.time("Calling Driver.verifyJavaPaths", () -> {
             try {

--- a/verifier/src/main/java/org/strata/jverify/verifier/VerifierOptions.java
+++ b/verifier/src/main/java/org/strata/jverify/verifier/VerifierOptions.java
@@ -22,7 +22,8 @@ public record VerifierOptions(PrintWriter outWriter,
                               boolean continueOnErrors,
                               @Nullable PositionFilter positionFilter,
                               boolean verbose,
-                              boolean shouldTrackTime) {
+                              boolean shouldTrackTime,
+                              @Nullable Path keepAllFilesDir) {
     public <T> T time(String name, Supplier<T> supply) {
         if (!shouldTrackTime) {
             return supply.get();

--- a/verifier/src/main/java/org/strata/jverify/verifier/laurel/LaurelDriver.java
+++ b/verifier/src/main/java/org/strata/jverify/verifier/laurel/LaurelDriver.java
@@ -116,9 +116,25 @@ public class LaurelDriver implements Driver {
     }
 
     public JVerifyResults runVerifier(FilesMap filesMap, IonValue serializedProgram) {
-        var processBuilder = new ProcessBuilder(
+        var command = new ArrayList<>(List.of(
                 "lake", "exe", "-q", "strata", "laurelAnalyzeBinary", "--solver", "z3"
-        );
+        ));
+        // Forward --keep-all-files so Strata writes the intermediate Laurel and Core IR for
+        // debugging. Strata treats the value as a path *prefix* (it appends ".<n>.<phase>.<ext>")
+        // and creates the prefix's parent directory. We resolve the user-provided directory to an
+        // absolute path (the process runs from the StrataCLI subdirectory, so a relative path would
+        // otherwise be interpreted relative to that) and use "<dir>/program" as the prefix, so every
+        // emitted file lands inside the requested folder.
+        if (verifierOptions.keepAllFilesDir() != null) {
+            var prefix = verifierOptions.workingDirectory()
+                    .resolve(verifierOptions.keepAllFilesDir())
+                    .resolve("program")
+                    .toAbsolutePath()
+                    .normalize();
+            command.add("--keep-all-files");
+            command.add(prefix.toString());
+        }
+        var processBuilder = new ProcessBuilder(command);
         // The `strata` executable lives in the StrataCLI subpackage, so `lake` must be invoked from there.
         processBuilder.directory(verifierOptions.backendPath().resolve("StrataCLI").toFile());
         return verifierOptions.time("Running Strata", () -> {

--- a/verifier/src/test/java/org/strata/jverify/verifier/EmitLaurelWorkflowTest.java
+++ b/verifier/src/test/java/org/strata/jverify/verifier/EmitLaurelWorkflowTest.java
@@ -104,6 +104,7 @@ public class EmitLaurelWorkflowTest {
                 base.continueOnErrors(),
                 base.positionFilter(),
                 base.verbose(),
-                base.shouldTrackTime());
+                base.shouldTrackTime(),
+                base.keepAllFilesDir());
     }
 }


### PR DESCRIPTION
Add a --keep-all-files CLI option that forwards a directory to Strata so the intermediate Laurel and Core IR emitted after each pipeline phase is retained for debugging. The directory is resolved to an absolute path and used as a `<dir>` prefix when invoking the Strata backend.

Thread the new keepAllFilesDir field through VerifierOptions and update the test engine and EmitLaurelWorkflowTest call sites accordingly.

<!-- Please remove these Markdown comments before publishing this PR, since the PR message is often used as the commit description. 
We only allow squash merging and GH suggests the PR details as a default commit message. -->

### What was changed?
<!-- Is this a user-visible change? Remember to update RELEASE_NOTES.md -->

### How has this been tested?

Manually tested.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/strata-org/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
