### PR TITLE
JVerify: fix empty-statement NPE in Java-to-Laurel lowering

### DIFF
--- a/verifier/src/main/java/org/strata/jverify/verifier/compiler/generator/laurel/JavaToLaurelCompiler.java
+++ b/verifier/src/main/java/org/strata/jverify/verifier/compiler/generator/laurel/JavaToLaurelCompiler.java
@@ -504,6 +504,19 @@ public class JavaToLaurelCompiler {
             return convertStatement(statement, Map.of());
         }
 
+        /**
+         * Convert a statement that appears in a position requiring a non-null
+         * {@link StmtExpr} (an if/else branch, a labeled-statement body, or a
+         * non-block loop body). An empty statement ({@code ;}) converts to
+         * {@code null}, which cannot be serialized as a Laurel node; substitute
+         * an empty block so e.g. {@code if (c) ;} and {@code for (..) ;} are
+         * valid no-ops rather than crashing the Ion serializer with an NPE.
+         */
+        private StmtExpr convertStatementOrEmpty(JCTree.JCStatement statement, Map<String, String> renames) {
+            StmtExpr converted = convertStatement(statement, renames);
+            return converted != null ? converted : block(toSourceRange(statement), List.of());
+        }
+
         private StmtExpr convertStatement(JCTree.JCStatement statement, Map<String, String> renames) {
             return switch (statement) {
                 case JCTree.JCAssert assertStmt ->
@@ -520,7 +533,7 @@ public class JavaToLaurelCompiler {
                 }
                 case JCTree.JCIf ifStmt -> {
                     StmtExpr cond = convertExpression(ifStmt.cond, renames);
-                    StmtExpr thenBranch = convertStatement(ifStmt.thenpart, renames);
+                    StmtExpr thenBranch = convertStatementOrEmpty(ifStmt.thenpart, renames);
                     Optional<ElseBranch> elseB = Optional.empty();
                     if (ifStmt.elsepart != null) {
                         StmtExpr elseStmt = convertStatement(ifStmt.elsepart, renames);
@@ -615,7 +628,7 @@ public class JavaToLaurelCompiler {
                         labelStack.push(new LabelEntry(pendingLabel, breakLbl, null));
                         pendingLabel = null;
                         try {
-                            StmtExpr body = convertStatement(labeledStmt.body, renames);
+                            StmtExpr body = convertStatementOrEmpty(labeledStmt.body, renames);
                             yield labelledBlock(toSourceRange(labeledStmt), List.of(body), breakLbl);
                         } finally {
                             labelStack.pop();
@@ -676,7 +689,7 @@ public class JavaToLaurelCompiler {
                 }
                 return new LoopParts(invariants, block(toSourceRange(loopBlock), stmts));
             } else {
-                return new LoopParts(List.of(), convertStatement(body, renames));
+                return new LoopParts(List.of(), convertStatementOrEmpty(body, renames));
             }
         }
 

--- a/verifier/src/test/java/org/strata/jverify/verifier/tests/javasupport/statements/EmptyStatement.java
+++ b/verifier/src/test/java/org/strata/jverify/verifier/tests/javasupport/statements/EmptyStatement.java
@@ -1,0 +1,38 @@
+package org.strata.jverify.verifier.tests.javasupport.statements;
+
+import org.strata.jverify.testengine.JVerifyTest;
+
+import static org.strata.jverify.JVerify.*;
+
+/**
+ * Regression test for the empty-statement ({@code ;}) NPE in Java-to-Laurel
+ * lowering. An empty statement converts to {@code null}; three positions used
+ * to propagate that null into Laurel nodes the Ion serializer then
+ * dereferenced (Node.toIon NPE): the if-then branch, a labeled-statement body,
+ * and a non-block loop body ({@code for (..) ;}). Each is now a valid no-op.
+ */
+@SuppressWarnings({"StatementWithEmptyBody", "ConstantValue", "UnnecessaryLabelOnContinueStatement"})
+@JVerifyTest(methodsVerified = 4, errorCount = 0)
+class EmptyStatement {
+    // if-then branch is an empty statement
+    void emptyIfBranch(int x) {
+        if (x > 0)
+            ;
+        check(true);
+    }
+
+    // labeled-statement body is an empty statement
+    void emptyLabeledStatement() {
+        label:
+        ;
+        check(true);
+    }
+
+    // non-block loop body is an empty statement
+    void emptyForBody() {
+        int i = 0;
+        for (i = 0; i < 5; i = i + 1)
+            ;
+        check(i == 5);
+    }
+}

--- a/verifier/src/test/java/org/strata/jverify/verifier/tests/javasupport/statements/EmptyStatement.java
+++ b/verifier/src/test/java/org/strata/jverify/verifier/tests/javasupport/statements/EmptyStatement.java
@@ -15,24 +15,26 @@ import static org.strata.jverify.JVerify.*;
 @JVerifyTest(methodsVerified = 4, errorCount = 0)
 class EmptyStatement {
     // if-then branch is an empty statement
-    void emptyIfBranch(int x) {
+    static void emptyIfBranch(int x) {
         if (x > 0)
             ;
         check(true);
     }
 
     // labeled-statement body is an empty statement
-    void emptyLabeledStatement() {
+    static void emptyLabeledStatement() {
         label:
         ;
         check(true);
     }
 
     // non-block loop body is an empty statement
-    void emptyForBody() {
-        int i = 0;
-        for (i = 0; i < 5; i = i + 1)
+    static void emptyForBody() {
+        // A boolean step avoids the integer-overflow proof obligation an
+        // `i = i + 1` step would carry without a loop invariant — this test
+        // only needs to exercise the non-block empty loop body lowering.
+        for (boolean done = false; !done; done = true)
             ;
-        check(i == 5);
+        check(true);
     }
 }


### PR DESCRIPTION
## Problem

An empty statement (`;` / `JCSkip`) converts to `null` in `JavaToLaurelCompiler`. Three positions propagated that `null` straight into Laurel nodes that the Ion serializer later dereferenced, crashing with an NPE in `Node.toIon`:

- the if-then branch — `if (c) ;`
- a labeled-statement body — `label: ;`
- a non-block loop body — `for (..) ;`

Block-based paths already filtered `null` out, so the bug only surfaced in these three "single statement required" positions.

## Fix

Add `convertStatementOrEmpty(...)`, which substitutes an empty block for a `null` conversion, and use it at the three positions that require a non-null `StmtExpr`. The empty statement now lowers to a valid no-op rather than crashing the serializer.

## Test

Add `EmptyStatement` regression test under `javasupport/statements`, covering all three positions (`if (x>0) ;`, `label: ;`, `for (..) ;`). Each verifies cleanly with no errors. The full `statements` test package still passes.