### PR TITLE
JavaToLaurel: emit a procedure (not a function) for @Pure methods

### DIFF
--- a/verifier/src/main/java/org/strata/jverify/verifier/compiler/generator/laurel/JavaToLaurelCompiler.java
+++ b/verifier/src/main/java/org/strata/jverify/verifier/compiler/generator/laurel/JavaToLaurelCompiler.java
@@ -465,21 +465,22 @@ public class JavaToLaurelCompiler {
                     ? Optional.of(body(methodBody))
                     : Optional.empty();
 
-            // Strata rejects transparent (visible-body) procedures unless they're functional;
-            // emit an OpaqueSpec to mark the body opaque otherwise. Pure functions stay
-            // transparent only when they have no ensures clauses (the schema can't carry
-            // ensures without an OpaqueSpec wrapper).
+            // A @Pure method with no ensures is emitted as a *transparent*
+            // procedure (visible body, no OpaqueSpec); with ensures it is
+            // opaque (the schema can't carry ensures without an OpaqueSpec
+            // wrapper). Non-pure methods are always opaque.
             // modifies is always empty: jverify doesn't yet emit modifies clauses.
             boolean canStayTransparent = isPure && ensures.isEmpty();
             Optional<OpaqueSpec> optSpec = canStayTransparent
                     ? Optional.empty()
                     : Optional.of(opaqueSpec(ensures, List.of()));
 
-            Procedure proc = isPure
-                    ? function(toSourceRange(method), methodName, params,
-                            retType, Optional.empty(), requires, Optional.empty(), optSpec, optBody)
-                    : procedure(toSourceRange(method), methodName, params,
-                            retType, Optional.empty(), requires, Optional.empty(), optSpec, optBody);
+            // Laurel functions are being removed (Strata #1408); a @Pure method
+            // now emits a procedure (transparent when it has no ensures) rather
+            // than a function. Transparent procedures give callers the same
+            // body-visible semantics that functions previously did.
+            Procedure proc = procedure(toSourceRange(method), methodName, params,
+                    retType, Optional.empty(), requires, Optional.empty(), optSpec, optBody);
             procedures.add(proc);
         }
 


### PR DESCRIPTION
Strata is removing Laurel `function`s (Strata PR #1408 "Remove functions"); transparent procedures take their place. jverify emitted a Laurel `function` for every @Pure method, so it will stop translating once functions are gone.

Emit a `procedure` instead. The transparency choice is unchanged: a @Pure method with no ensures becomes a *transparent* procedure (visible body, no OpaqueSpec) — giving callers the same body-visible semantics functions had — and one with ensures (or a non-pure method) is opaque. The `function` and `procedure` builders have identical signatures, so only the constructor differs.

Requires a Strata with [strata-org/Strata/#1408](https://github.com/strata-org/Strata/pull/1408) (transparent-procedure support): the current pre-#1408 Strata rejects transparent non-functional procedures. Validated against the https://github.com/strata-org/Strata/pull/1408 branch (`removeFunctions`, based on this submodule pin): @Pure methods translate and verify; the residual test deltas are [#1408](https://github.com/strata-org/Strata/pull/1408)'s own diagnostic-wording / behaviour changes (e.g. "does not hold" -> "could not be proved"), matching the test updates [#1408](https://github.com/strata-org/Strata/pull/1408) made in Strata, not this change.


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache-2.0](https://github.com/strata-org/jverify?tab=Apache-2.0-1-ov-file#readme).</small>
