### PR TITLE
JVerify: tolerate non-ClassSymbol owner chains in method-symbol resolution

### DIFF
--- a/verifier/src/main/java/org/strata/jverify/verifier/compiler/generator/laurel/JavaToLaurelCompiler.java
+++ b/verifier/src/main/java/org/strata/jverify/verifier/compiler/generator/laurel/JavaToLaurelCompiler.java
@@ -227,11 +227,28 @@ public class JavaToLaurelCompiler {
     }
 
     private static String qualifiedMethodName(Symbol.MethodSymbol sym) {
-        // Use the outermost class's fully-qualified (package-included) name,
-        // sanitised like the CompositeType sort names ('$' -> '.'), so two
-        // same-named classes in different packages don't produce colliding
-        // procedure names.
-        return sym.outermostClass().getQualifiedName().toString().replace('$', '.') + "_" + sym.name;
+        // `outermostClass()` walks the owner chain to the first ClassSymbol,
+        // casting along the way; some invocations (record accessors of types
+        // declared inside an anonymous class, or built-ins on synthetic Symtab
+        // entries) reach here with a non-ClassSymbol owner and throw
+        // ClassCastException. Fall back to the immediate owner in that case.
+        Symbol.ClassSymbol outer;
+        try {
+            outer = sym.outermostClass();
+        } catch (ClassCastException e) {
+            outer = null;
+        }
+        if (outer != null) {
+            // Fully-qualified (package-included) name, sanitised like the
+            // CompositeType sort names ('$' -> '.'), so two same-named classes
+            // in different packages don't produce colliding procedure names.
+            return outer.getQualifiedName().toString().replace('$', '.') + "_" + sym.name;
+        }
+        Symbol owner = sym.owner;
+        String prefix = (owner != null && owner.name != null)
+                ? owner.name.toString()
+                : "$unknown";
+        return prefix + "_" + sym.name;
     }
 
     private class StaticMethodCollector extends TreeScanner {

--- a/verifier/src/main/java/org/strata/jverify/verifier/compiler/simplifications/JVerifyUtils.java
+++ b/verifier/src/main/java/org/strata/jverify/verifier/compiler/simplifications/JVerifyUtils.java
@@ -307,12 +307,38 @@ public class JVerifyUtils {
      * Otherwise, returns {@code null}.
      */
     public static Symbol.MethodSymbol getJVerifyMethod(JCTree.JCMethodInvocation invocation) {
-        var methodSymbol = (Symbol.MethodSymbol) TreeInfo.symbol(invocation.getMethodSelect());
+        var sym = TreeInfo.symbol(invocation.getMethodSelect());
+        if (!(sym instanceof Symbol.MethodSymbol methodSymbol)) {
+            // Some method invocations (e.g. record-component
+            // accessors, anonymous-class virtual calls) reach
+            // this with a non-MethodSymbol owner; treat them
+            // as definitely-not-JVerify.
+            return null;
+        }
         return fromJVerify(methodSymbol) ? methodSymbol : null;
     }
 
     private static boolean fromJVerify(Symbol.MethodSymbol methodSymbol) {
-        return methodSymbol.outermostClass().className().contentEquals(JVerifyUtils.JVERIFY_CLASS);
+        // `methodSymbol.outermostClass()` casts the symbol's
+        // owner chain up to ClassSymbol. For some invocations
+        // — typically record-component accessors of types
+        // declared inside an anonymous class, or method
+        // invocations on synthetic Symtab entries — the chain
+        // contains a non-ClassSymbol entry (e.g. Symtab$6,
+        // PackageSymbol, MethodSymbol) and the cast throws
+        // ClassCastException. Catching it and returning false
+        // is sound: such symbols cannot be the JVerify class
+        // itself, so the call is definitely-not-from-JVerify.
+        Symbol.ClassSymbol outer;
+        try {
+            outer = methodSymbol.outermostClass();
+        } catch (ClassCastException e) {
+            return false;
+        }
+        if (outer == null) {
+            return false;
+        }
+        return outer.className().contentEquals(JVerifyUtils.JVERIFY_CLASS);
     }
     
 }


### PR DESCRIPTION
Some method invocations reach the front end with a symbol whose owner chain contains a non-ClassSymbol — typically record-component accessors of types declared inside an anonymous class, or built-in methods on synthetic Symtab entries (e.g. Symtab$6). `Symbol.outermostClass()` casts the owner chain up to ClassSymbol and throws ClassCastException on those, aborting translation of the whole source file.

Guard the three affected sites so such symbols degrade gracefully instead of crashing; for the common case (regular static methods on a top-level class) every path produces identical results:

- JVerifyUtils.getJVerifyMethod: the method-select symbol may not be a MethodSymbol at all — treat that as definitely-not-a-JVerify-call.
- JVerifyUtils.fromJVerify: catch the outermostClass() cast and return false (such a symbol cannot be the JVerify class).
- JavaToLaurelCompiler.qualifiedMethodName: catch the cast and fall back to the immediate owner's name.


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/strata-org/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
